### PR TITLE
remove unused deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,11 +207,6 @@
             <version>1.7.30</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.11.2</version>
@@ -242,14 +237,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>io.tarantool</groupId>
             <artifactId>testcontainers-java-tarantool</artifactId>
             <version>0.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
jsr305 seems to be currently unused (I would suggest use it and it should provided than AFAIU)
logback-core is not needed as compile dep to not come to clients transitively and in tests should come transitively with logback-classic