### PR TITLE
Use correct Cartridge metadata format compatible with ddl.get_schema()

### DIFF
--- a/src/main/java/io/tarantool/driver/metadata/ProxyTarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/metadata/ProxyTarantoolSpaceMetadataConverter.java
@@ -28,8 +28,8 @@ public class ProxyTarantoolSpaceMetadataConverter
 
     private static final ImmutableStringValue SPACE_ID_KEY = new ImmutableStringValueImpl("id");
     private static final ImmutableStringValue SPACE_NAME_KEY = new ImmutableStringValueImpl("name");
-    private static final ImmutableStringValue SPACE_FORMAT_KEY = new ImmutableStringValueImpl("_format");
-    private static final ImmutableStringValue SPACE_INDEX_KEY = new ImmutableStringValueImpl("index");
+    private static final ImmutableStringValue SPACE_FORMAT_KEY = new ImmutableStringValueImpl("format");
+    private static final ImmutableStringValue SPACE_INDEXES_KEY = new ImmutableStringValueImpl("indexes");
 
     private static final ImmutableStringValue FORMAT_NAME_KEY = new ImmutableStringValueImpl("name");
     private static final ImmutableStringValue FORMAT_TYPE_KEY = new ImmutableStringValueImpl("type");
@@ -96,7 +96,7 @@ public class ProxyTarantoolSpaceMetadataConverter
 
         proxyMetadata.addSpace(spaceMetadata);
 
-        Value indexesValue = spacesMap.get(SPACE_INDEX_KEY);
+        Value indexesValue = spacesMap.get(SPACE_INDEXES_KEY);
         if (indexesValue != null && indexesValue.isArrayValue() && indexesValue.asArrayValue().size() > 0) {
             List<Value> indexes = indexesValue.asArrayValue().list();
             proxyMetadata.addIndexes(spaceMetadata.getSpaceName(), parseIndexes(indexes));

--- a/src/main/java/io/tarantool/driver/proxy/ProxyOperationsMapping.java
+++ b/src/main/java/io/tarantool/driver/proxy/ProxyOperationsMapping.java
@@ -7,14 +7,14 @@ package io.tarantool.driver.proxy;
  */
 public interface ProxyOperationsMapping {
 
-    String FUNCTION_PREFIX = "crud.";
-    String SCHEMA_FUNCTION = "crud_get_schema";
-    String DELETE_FUNCTION = FUNCTION_PREFIX + "delete";
-    String INSERT_FUNCTION = FUNCTION_PREFIX + "insert";
-    String REPLACE_FUNCTION = FUNCTION_PREFIX + "replace";
-    String SELECT_FUNCTION = FUNCTION_PREFIX + "select";
-    String UPDATE_FUNCTION = FUNCTION_PREFIX + "update";
-    String UPSERT_UPSERT = FUNCTION_PREFIX + "upsert";
+    String CRUD_PREFIX = "crud.";
+    String SCHEMA_FUNCTION = "cartridge.get_schema";
+    String DELETE_FUNCTION = CRUD_PREFIX + "delete";
+    String INSERT_FUNCTION = CRUD_PREFIX + "insert";
+    String REPLACE_FUNCTION = CRUD_PREFIX + "replace";
+    String SELECT_FUNCTION = CRUD_PREFIX + "select";
+    String UPDATE_FUNCTION = CRUD_PREFIX + "update";
+    String UPSERT_UPSERT = CRUD_PREFIX + "upsert";
 
     /**
      * Get API function name for getting the spaces and indexes schema. The default value is

--- a/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
@@ -1,17 +1,25 @@
 package io.tarantool.driver.integration;
 
 import org.junit.ClassRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.TarantoolCartridgeContainer;
 import org.testcontainers.containers.TarantoolContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 abstract class SharedCartridgeContainer {
 
+    private static final Logger logger = LoggerFactory.getLogger(SharedCartridgeContainer.class);
+
     @ClassRule
-    protected static final TarantoolCartridgeContainer container = new TarantoolCartridgeContainer(
+    protected static final TarantoolCartridgeContainer container =
+            (TarantoolCartridgeContainer) new TarantoolCartridgeContainer(
             "cartridge/instances.yml",
             "cartridge/topology.lua")
             .withDirectoryBinding("cartridge")
-            .cleanUpDirectory("cartridge/tmp");
+            .cleanUpDirectory("cartridge/tmp")
+            .withLogConsumer(new Slf4jLogConsumer(logger));
 
     protected static void startCluster() {
         if (!container.isRunning()) {

--- a/src/test/java/io/tarantool/driver/integration/TestProxyTarantoolClient.java
+++ b/src/test/java/io/tarantool/driver/integration/TestProxyTarantoolClient.java
@@ -1,0 +1,18 @@
+package io.tarantool.driver.integration;
+
+import io.tarantool.driver.ProxyTarantoolClient;
+import io.tarantool.driver.api.TarantoolClient;
+
+/**
+ * @author Alexey Kuzin
+ */
+public class TestProxyTarantoolClient extends ProxyTarantoolClient {
+    public TestProxyTarantoolClient(TarantoolClient decoratedClient) {
+        super(decoratedClient);
+    }
+
+    @Override
+    public String getGetSchemaFunctionName() {
+        return "ddl.get_schema";
+    }
+}

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -2,41 +2,11 @@ local vshard = require('vshard')
 local cartridge_pool = require('cartridge.pool')
 local cartridge_rpc = require('cartridge.rpc')
 
--- function to get cluster schema
-local function crud_get_schema()
-    local replicaset = select(2, next(vshard.router.routeall()))
-    local uniq_spaces = {}
-    local spaces_ids = {}
-    for _, space in pairs(replicaset.master.conn.space) do
-        
-        if (spaces_ids[space.id] == nil) then
-            local space_copy = {
-                engine = space.engine,
-                field_count = space.field_count,
-                id = space.id,
-                name = space.name,
-                index = {},
-                _format = space._format,
-            }
-
-            for i, space_index in pairs(space.index) do
-                if type(i) == 'number' then
-                    local index_copy = {
-                        id = space_index.id,
-                        name = space_index.name,
-                        unique = space_index.unique,
-                        type = space_index.type,
-                        parts = space_index.parts,
-                    }
-                    table.insert(space_copy.index, index_copy)
-                end
-            end
-
-            table.insert(uniq_spaces, {space_copy} )
-            spaces_ids[space.id] = true
-        end
+local function get_schema()
+    for _, instance_uri in pairs(cartridge_rpc.get_candidates('app.roles.api_storage', { leader_only = true })) do
+        local conn = cartridge_pool.connect(instance_uri)
+        return conn:call('ddl.get_schema', {})
     end
-    return uniq_spaces
 end
 
 local function truncate_space(space_name)
@@ -46,8 +16,9 @@ end
 
 local function init(opts)
 
-    rawset(_G, 'crud_get_schema', crud_get_schema)
     rawset(_G, 'truncate_space', truncate_space)
+
+    rawset(_G, 'ddl', { get_schema = get_schema })
 
     return true
 end

--- a/src/test/resources/cartridge/app/roles/api_storage.lua
+++ b/src/test/resources/cartridge/app/roles/api_storage.lua
@@ -53,6 +53,8 @@ local function init(opts)
         init_space()
     end
 
+    rawset(_G, 'ddl', { get_schema = require('ddl').get_schema })
+
     return true
 end
 


### PR DESCRIPTION
 - Use `cartridge.get_schema` by default
 - Make README more useful

Fixes #27 