### PR TITLE
Handle correctly all errors when establishing connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>io.tarantool</groupId>
             <artifactId>testcontainers-java-tarantool</artifactId>
-            <version>0.2.3</version>
+            <version>0.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolConnectionManager.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolConnectionManager.java
@@ -162,6 +162,9 @@ public abstract class AbstractTarantoolConnectionManager implements TarantoolCon
         List<CompletableFuture<TarantoolConnection>> connections = connectionFactory
             .multiConnection(serverAddress.getSocketAddress(), config.getConnections()).stream()
             .peek(cf -> cf.thenApply(conn -> {
+                if (conn.isConnected()) {
+                    logger.info("Connected to Tarantool server at {}", conn.getRemoteAddress());
+                }
                 conn.addConnectionFailureListener(ex -> {
                     logger.error("Disconnected from Tarantool server", ex);
                     connectionMode.set(true);

--- a/src/main/java/io/tarantool/driver/core/TarantoolConnection.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolConnection.java
@@ -6,9 +6,17 @@ import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 
 public interface TarantoolConnection extends AutoCloseable {
+    /**
+     * Get the Tarantool server address for this connection
+     * @return server address
+     * @throws TarantoolClientException if the client is not connected
+     */
+    InetSocketAddress getRemoteAddress() throws TarantoolClientException;
+
     /**
      * Get the Tarantool server version
      * @return {@link TarantoolVersion}

--- a/src/main/java/io/tarantool/driver/core/TarantoolConnectionImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolConnectionImpl.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -33,6 +34,14 @@ public class TarantoolConnectionImpl implements TarantoolConnection {
                }
            }
         });
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() throws TarantoolClientException {
+        if (!isConnected()) {
+            throw new TarantoolClientException("Not connected to Tarantool server");
+        }
+        return (InetSocketAddress) channel.remoteAddress();
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolMetadataRequestException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolMetadataRequestException.java
@@ -1,0 +1,12 @@
+package io.tarantool.driver.exceptions;
+
+/**
+ * The exception occurs when the metadata returned by proxy function has a wrong format or the metadata request failed
+ *
+ * @author Alexey Kuzin
+ */
+public class TarantoolMetadataRequestException extends TarantoolClientException {
+    public TarantoolMetadataRequestException(String function, Throwable cause) {
+        super(String.format("Failed to retrieve space and index metadata using proxy function %s", function), cause);
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolTupleConversionException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolTupleConversionException.java
@@ -1,0 +1,14 @@
+package io.tarantool.driver.exceptions;
+
+import org.msgpack.value.Value;
+
+/**
+ * Represents errors occurring when MessagePack mapper tries to parse the incoming data into a tuple object
+ *
+ * @author Alexey Kuzin
+ */
+public class TarantoolTupleConversionException extends TarantoolClientException {
+    public TarantoolTupleConversionException(Value messagePackValue, Throwable cause) {
+        super(String.format("Failed to convert MessagePack array %s to tuple", messagePackValue.toString()), cause);
+    }
+}

--- a/src/main/java/io/tarantool/driver/metadata/ProxyTarantoolMetadata.java
+++ b/src/main/java/io/tarantool/driver/metadata/ProxyTarantoolMetadata.java
@@ -20,13 +20,13 @@ import java.util.concurrent.CompletionException;
  */
 public class ProxyTarantoolMetadata extends AbstractTarantoolMetadata {
 
-    private final String getMetadataFunctionName;
+    private final String metadataFunctionName;
     private final TarantoolClient client;
     private final ProxyTarantoolSpaceMetadataConverter metadataConverter;
 
-    public ProxyTarantoolMetadata(String getMetadataFunctionName,
+    public ProxyTarantoolMetadata(String metadataFunctionName,
                                   TarantoolClient client) {
-        this.getMetadataFunctionName = getMetadataFunctionName;
+        this.metadataFunctionName = metadataFunctionName;
         this.client = client;
         this.metadataConverter = new ProxyTarantoolSpaceMetadataConverter(client.getConfig().getMessagePackMapper());
     }
@@ -35,7 +35,7 @@ public class ProxyTarantoolMetadata extends AbstractTarantoolMetadata {
     public CompletableFuture<Void> populateMetadata() throws TarantoolClientException {
 
         CompletableFuture<TarantoolResult<ProxyTarantoolSpaceMetadataContainer>> callResult = client.call(
-                getMetadataFunctionName,
+                metadataFunctionName,
                 metadataConverter);
 
         return callResult.thenAccept(result -> {

--- a/src/main/java/io/tarantool/driver/metadata/ProxyTarantoolMetadata.java
+++ b/src/main/java/io/tarantool/driver/metadata/ProxyTarantoolMetadata.java
@@ -3,9 +3,11 @@ package io.tarantool.driver.metadata;
 import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.exceptions.TarantoolMetadataRequestException;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Populates metadata from results of a call to proxy API function in Tarantool instance. The function result is
@@ -53,6 +55,14 @@ public class ProxyTarantoolMetadata extends AbstractTarantoolMetadata {
                     }
                 });
             });
+        }).exceptionally(ex -> {
+            if (ex.getCause() != null && ex.getCause() instanceof TarantoolClientException) {
+                throw new TarantoolMetadataRequestException(metadataFunctionName, ex);
+            } else if (ex instanceof RuntimeException) {
+                throw (RuntimeException) ex;
+            } else {
+                throw new CompletionException(ex);
+            }
         });
     }
 }

--- a/src/test/java/io/tarantool/driver/core/CustomConnection.java
+++ b/src/test/java/io/tarantool/driver/core/CustomConnection.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,6 +40,11 @@ final class CustomConnection implements TarantoolConnection {
 
     public int getCount() {
         return count.get();
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() throws TarantoolClientException {
+        return new InetSocketAddress(host, port);
     }
 
     @Override

--- a/src/test/java/io/tarantool/driver/integration/ConnectionIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ConnectionIT.java
@@ -1,0 +1,207 @@
+package io.tarantool.driver.integration;
+
+import io.tarantool.driver.StandaloneTarantoolClient;
+import io.tarantool.driver.TarantoolClientConfig;
+import io.tarantool.driver.TarantoolServerAddress;
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.exceptions.NoAvailableConnectionsException;
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.exceptions.TarantoolServerException;
+import io.tarantool.driver.exceptions.TarantoolSocketException;
+import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.TarantoolContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Alexey Kuzin
+ */
+@Testcontainers
+public class ConnectionIT {
+    private static final String TEST_SPACE_NAME = "test_space";
+    private static final Logger log = LoggerFactory.getLogger(StandaloneTarantoolClientIT.class);
+
+    @Container
+    private static final TarantoolContainer tarantoolContainer = new TarantoolContainer()
+            .withScriptFileName("org/testcontainers/containers/server.lua");
+
+    @Test
+    public void connectAndCheckMetadata() throws Exception {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
+
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                tarantoolContainer.getHost(), tarantoolContainer.getPort());
+
+        try (TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress)) {
+            ExecutorService executor = Executors.newFixedThreadPool(10);
+            List<CompletableFuture<?>> futures = new ArrayList<>(10);
+            for (int i = 0; i < 10; i++) {
+                futures.add(CompletableFuture.runAsync(() -> {
+                    Optional<TarantoolSpaceMetadata> spaceHolder = client.metadata().getSpaceByName("_space");
+                    assertTrue(spaceHolder.isPresent(), "Failed to get space metadata");
+                }, executor));
+            }
+            futures.forEach(CompletableFuture::join);
+
+            Optional<TarantoolSpaceMetadata> spaceMetadata = client.metadata().getSpaceByName(TEST_SPACE_NAME);
+            assertTrue(spaceMetadata.isPresent(), String.format("Failed to get '%s' metadata", TEST_SPACE_NAME));
+            assertEquals(TEST_SPACE_NAME, spaceMetadata.get().getSpaceName());
+            log.info("Retrieved ID from metadata for space '{}': {}",
+                    spaceMetadata.get().getSpaceName(), spaceMetadata.get().getSpaceId());
+        }
+    }
+
+    private CompletableFuture<List<?>> connectAndEval(String command) throws Exception {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
+
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                tarantoolContainer.getHost(), tarantoolContainer.getPort());
+
+        try (TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress)) {
+            return client.eval(command);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    @Test
+    public void connectAndCloseAfterFuture() throws Exception {
+        List<?> result = connectAndEval("return 1, 2").get(1000, TimeUnit.MILLISECONDS);
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0));
+        assertEquals(2, result.get(1));
+    }
+
+    @Test
+    public void testIncorrectHostname_shouldThrowException() {
+        assertThrows(TarantoolSocketException.class, () -> {
+            TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                    tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
+            TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                    "wronghost", tarantoolContainer.getPort());
+            TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress);
+            // Connection is actually performed here
+            client.getVersion();
+        });
+    }
+
+    @Test
+    public void testIncorrectPort_shouldThrowException() {
+        assertThrows(TarantoolClientException.class, () -> {
+            TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                    tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
+            TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                    tarantoolContainer.getHost(), 9999);
+            TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress);
+            // Connection is actually performed here
+            client.getVersion();
+        });
+    }
+
+    @Test
+    public void testCloseAfterIncorrectPort_shouldThrowException() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                tarantoolContainer.getHost(), 9999);
+        assertThrows(TarantoolClientException.class, () -> {
+            try (TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress)) {
+                // Connection is actually performed here
+                client.getVersion();
+            }
+        });
+    }
+
+    @Test
+    public void testCloseAfterIncorrectPassword_shouldThrowException() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), "incorrect");
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                tarantoolContainer.getHost(), tarantoolContainer.getPort());
+        assertThrows(TarantoolServerException.class, () -> {
+            try (TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress)) {
+                // Connection is actually performed here
+                client.getVersion();
+            }
+        });
+    }
+
+    @Test
+    public void testIncorrectPassword_secondRequestShouldNotHang() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), "incorrect");
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                tarantoolContainer.getHost(), tarantoolContainer.getPort());
+        assertThrows(TarantoolClientException.class, () -> {
+            try (TarantoolClient client = new StandaloneTarantoolClient(credentials, serverAddress)) {
+                // Connection is actually performed here
+                try {
+                    client.getVersion();
+                } catch (TarantoolServerException e) {
+                    // ignore
+                }
+                // the second request should not hang, but should throw the exception
+                client.metadata().getSpaceByName("_vspace");
+            }
+        });
+    }
+
+    @Test
+    public void testIncorrectPassword_multipleRequestsShouldNotHang() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), "incorrect");
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                "neverwhere", tarantoolContainer.getPort());
+        TarantoolClientConfig config = TarantoolClientConfig.builder()
+                .withConnectTimeout(100)
+                .withRequestTimeout(100)
+                .withCredentials(credentials)
+                .withConnections(10)
+                .build();
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        assertThrows(ExecutionException.class, () -> {
+            try (TarantoolClient client = new StandaloneTarantoolClient(config, serverAddress)) {
+                // Connection is actually performed here
+                List<CompletableFuture<?>> futures = new ArrayList<>(10);
+                for (int i = 0; i < 10; i++) {
+                    futures.add(CompletableFuture.runAsync(() -> {
+                        try {
+                            CompletableFuture<TarantoolResult<TarantoolTuple>> result =
+                                    client.space("_vspace").select(Conditions.any());
+                            result.get(100, TimeUnit.MILLISECONDS);
+                        } catch (TarantoolServerException | NoAvailableConnectionsException e) {
+                            log.error("Caught exception {}", e.getMessage());
+                        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }, executor));
+                }
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[]{}))
+                        .get(1000, TimeUnit.MILLISECONDS);
+            }
+        });
+    }
+}

--- a/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
@@ -14,11 +14,10 @@ abstract class SharedCartridgeContainer {
 
     @ClassRule
     protected static final TarantoolCartridgeContainer container =
-            (TarantoolCartridgeContainer) new TarantoolCartridgeContainer(
+            new TarantoolCartridgeContainer(
             "cartridge/instances.yml",
             "cartridge/topology.lua")
             .withDirectoryBinding("cartridge")
-            .cleanUpDirectory("cartridge/tmp")
             .withLogConsumer(new Slf4jLogConsumer(logger));
 
     protected static void startCluster() {

--- a/src/test/resources/cartridge/.cartridge.yml
+++ b/src/test/resources/cartridge/.cartridge.yml
@@ -1,3 +1,2 @@
 ---
-run_dir: 'tmp'
 cfg: instances.yml


### PR DESCRIPTION
Fixes #57 

Includes changes:
 - Make errors when retrieving metadata more readable
 - Update driver to testcontainers 0.4.0 (possibly fixes #25)
 - Add a message with server address the client established a connection to