### PR TITLE
Update Proxy client for tarantool/crud version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ class Scratch {
 ### Proxy Tarantool client
 
 A decorator for any of the basic client types. Allows connecting to instances with CRUD interfaces defined as user API
-functions or as exposed [CRUD](https://github.com/tarantool/crud) functions. Works with tarantool/crud 0.2.0+.
+functions or Cartridge roles based on 'crud-router' from module [CRUD](https://github.com/tarantool/crud). Works with
+tarantool/crud 0.3.0+.
 
 See an example how to use the `ProxyTarantoolClient`:
 
@@ -165,6 +166,7 @@ class Scratch {
         TarantoolClient client = new ProxyTarantoolClient(clusterClient);
 
         Conditions conditions = Conditions.greaterOrEquals("profile_id", 1_000_000);
+        // crud.select(...) on the Cartridge router will be called internally
         TarantoolResult<TarantoolTuple> selectResult = profileSpace.select(conditions).get();
         assertEquals(20, selectResult.size());
 

--- a/src/main/java/io/tarantool/driver/proxy/ProxyOperationsMapping.java
+++ b/src/main/java/io/tarantool/driver/proxy/ProxyOperationsMapping.java
@@ -7,14 +7,14 @@ package io.tarantool.driver.proxy;
  */
 public interface ProxyOperationsMapping {
 
-    String FUNCTION_PREFIX = "crud";
-    String SCHEMA_FUNCTION = FUNCTION_PREFIX + "_get_schema";
-    String DELETE_FUNCTION = FUNCTION_PREFIX + "_delete";
-    String INSERT_FUNCTION = FUNCTION_PREFIX + "_insert";
-    String REPLACE_FUNCTION = FUNCTION_PREFIX + "_replace";
-    String SELECT_FUNCTION = FUNCTION_PREFIX + "_select";
-    String UPDATE_FUNCTION = FUNCTION_PREFIX + "_update";
-    String UPSERT_UPSERT = FUNCTION_PREFIX + "_upsert";
+    String FUNCTION_PREFIX = "crud.";
+    String SCHEMA_FUNCTION = "crud_get_schema";
+    String DELETE_FUNCTION = FUNCTION_PREFIX + "delete";
+    String INSERT_FUNCTION = FUNCTION_PREFIX + "insert";
+    String REPLACE_FUNCTION = FUNCTION_PREFIX + "replace";
+    String SELECT_FUNCTION = FUNCTION_PREFIX + "select";
+    String UPDATE_FUNCTION = FUNCTION_PREFIX + "update";
+    String UPSERT_UPSERT = FUNCTION_PREFIX + "upsert";
 
     /**
      * Get API function name for getting the spaces and indexes schema. The default value is

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -1,35 +1,4 @@
-local cartridge = require('cartridge')
 local vshard = require('vshard')
-local crud = require('crud')
-
--- CRUD functions wrappers
-local function crud_get(space_name, key, opts)
-    return crud.get(space_name, key, opts)
-end
-
-local function crud_insert(space_name, obj, opts)
-    return crud.insert(space_name, obj, opts)
-end
-
-local function crud_delete(space_name, key, opts)
-    return crud.delete(space_name, key, opts)
-end
-
-local function crud_replace(space_name, obj, opts)
-    return crud.replace(space_name, obj, opts)
-end
-
-local function crud_update(space_name, key, operations, opts)
-    return crud.update(space_name, key, operations, opts)
-end
-
-local function crud_upsert(space_name, obj, operations, opts)
-    return crud.upsert(space_name, obj, operations, opts)
-end
-
-local function crud_select(space_name, user_conditions, opts)
-    return crud.select(space_name, user_conditions, opts)
-end
 
 -- function to get cluster schema
 local function crud_get_schema()
@@ -70,16 +39,6 @@ end
 
 
 local function init(opts)
-    if opts.is_master then
-    end
-
-    rawset(_G, 'crud_get', crud_get)
-    rawset(_G, 'crud_insert', crud_insert)
-    rawset(_G, 'crud_delete', crud_delete)
-    rawset(_G, 'crud_replace', crud_replace)
-    rawset(_G, 'crud_update', crud_update)
-    rawset(_G, 'crud_upsert', crud_upsert)
-    rawset(_G, 'crud_select', crud_select)
 
     rawset(_G, 'crud_get_schema', crud_get_schema)
 
@@ -90,6 +49,6 @@ return {
     role_name = 'app.roles.api_router',
     init = init,
     dependencies = {
-        'cartridge.roles.vshard-router'
+        'cartridge.roles.crud-router',
     }
 }

--- a/src/test/resources/cartridge/app/roles/api_storage.lua
+++ b/src/test/resources/cartridge/app/roles/api_storage.lua
@@ -1,5 +1,3 @@
-local crud = require('crud')
-
 local function init_space()
     local profile = box.schema.space.create(
             'test__profile',
@@ -51,9 +49,6 @@ local function init_space()
 end
 
 local function init(opts)
-    -- initialize crud
-    crud.init()
-
     if opts.is_master then
         init_space()
     end
@@ -65,6 +60,6 @@ return {
     role_name = 'app.roles.api_storage',
     init = init,
     dependencies = {
-        'cartridge.roles.vshard-storage'
+        'cartridge.roles.crud-storage'
     }
 }

--- a/src/test/resources/cartridge/init.lua
+++ b/src/test/resources/cartridge/init.lua
@@ -33,8 +33,8 @@ local cartridge = require('cartridge')
 local ok, err = cartridge.cfg({
     workdir = 'tmp/db',
     roles = {
-        'cartridge.roles.vshard-storage',
-        'cartridge.roles.vshard-router',
+        'cartridge.roles.crud-storage',
+        'cartridge.roles.crud-router',
         'app.roles.api_router',
         'app.roles.api_storage',
         'app.roles.custom',

--- a/src/test/resources/cartridge/testapp-scm-1.rockspec
+++ b/src/test/resources/cartridge/testapp-scm-1.rockspec
@@ -10,7 +10,7 @@ dependencies = {
     'checks == 3.0.1-1',
     'cartridge == 2.3.0-1',
     'ddl == 1.1.0-1',
-    'crud == 0.2.0-1',
+    'crud == 0.3.0-1',
 }
 build = {
     type = 'none';


### PR DESCRIPTION
 - Get rid of proxy methods (fixed in https://github.com/tarantool/crud/pull/58) and bump CRUD version in tests
 - Change the default method names in ProxyClient