### PR TITLE
Add support for reconnection strategies

### DIFF
--- a/src/main/java/io/tarantool/driver/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/AbstractTarantoolClient.java
@@ -70,17 +70,32 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
      * @param config the client configuration
      * @see TarantoolClientConfig
      */
-    protected AbstractTarantoolClient(TarantoolClientConfig config) {
+    public AbstractTarantoolClient(TarantoolClientConfig config) {
         this(config, new TarantoolConnectionListeners());
     }
 
     /**
      * Create a client, specifying the connection established event listeners.
-     * @param listeners connection established event listeners
+     * @deprecated
      * @param config the client configuration
+     * @param selectionStrategyFactory instantiates strategies which provide the algorithm of selecting connections
+     *                                 from the connection pool for performing the next request
+     * @param listeners connection established event listeners
      * @see TarantoolClientConfig
      */
-    protected AbstractTarantoolClient(TarantoolClientConfig config, TarantoolConnectionListeners listeners) {
+    protected AbstractTarantoolClient(TarantoolClientConfig config,
+                                      ConnectionSelectionStrategyFactory selectionStrategyFactory,
+                                      TarantoolConnectionListeners listeners) {
+        this(config, listeners);
+    }
+
+    /**
+     * Create a client, specifying the connection established event listeners.
+     * @param config the client configuration
+     * @param listeners connection established event listeners
+     * @see TarantoolClientConfig
+     */
+    public AbstractTarantoolClient(TarantoolClientConfig config, TarantoolConnectionListeners listeners) {
         Assert.notNull(config, "Tarantool client config must not be null");
         Assert.notNull(listeners, "Tarantool connection listeners must not be null");
 
@@ -94,7 +109,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
                 .option(ChannelOption.SO_KEEPALIVE, true)
                 .option(ChannelOption.TCP_NODELAY, true)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.getConnectTimeout());
-        this.connectionFactory = new TarantoolConnectionFactory(config, getBootstrap());
+        this.connectionFactory = new TarantoolConnectionFactory(config, this.bootstrap);
         this.listeners = listeners;
         this.metadataProvider = new SpacesMetadataProvider(this, config.getMessagePackMapper());
     }

--- a/src/main/java/io/tarantool/driver/ClusterTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/ClusterTarantoolClient.java
@@ -22,34 +22,27 @@ import java.util.Collection;
 public abstract class ClusterTarantoolClient<T extends Packable, R extends Collection<T>>
         extends AbstractTarantoolClient<T, R> {
 
-    private final ConnectionSelectionStrategyFactory selectStrategyFactory;
     private final TarantoolClusterAddressProvider addressProvider;
 
     /**
      * Create a client. The server address for connecting to the server is specified by the passed address provider.
      * @param config the client configuration
      * @param addressProvider provides Tarantool server address for connection
-     * @param selectStrategyFactory instantiates strategies which provide the algorithm of selecting connections
-     *                              from the connection pool for performing the next request
      * @see TarantoolClientConfig
      */
     public ClusterTarantoolClient(TarantoolClientConfig config,
-                                  TarantoolClusterAddressProvider addressProvider,
-                                  ConnectionSelectionStrategyFactory selectStrategyFactory) {
+                                  TarantoolClusterAddressProvider addressProvider) {
         super(config);
 
         Assert.notNull(addressProvider, "Address provider must not be null");
-        Assert.notNull(selectStrategyFactory, "Connection selection strategy factory must not be null");
 
         this.addressProvider = addressProvider;
-        this.selectStrategyFactory = selectStrategyFactory;
     }
 
     @Override
     protected TarantoolConnectionManager connectionManager(TarantoolClientConfig config,
                                                            TarantoolConnectionFactory connectionFactory,
                                                            TarantoolConnectionListeners listeners) {
-        return new TarantoolClusterConnectionManager(
-                config, connectionFactory, selectStrategyFactory, listeners, addressProvider);
+        return new TarantoolClusterConnectionManager(config, connectionFactory, listeners, addressProvider);
     }
 }

--- a/src/main/java/io/tarantool/driver/ClusterTarantoolTupleClient.java
+++ b/src/main/java/io/tarantool/driver/ClusterTarantoolTupleClient.java
@@ -53,6 +53,17 @@ public class ClusterTarantoolTupleClient
     }
 
     /**
+     * Create a client. Connects to a Tarantool server using the specified host and port.
+     * @param config                client configuration
+     * @param host                  valid host name or IP address
+     * @param port                  valid port number
+     * @see TarantoolCredentials
+     */
+    public ClusterTarantoolTupleClient(TarantoolClientConfig config, String host, int port) {
+        this(config, Collections.singletonList(new TarantoolServerAddress(host, port)));
+    }
+
+    /**
      * Create a client using provided credentials information. Connects to a Tarantool server using the specified
      * server address.
      *

--- a/src/main/java/io/tarantool/driver/ClusterTarantoolTupleClient.java
+++ b/src/main/java/io/tarantool/driver/ClusterTarantoolTupleClient.java
@@ -63,10 +63,9 @@ public class ClusterTarantoolTupleClient
      */
     public ClusterTarantoolTupleClient(TarantoolCredentials credentials, TarantoolServerAddress address) {
         this(TarantoolClientConfig.builder()
-                        .withCredentials(credentials)
-                        .build(),
-                () -> Collections.singletonList(address),
-                ParallelRoundRobinStrategyFactory.INSTANCE);
+                .withCredentials(credentials)
+                .build(),
+            address);
     }
 
     /**
@@ -79,7 +78,7 @@ public class ClusterTarantoolTupleClient
      * @see TarantoolServerAddress
      */
     public ClusterTarantoolTupleClient(TarantoolClientConfig config, TarantoolServerAddress address) {
-        this(config, () -> Collections.singletonList(address), ParallelRoundRobinStrategyFactory.INSTANCE);
+        this(config, () -> Collections.singletonList(address));
     }
 
     /**
@@ -93,10 +92,10 @@ public class ClusterTarantoolTupleClient
      */
     public ClusterTarantoolTupleClient(TarantoolCredentials credentials, Collection<TarantoolServerAddress> addresses) {
         this(TarantoolClientConfig.builder()
-                        .withCredentials(credentials)
-                        .build(),
-                () -> addresses,
-                ParallelRoundRobinStrategyFactory.INSTANCE);
+                .withCredentials(credentials)
+                .withConnectionSelectionStrategyFactory(ParallelRoundRobinStrategyFactory.INSTANCE)
+                .build(),
+            () -> addresses);
     }
 
     /**
@@ -108,7 +107,7 @@ public class ClusterTarantoolTupleClient
      * @see TarantoolServerAddress
      */
     public ClusterTarantoolTupleClient(TarantoolClientConfig config, Collection<TarantoolServerAddress> addresses) {
-        this(config, () -> addresses, ParallelRoundRobinStrategyFactory.INSTANCE);
+        this(config, () -> addresses);
     }
 
     /**
@@ -119,22 +118,7 @@ public class ClusterTarantoolTupleClient
      * @see TarantoolClientConfig
      */
     public ClusterTarantoolTupleClient(TarantoolClientConfig config, TarantoolClusterAddressProvider addressProvider) {
-        this(config, addressProvider, ParallelRoundRobinStrategyFactory.INSTANCE);
-    }
-
-    /**
-     * Create a client. Connect using the list of Tarantool servers returned by the specified server address provider.
-     *
-     * @param config                the client configuration
-     * @param addressProvider       provides Tarantool server address for connection
-     * @param selectStrategyFactory instantiates strategies which provide the algorithm of selecting connections
-     *                              from the connection pool for performing the next request
-     * @see TarantoolClientConfig
-     */
-    public ClusterTarantoolTupleClient(TarantoolClientConfig config,
-                                       TarantoolClusterAddressProvider addressProvider,
-                                       ConnectionSelectionStrategyFactory selectStrategyFactory) {
-        super(config, addressProvider, selectStrategyFactory);
+        super(config, addressProvider);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/ConnectionSelectionStrategyFactory.java
+++ b/src/main/java/io/tarantool/driver/ConnectionSelectionStrategyFactory.java
@@ -5,7 +5,8 @@ import io.tarantool.driver.core.TarantoolConnection;
 import java.util.Collection;
 
 /**
- * Manages instantiation of connection selection strategies
+ * Manages instantiation of connection selection strategies. A strategy contains the algorithm of selecting connections
+ * from the connection pool for performing the next request
  *
  * @see ConnectionSelectionStrategy
  * @author Alexey Kuzin

--- a/src/main/java/io/tarantool/driver/RequestRetryPolicy.java
+++ b/src/main/java/io/tarantool/driver/RequestRetryPolicy.java
@@ -1,0 +1,75 @@
+package io.tarantool.driver;
+
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.utils.Assert;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+/**
+ * Request retry policy contains an algorithm of deciding whether an exception is retriable and settings for
+ * limiting the retry attempts
+ *
+ * @author Alexey Kuzin
+ */
+public interface RequestRetryPolicy {
+    /**
+     * A callback called when the request ends with an exception. Should return {@code true} if and only if the request
+     * may be performed again (e.g. it is a timeout exception and it indicates only that the current server is
+     * overloaded). This may depend not only on the exception type, but also on the other conditions like the allowed
+     * number of retries or the maximum request execution time.
+     *
+     * Effective use of the retry policies may be achieved by combining them with multiple server connections and a
+     * {@link ConnectionSelectionStrategy}.
+     *
+     * @param throwable exception a request failed with
+     * @return true if the request may be retried
+     */
+    boolean canRetryRequest(Throwable throwable);
+
+    /**
+     * Get timeout value for one operation attempt. The default value is 1 hour.
+     *
+     * @return operation timeout, should be greater or equal to 0
+     */
+    default long getOperationTimeout() {
+        return TimeUnit.HOURS.toMillis(1);
+    }
+
+    /**
+     * Wrap a generic operation taking an arbitrary number of arguments and returning a {@link CompletableFuture}.
+     * Each operation attempt is limited with a timeout returned by {@link #getOperationTimeout()}
+     *
+     * @param operation supplier for the operation to perform. Must return a new operation instance
+     * @param executor executor in which the retry callbacks will be scheduled
+     * @param <T> operation result type
+     * @return {@link CompletableFuture} with the same type as the operation result type
+     */
+    default <T> CompletableFuture<T> wrapOperation(Supplier<CompletableFuture<T>> operation, Executor executor) {
+        Assert.notNull(operation, "Operation must not be null");
+        Assert.notNull(executor, "Executor must not be null");
+
+        return operation.get().handleAsync((value, ex) -> {
+            if (ex == null) {
+                return value;
+            } else {
+                do {
+                    try {
+                        return operation.get().get(getOperationTimeout(), TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException | TimeoutException e) {
+                        ex = e;
+                    } catch (ExecutionException e) {
+                        ex = e.getCause();
+                    }
+                }
+                while (this.canRetryRequest(ex));
+                throw new CompletionException(ex);
+            }
+        });
+    }
+}

--- a/src/main/java/io/tarantool/driver/RequestRetryPolicyFactory.java
+++ b/src/main/java/io/tarantool/driver/RequestRetryPolicyFactory.java
@@ -1,0 +1,18 @@
+package io.tarantool.driver;
+
+/**
+ * Manages instantiation of request retry policies. A policy contains an algorithm of deciding whether an exception
+ * is retriable and settings for limiting the retry attempts
+ *
+ * @see RequestRetryPolicy
+ * @author Alexey Kuzin
+ */
+public interface RequestRetryPolicyFactory {
+    /**
+     * Instantiate a new request retry policy instance. The policy may be either stateful or stateless, so depending on
+     * that the policy may be either instantiated as a singleton or once per request.
+     *
+     * @return new policy instance
+     */
+    RequestRetryPolicy create();
+}

--- a/src/main/java/io/tarantool/driver/RetryingTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/RetryingTarantoolClient.java
@@ -1,0 +1,324 @@
+package io.tarantool.driver;
+
+import io.tarantool.driver.api.MultiValueCallResult;
+import io.tarantool.driver.api.SingleValueCallResult;
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.space.RetryingTarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.core.TarantoolConnectionListeners;
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.mappers.CallResultMapper;
+import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.MessagePackObjectMapper;
+import io.tarantool.driver.mappers.MessagePackValueMapper;
+import io.tarantool.driver.mappers.ResultMapperFactoryFactory;
+import io.tarantool.driver.metadata.TarantoolMetadataOperations;
+import io.tarantool.driver.metadata.TarantoolMetadataProvider;
+import io.tarantool.driver.protocol.Packable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+/**
+ * Client implementation that decorates a {@link TarantoolClient} instance, allowing to specify a retry policy for
+ * all requests made through this client instance.
+ *
+ * Retry policy is applied before the possible exception is propagated to the user in the wrapping CompletableFuture.
+ * Since that, the timeout specified for waiting the future result, bounds externally the overall operation time.
+ *
+ * @param <T> target tuple type
+ * @param <R> target tuple collection type
+ * @author Alexey Kuzin
+ */
+public abstract class RetryingTarantoolClient<T extends Packable, R extends Collection<T>>
+        implements TarantoolClient<T, R> {
+
+    private final TarantoolClient<T, R> client;
+    private final RequestRetryPolicyFactory retryPolicyFactory;
+    private final Executor executor;
+
+    /**
+     * Basic constructor. {@link Executors#newWorkStealingPool()} is used for executor by default.
+     *
+     * @param decoratedClient       configured Tarantool client
+     * @param retryPolicyFactory    request retrying policy settings
+     */
+    public RetryingTarantoolClient(TarantoolClient<T, R> decoratedClient,
+                                   RequestRetryPolicyFactory retryPolicyFactory) {
+        this(decoratedClient, retryPolicyFactory, Executors.newWorkStealingPool());
+    }
+
+    /**
+     * Basic constructor
+     * @param decoratedClient       configured Tarantool client
+     * @param retryPolicyFactory    request retrying policy settings
+     * @param executor              executor service for retry callbacks
+     */
+    public RetryingTarantoolClient(TarantoolClient<T, R> decoratedClient,
+                                   RequestRetryPolicyFactory retryPolicyFactory,
+                                   Executor executor) {
+        this.client = decoratedClient;
+        this.retryPolicyFactory = retryPolicyFactory;
+        this.executor = executor;
+    }
+
+    @Override
+    public TarantoolMetadataProvider metadataProvider() {
+        return client.metadataProvider();
+    }
+
+    @Override
+    public TarantoolClientConfig getConfig() {
+        return client.getConfig();
+    }
+
+    @Override
+    public TarantoolVersion getVersion() throws TarantoolClientException {
+        return client.getVersion();
+    }
+
+    @Override
+    public TarantoolSpaceOperations<T, R> space(String spaceName) throws TarantoolClientException {
+        return spaceOperations(client.space(spaceName), retryPolicyFactory, executor);
+    }
+
+    @Override
+    public TarantoolSpaceOperations<T, R> space(int spaceId) throws TarantoolClientException {
+        return spaceOperations(client.space(spaceId), retryPolicyFactory, executor);
+    }
+
+    /**
+     * Creates a space API implementation instance for the specified space
+     *
+     * @param decoratedSpaceOperations  space API implementation form the decorated Tarantool client instance
+     * @param retryPolicyFactory        request retrying policy factory
+     * @param executor                  executor service for retry callbacks
+     * @return space API implementation instance
+     */
+    protected abstract RetryingTarantoolSpaceOperations<T, R> spaceOperations(
+            TarantoolSpaceOperations<T, R> decoratedSpaceOperations,
+            RequestRetryPolicyFactory retryPolicyFactory,
+            Executor executor);
+
+    @Override
+    public TarantoolMetadataOperations metadata() throws TarantoolClientException {
+        return client.metadata();
+    }
+
+    @Override
+    public TarantoolConnectionListeners getListeners() {
+        return client.getListeners();
+    }
+
+    @Override
+    public CompletableFuture<List<?>> call(String functionName) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> call(String functionName, Object... arguments) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> call(String functionName, List<?> arguments) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> call(String functionName,
+                                           List<?> arguments,
+                                           MessagePackMapper mapper) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments, mapper));
+    }
+
+    @Override
+    public <T> CompletableFuture<TarantoolResult<T>> call(String functionName,
+                                                          Class<T> entityClass) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, entityClass));
+    }
+
+    @Override
+    public <T> CompletableFuture<TarantoolResult<T>> call(
+            String functionName,
+            CallResultMapper<TarantoolResult<T>, SingleValueCallResult<TarantoolResult<T>>> resultMapper)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, resultMapper));
+    }
+
+    @Override
+    public <T> CompletableFuture<TarantoolResult<T>> call(String functionName,
+                                                          List<?> arguments,
+                                                          Class<T> entityClass) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments, entityClass));
+    }
+
+    @Override
+    public <T> CompletableFuture<TarantoolResult<T>> call(
+            String functionName,
+            List<?> arguments,
+            CallResultMapper<TarantoolResult<T>, SingleValueCallResult<TarantoolResult<T>>> resultMapper)
+            throws TarantoolClientException {
+        return null;
+    }
+
+    @Override
+    public <T> CompletableFuture<TarantoolResult<T>> call(String functionName,
+                                                          List<?> arguments,
+                                                          MessagePackObjectMapper argumentsMapper,
+                                                          Class<T> entityClass) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments, argumentsMapper, entityClass));
+    }
+
+    @Override
+    public <T> CompletableFuture<TarantoolResult<T>> call(
+            String functionName,
+            List<?> arguments,
+            MessagePackObjectMapper argumentsMapper,
+            CallResultMapper<TarantoolResult<T>, SingleValueCallResult<TarantoolResult<T>>> resultMapper)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments, argumentsMapper, resultMapper));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> callForSingleResult(String functionName,
+                                                        List<?> arguments,
+                                                        MessagePackObjectMapper argumentsMapper,
+                                                        Class<T> resultClass) throws TarantoolClientException {
+        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, argumentsMapper, resultClass));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> callForSingleResult(String functionName,
+                                                        List<?> arguments,
+                                                        MessagePackObjectMapper argumentsMapper,
+                                                        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapper));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> callForSingleResult(String functionName, List<?> arguments, Class<T> resultClass)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, resultClass));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> callForSingleResult(String functionName,
+                                                        List<?> arguments,
+                                                        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, resultMapper));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> callForSingleResult(String functionName, Class<T> resultClass)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForSingleResult(functionName, resultClass));
+    }
+
+    @Override
+    public <T> CompletableFuture<T> callForSingleResult(String functionName,
+                                                        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForSingleResult(functionName, resultMapper));
+    }
+
+    @Override
+    public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(String functionName,
+                                                                          List<?> arguments,
+                                                                          MessagePackObjectMapper argumentsMapper,
+                                                                          Class<R> resultClass)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, argumentsMapper, resultClass));
+    }
+
+    @Override
+    public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
+            String functionName,
+            List<?> arguments,
+            MessagePackObjectMapper argumentsMapper,
+            CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapper));
+    }
+
+    @Override
+    public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(String functionName,
+                                                                          List<?> arguments,
+                                                                          Class<R> resultClass)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, resultClass));
+    }
+
+    @Override
+    public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
+            String functionName,
+            List<?> arguments,
+            CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper) throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, resultMapper));
+    }
+
+    @Override
+    public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(String functionName, Class<R> resultClass)
+            throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, resultClass));
+    }
+
+    @Override
+    public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
+            String functionName,
+            CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper) throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, resultMapper));
+    }
+
+    @Override
+    public ResultMapperFactoryFactory getResultMapperFactoryFactory() {
+        return client.getResultMapperFactoryFactory();
+    }
+
+    @Override
+    public CompletableFuture<List<?>> eval(String expression) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> eval(String expression, List<?> arguments) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, arguments));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> eval(String expression,
+                                           MessagePackValueMapper resultMapper) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, resultMapper));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> eval(String expression,
+                                           List<?> arguments,
+                                           MessagePackValueMapper resultMapper) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, arguments, resultMapper));
+    }
+
+    @Override
+    public CompletableFuture<List<?>> eval(String expression, List<?> arguments,
+                                           MessagePackObjectMapper argumentsMapper,
+                                           MessagePackValueMapper resultMapper) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, arguments, argumentsMapper, resultMapper));
+    }
+
+    @Override
+    public void close() throws Exception {
+        client.close();
+    }
+
+    private <S> CompletableFuture<S> wrapOperation(Supplier<CompletableFuture<S>> operation) {
+        RequestRetryPolicy retryPolicy = retryPolicyFactory.create();
+        return retryPolicy.wrapOperation(operation, executor);
+    }
+}

--- a/src/main/java/io/tarantool/driver/RetryingTarantoolTupleClient.java
+++ b/src/main/java/io/tarantool/driver/RetryingTarantoolTupleClient.java
@@ -1,0 +1,51 @@
+package io.tarantool.driver;
+
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.space.RetryingTarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@link RetryingTarantoolClient} implementation for working with default tuples
+ *
+ * @author Alexey Kuzin
+ */
+public class RetryingTarantoolTupleClient
+        extends RetryingTarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> {
+    /**
+     * Basic constructor
+     *
+     * @param decoratedClient    configured Tarantool client
+     * @param retryPolicyFactory request retrying policy settings
+     */
+    public RetryingTarantoolTupleClient(
+            TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> decoratedClient,
+            RequestRetryPolicyFactory retryPolicyFactory) {
+        super(decoratedClient, retryPolicyFactory);
+    }
+
+    /**
+     * Basic constructor
+     *
+     * @param decoratedClient    configured Tarantool client
+     * @param retryPolicyFactory request retrying policy settings
+     * @param executor           executor service for retry callbacks
+     */
+    public RetryingTarantoolTupleClient(
+            TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> decoratedClient,
+            RequestRetryPolicyFactory retryPolicyFactory,
+            Executor executor) {
+        super(decoratedClient, retryPolicyFactory, executor);
+    }
+
+    @Override
+    protected
+    RetryingTarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>>
+    spaceOperations(TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> decoratedSpaceOperations,
+                    RequestRetryPolicyFactory retryPolicyFactory, Executor executor) {
+        return new RetryingTarantoolSpaceOperations<>(decoratedSpaceOperations, retryPolicyFactory, executor);
+    }
+}

--- a/src/main/java/io/tarantool/driver/TarantoolClientConfig.java
+++ b/src/main/java/io/tarantool/driver/TarantoolClientConfig.java
@@ -3,6 +3,7 @@ package io.tarantool.driver;
 import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.core.TarantoolConnectionSelectionStrategies;
 import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.utils.Assert;
@@ -29,6 +30,8 @@ public class TarantoolClientConfig {
     private int connections = DEFAULT_CONNECTIONS;
     private MessagePackMapper messagePackMapper =
             DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
+    private ConnectionSelectionStrategyFactory connectionSelectionStrategyFactory =
+            TarantoolConnectionSelectionStrategies.RoundRobinStrategyFactory.INSTANCE;
 
     /**
      * Basic constructor.
@@ -135,6 +138,24 @@ public class TarantoolClientConfig {
     }
 
     /**
+     * Get factory implementation for collection selection strategy instances
+     * @return connection selection strategy factory instance
+     */
+    public ConnectionSelectionStrategyFactory getConnectionSelectionStrategyFactory() {
+        return connectionSelectionStrategyFactory;
+    }
+
+    /**
+     * Set factory implementation for collection selection strategy instances, for example, an instance of
+     * {@link io.tarantool.driver.core.TarantoolConnectionSelectionStrategies.RoundRobinStrategyFactory}
+     * @param connectionSelectionStrategyFactory connection selection strategy factory instance
+     */
+    public void setConnectionSelectionStrategyFactory(
+            ConnectionSelectionStrategyFactory connectionSelectionStrategyFactory) {
+        this.connectionSelectionStrategyFactory = connectionSelectionStrategyFactory;
+    }
+
+    /**
      * Create a builder instance.
      *
      * @return a builder
@@ -226,6 +247,18 @@ public class TarantoolClientConfig {
         public Builder withConnections(int connections) {
             Assert.state(connections > 1, "The number of server connections must be greater than 0");
             config.connections = connections;
+            return this;
+        }
+
+        /**
+         * Set the implementation of a factory which instantiates a strategy instance providing the algorithm of
+         * selecting the next connection from a connection pool for performing the next request
+         * @param factory connection selection strategy factory instance
+         * @return builder
+         */
+        public Builder withConnectionSelectionStrategyFactory(ConnectionSelectionStrategyFactory factory) {
+            Assert.notNull(factory, "Connection selection strategy factory must not be null");
+            config.setConnectionSelectionStrategyFactory(factory);
             return this;
         }
 

--- a/src/main/java/io/tarantool/driver/TarantoolRequestRetryPolicies.java
+++ b/src/main/java/io/tarantool/driver/TarantoolRequestRetryPolicies.java
@@ -1,0 +1,89 @@
+package io.tarantool.driver;
+
+import java.util.function.Function;
+
+/**
+ * Class-container for default kinds of request retry policies
+ *
+ * @author Alexey Kuzin
+ */
+public final class TarantoolRequestRetryPolicies {
+
+    private TarantoolRequestRetryPolicies() {
+    }
+
+    /**
+     * Retry policy shich accepts a maximum number of attempts and an exception checking callback.
+     * If the exception check passes and there are any attempts left, the policy returns {@code true}.
+     *
+     * @param <T> exception checking callback function type
+     */
+    public static final class AttemptsBoundRetryPolicy<T extends Function<Throwable, Boolean>>
+            implements RequestRetryPolicy {
+
+        private int attempts;
+        private final T callback;
+
+        /**
+         * Basic constructor
+         *
+         * @param attempts maximum number of retry attempts
+         * @param callback function checking whether the given exception may be retried
+         */
+        public AttemptsBoundRetryPolicy(int attempts, T callback) {
+            this.attempts = attempts;
+            this.callback = callback;
+        }
+
+        @Override
+        public boolean canRetryRequest(Throwable throwable) {
+            if (callback.apply(throwable) && attempts > 0) {
+                attempts--;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Factory for {@link AttemptsBoundRetryPolicy}
+     *
+     * @param <T> exception checking callback function type
+     */
+    public static final class AttemptsBoundRetryPolicyFactory<T extends Function<Throwable, Boolean>>
+            implements RequestRetryPolicyFactory {
+
+        private final int numberOfAttempts;
+        private final T callback;
+
+        /**
+         * Basic constructor
+         *
+         * @param numberOfAttempts  maximum number of retry attempts
+         * @param callback          function checking whether the given exception may be retried
+         */
+        public AttemptsBoundRetryPolicyFactory(int numberOfAttempts, T callback) {
+            this.numberOfAttempts = numberOfAttempts;
+            this.callback = callback;
+        }
+
+        @Override
+        public RequestRetryPolicy create() {
+            return new AttemptsBoundRetryPolicy<>(numberOfAttempts, callback);
+        }
+    }
+
+    /**
+     * Create a factory for retry policy bound by retry attempts
+     *
+     * @param numberOfAttempts  maximum number of retries
+     * @param exceptionCheck    function callback, checking the given exception whether the request may be retried
+     * @param <T> exception checking callback function type
+     * @return new factory instance
+     */
+    public static
+    <T extends Function<Throwable, Boolean>> AttemptsBoundRetryPolicyFactory<T>
+    byNumberOfAttempts(int numberOfAttempts, T exceptionCheck) {
+        return new AttemptsBoundRetryPolicyFactory<>(numberOfAttempts, exceptionCheck);
+    }
+}

--- a/src/main/java/io/tarantool/driver/api/cursor/OffsetCursor.java
+++ b/src/main/java/io/tarantool/driver/api/cursor/OffsetCursor.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutionException;
  *
  * @author Vladimir Rogach
  */
-public class OffsetCursor<T extends Packable, R extends Collection<T>> extends TarantoolCursorBase<T,R> {
+public class OffsetCursor<T extends Packable, R extends Collection<T>> extends TarantoolCursorBase<T, R> {
 
     private final TarantoolSpaceOperations<T, R> space;
     private final Conditions initConditions;

--- a/src/main/java/io/tarantool/driver/api/cursor/StartAfterCursor.java
+++ b/src/main/java/io/tarantool/driver/api/cursor/StartAfterCursor.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
  *
  * @author Vladimir Rogach
  */
-public class StartAfterCursor<T extends Packable, R extends Collection<T>> extends TarantoolCursorBase<T,R> {
+public class StartAfterCursor<T extends Packable, R extends Collection<T>> extends TarantoolCursorBase<T, R> {
 
     private final TarantoolSpaceOperations<T, R> space;
     private final Conditions initConditions;
@@ -48,7 +48,6 @@ public class StartAfterCursor<T extends Packable, R extends Collection<T>> exten
         this.spaceOffset = 0;
         this.mapper = mapper;
     }
-
 
     @Override
     protected void fetchNextTuples() throws TarantoolClientException {

--- a/src/main/java/io/tarantool/driver/api/cursor/TarantoolCursorBase.java
+++ b/src/main/java/io/tarantool/driver/api/cursor/TarantoolCursorBase.java
@@ -1,15 +1,10 @@
 package io.tarantool.driver.api.cursor;
 
-import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.exceptions.TarantoolSpaceOperationException;
 import io.tarantool.driver.protocol.Packable;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Generic cursor imlementation that performs client calls
@@ -20,9 +15,9 @@ import java.util.concurrent.ExecutionException;
 public abstract class TarantoolCursorBase<T extends Packable, R extends Collection<T>>
         implements TarantoolCursor<T> {
 
-    abstract protected void fetchNextTuples();
-    abstract protected boolean advanceIterator();
-    abstract protected T getCurrentValue();
+    protected abstract void fetchNextTuples();
+    protected abstract boolean advanceIterator();
+    protected abstract T getCurrentValue();
 
     /**
      * If batchSize is less than condition limit

--- a/src/main/java/io/tarantool/driver/api/space/RetryingTarantoolSpaceOperations.java
+++ b/src/main/java/io/tarantool/driver/api/space/RetryingTarantoolSpaceOperations.java
@@ -1,0 +1,103 @@
+package io.tarantool.driver.api.space;
+
+import io.tarantool.driver.RequestRetryPolicy;
+import io.tarantool.driver.RequestRetryPolicyFactory;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.cursor.TarantoolCursor;
+import io.tarantool.driver.api.tuple.operations.TupleOperations;
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
+import io.tarantool.driver.protocol.Packable;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * Wrapper for {@link TarantoolSpaceOperations} instances which adds request retry policy to each operation
+ *
+ * @param <T> target tuple type
+ * @param <R> target tuple collection type
+ * @author Alexey Kuzin
+ */
+public class RetryingTarantoolSpaceOperations<T extends Packable, R extends Collection<T>>
+        implements TarantoolSpaceOperations<T, R> {
+
+    private final TarantoolSpaceOperations<T, R> spaceOperations;
+    private final RequestRetryPolicyFactory retryPolicyFactory;
+    private final Executor executor;
+
+    /**
+     * Basic constructor
+     *
+     * @param spaceOperations       {@link TarantoolSpaceOperations} instance which operations will be wrapped
+     * @param retryPolicyFactory    request retrying policy factory
+     * @param executor              executor service for retry callbacks
+     */
+    public RetryingTarantoolSpaceOperations(TarantoolSpaceOperations<T, R> spaceOperations,
+                                            RequestRetryPolicyFactory retryPolicyFactory,
+                                            Executor executor) {
+        this.spaceOperations = spaceOperations;
+        this.retryPolicyFactory = retryPolicyFactory;
+        this.executor = executor;
+    }
+
+    @Override
+    public CompletableFuture<R> delete(Conditions conditions)
+            throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.delete(conditions));
+    }
+
+    @Override
+    public CompletableFuture<R> insert(T tuple) throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.insert(tuple));
+    }
+
+    @Override
+    public CompletableFuture<R> replace(T tuple)
+            throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.replace(tuple));
+    }
+
+    @Override
+    public CompletableFuture<R> select(Conditions conditions)
+            throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.select(conditions));
+    }
+
+    @Override
+    public CompletableFuture<R> update(Conditions conditions, T tuple) {
+        return wrapOperation(() -> spaceOperations.update(conditions, tuple));
+    }
+
+    @Override
+    public CompletableFuture<R> update(Conditions conditions, TupleOperations operations) {
+        return wrapOperation(() -> spaceOperations.update(conditions, operations));
+    }
+
+    @Override
+    public CompletableFuture<R> upsert(Conditions conditions, T tuple, TupleOperations operations) {
+        return wrapOperation(() -> spaceOperations.upsert(conditions, tuple, operations));
+    }
+
+    @Override
+    public TarantoolSpaceMetadata getMetadata() {
+        return spaceOperations.getMetadata();
+    }
+
+    @Override
+    public TarantoolCursor<T> cursor(Conditions conditions, int batchSize) {
+        return spaceOperations.cursor(conditions, batchSize);
+    }
+
+    @Override
+    public TarantoolCursor<T> cursor(Conditions conditions) {
+        return spaceOperations.cursor(conditions);
+    }
+
+    private CompletableFuture<R> wrapOperation(Supplier<CompletableFuture<R>> operation) {
+        RequestRetryPolicy retryPolicy = retryPolicyFactory.create();
+        return retryPolicy.wrapOperation(operation, executor);
+    }
+}

--- a/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
+++ b/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
@@ -94,24 +94,26 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      */
     TarantoolSpaceMetadata getMetadata();
 
-
     /**
      * Cursor is an iterator-like object that is able to scroll through
      * results of a query. Unlike a single cursor loads new tuples
-     * dinamically issuing requests to server.
+     * dynamically issuing requests to server.
      *
      * Select will fetch tuples matching the specified query.
      * Each request to server will fetch no more than 'batch size' tuples.
      *
      * @param conditions query with options
      * @param batchSize  size of a batch of single client request
-     * @return a cursor that can iterate through all corresponding tuples.
+     * @return cursor that can iterate through all corresponding tuples
      */
     TarantoolCursor<T> cursor(Conditions conditions, int batchSize);
 
     /**
      * Same as {@link TarantoolSpaceOperations#cursor(Conditions, int)}
-     * but uses default batch size.
+     * but uses the default batch size.
+     *
+     * @param conditions query with options
+     * @return cursor that can iterate through all corresponding tuples
      */
     TarantoolCursor<T> cursor(Conditions conditions);
 }

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolConnectionManager.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolConnectionManager.java
@@ -47,13 +47,33 @@ public abstract class AbstractTarantoolConnectionManager implements TarantoolCon
     private final Phaser initPhaser = new Phaser(0);
     private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
+    /**
+     * Constructor
+     * @deprecated
+     * @param config Tarantool client config
+     * @param connectionFactory connection factory
+     * @param selectionStrategyFactory connection selection strategy factory
+     * @param connectionListeners connection listeners
+     */
+    protected AbstractTarantoolConnectionManager(TarantoolClientConfig config,
+                                                 TarantoolConnectionFactory connectionFactory,
+                                                 ConnectionSelectionStrategyFactory selectionStrategyFactory,
+                                                 TarantoolConnectionListeners connectionListeners) {
+        this(config, connectionFactory, connectionListeners);
+    }
+
+    /**
+     * Basic constructor
+     * @param config Tarantool client config
+     * @param connectionFactory connection factory
+     * @param connectionListeners connection listeners
+     */
     public AbstractTarantoolConnectionManager(TarantoolClientConfig config,
                                               TarantoolConnectionFactory connectionFactory,
-                                              ConnectionSelectionStrategyFactory selectStrategyFactory,
                                               TarantoolConnectionListeners connectionListeners) {
         this.config = config;
         this.connectionFactory = connectionFactory;
-        this.selectStrategyFactory = selectStrategyFactory;
+        this.selectStrategyFactory = config.getConnectionSelectionStrategyFactory();
         this.connectionSelectStrategy.set(selectStrategyFactory.create(config, Collections.emptyList()));
         this.connectionListeners = connectionListeners;
     }

--- a/src/main/java/io/tarantool/driver/core/TarantoolClusterConnectionManager.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolClusterConnectionManager.java
@@ -1,6 +1,5 @@
 package io.tarantool.driver.core;
 
-import io.tarantool.driver.ConnectionSelectionStrategyFactory;
 import io.tarantool.driver.TarantoolClientConfig;
 import io.tarantool.driver.TarantoolClusterAddressProvider;
 import io.tarantool.driver.TarantoolServerAddress;
@@ -20,16 +19,14 @@ public class TarantoolClusterConnectionManager extends AbstractTarantoolConnecti
      *
      * @param config client configuration
      * @param connectionFactory manages instantiation of Tarantool server connections
-     * @param selectStrategyFactory manages selection of the next connection from available ones
      * @param listeners are invoked after connection is established
      * @param addressProvider provides Tarantool server nodes addresses
      */
     public TarantoolClusterConnectionManager(TarantoolClientConfig config,
                                              TarantoolConnectionFactory connectionFactory,
-                                             ConnectionSelectionStrategyFactory selectStrategyFactory,
                                              TarantoolConnectionListeners listeners,
                                              TarantoolClusterAddressProvider addressProvider) {
-        super(config, connectionFactory, selectStrategyFactory, listeners);
+        super(config, connectionFactory, listeners);
         this.addressProvider = addressProvider;
     }
 

--- a/src/main/java/io/tarantool/driver/mappers/DefaultSingleValueResultMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultSingleValueResultMapper.java
@@ -1,0 +1,33 @@
+package io.tarantool.driver.mappers;
+
+import io.tarantool.driver.api.SingleValueCallResult;
+import org.msgpack.value.ArrayValue;
+
+/**
+ * Default mapper for {@link SingleValueCallResult} with content types supported by the given value mapper
+ *
+ * @author Alexey Kuzin
+ * @param <T> target result content type
+ */
+public class DefaultSingleValueResultMapper<T> extends CallResultMapper<T, SingleValueCallResult<T>> {
+
+    /**
+     * Constructor. The converter target type is determined via reflection.
+     *
+     * @param valueMapper value mapper for result content conversion
+     * @param contentClass target result content class
+     */
+    public DefaultSingleValueResultMapper(MessagePackValueMapper valueMapper, Class<T> contentClass) {
+        super(valueMapper, defaultValueConverter(valueMapper), getResultClass(contentClass));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<SingleValueCallResult<T>> getResultClass(Class<T> contentClass) {
+        return (Class<SingleValueCallResult<T>>) (Class<?>) SingleValueCallResult.class;
+    }
+
+    private static <T> ValueConverter<ArrayValue, ? extends SingleValueCallResult<T>> defaultValueConverter(
+            MessagePackValueMapper valueMapper) {
+        return new SingleValueCallResultConverter<>(valueMapper::fromValue);
+    }
+}

--- a/src/test/java/io/tarantool/driver/RequestRetryPolicyTest.java
+++ b/src/test/java/io/tarantool/driver/RequestRetryPolicyTest.java
@@ -1,0 +1,135 @@
+package io.tarantool.driver;
+
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Alexey Kuzin
+ */
+class RequestRetryPolicyTest {
+
+    private final Executor executor = Executors.newWorkStealingPool();
+
+    @Test
+    void testInfiniteRetryPolicy_success() throws ExecutionException, InterruptedException {
+        RequestRetryPolicy policy = throwable -> true;
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(this::simpleSuccessFuture, executor);
+        assertTrue(wrappedFuture.get());
+    }
+
+    @Test
+    void testInfiniteRetryPolicy_successWithFuture() throws ExecutionException, InterruptedException {
+        RequestRetryPolicy policy = throwable -> true;
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(() -> future, executor);
+        future.complete(true);
+        assertTrue(wrappedFuture.get());
+    }
+
+    @Test
+    void testInfiniteRetryPolicy_successAfterFails() throws ExecutionException, InterruptedException {
+        RequestRetryPolicy policy = throwable -> true;
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(() -> future, executor);
+        future.complete(true);
+        assertTrue(wrappedFuture.get());
+    }
+
+    @Test
+    void testInfiniteRetryPolicy_unretryableError() throws ExecutionException, InterruptedException {
+        RequestRetryPolicy policy = throwable -> throwable instanceof TarantoolClientException;
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(this::simpleFailingFuture, executor);
+        try {
+            wrappedFuture.get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof RuntimeException);
+            assertEquals("Fail", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    void testAttemptsBoundRetryPolicy_returnSuccessAfterFails() throws ExecutionException, InterruptedException {
+        AtomicReference<Integer> retries = new AtomicReference<>(3);
+        RequestRetryPolicy policy = new TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicy<>(4, throwable -> true);
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(
+                () -> {
+                    retries.set(retries.get() - 1);
+                    return failingIfAvailableRetriesFuture(retries.get());
+                }, executor);
+        assertTrue(wrappedFuture.get());
+    }
+
+    @Test
+    void testAttemptsBoundRetryPolicy_runOutOfAttempts() throws ExecutionException, InterruptedException {
+        AtomicReference<Integer> retries = new AtomicReference<>(3);
+        RequestRetryPolicy policy = new TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicy<>(3, throwable -> true);
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(
+                () -> {
+                    retries.set(retries.get() - 1);
+                    return failingIfAvailableRetriesFuture(retries.get());
+                }, executor);
+        try {
+            wrappedFuture.get();
+        } catch (ExecutionException e) {
+            assertEquals(RuntimeException.class, e.getCause().getClass());
+            assertEquals("Should fail " + retries.get() + " times", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    void testAttemptsBoundRetryPolicy_zeroAttempts() throws ExecutionException, InterruptedException {
+        AtomicReference<Integer> retries = new AtomicReference<>(1);
+        RequestRetryPolicy policy = new TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicy<>(0, throwable -> true);
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(
+                () -> {
+                    retries.set(retries.get() - 1);
+                    return failingIfAvailableRetriesFuture(retries.get());
+                }, executor);
+        try {
+            wrappedFuture.get();
+        } catch (ExecutionException e) {
+            assertEquals(RuntimeException.class, e.getCause().getClass());
+            assertEquals("Should fail " + retries.get() + " times", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    void testAttemptsBoundRetryPolicy_unretryableError() throws ExecutionException, InterruptedException {
+        RequestRetryPolicy policy = new TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicy<>(4, throwable -> true);
+        CompletableFuture<Boolean> wrappedFuture = policy.wrapOperation(this::simpleFailingFuture, executor);
+        try {
+            wrappedFuture.get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof RuntimeException);
+            assertEquals("Fail", e.getCause().getMessage());
+        }
+    }
+
+    private CompletableFuture<Boolean> simpleSuccessFuture() {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    private CompletableFuture<Boolean> simpleFailingFuture() {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        result.completeExceptionally(new RuntimeException("Fail"));
+        return result;
+    }
+
+    private CompletableFuture<Boolean> failingIfAvailableRetriesFuture(int retries) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        if (retries > 0) {
+            result.completeExceptionally(new RuntimeException("Should fail " + retries + " times"));
+        } else {
+            result.complete(true);
+        }
+        return result;
+    }
+}

--- a/src/test/java/io/tarantool/driver/integration/ClusterDiscoveryIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterDiscoveryIT.java
@@ -12,7 +12,6 @@ import io.tarantool.driver.cluster.HTTPDiscoveryClusterAddressProvider;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.auth.TarantoolCredentials;
 import io.tarantool.driver.cluster.TestWrappedClusterAddressProvider;
-import io.tarantool.driver.core.TarantoolConnectionSelectionStrategies;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -111,8 +110,7 @@ public class ClusterDiscoveryIT extends SharedCartridgeContainer {
 
         ClusterTarantoolTupleClient client = new ClusterTarantoolTupleClient(
                 config,
-                new TestWrappedClusterAddressProvider(getBinaryProvider(), container),
-                TarantoolConnectionSelectionStrategies.RoundRobinStrategyFactory.INSTANCE);
+                new TestWrappedClusterAddressProvider(getBinaryProvider(), container));
 
         assertNotNull(client.getVersion(), "Version must not be null");
         assertTrue(client.getVersion().toString().contains("Tarantool"), "Version must contain Tarantool");
@@ -129,8 +127,7 @@ public class ClusterDiscoveryIT extends SharedCartridgeContainer {
 
         ClusterTarantoolTupleClient client = new ClusterTarantoolTupleClient(
                 config,
-                new TestWrappedClusterAddressProvider(getHttpProvider(), container),
-                TarantoolConnectionSelectionStrategies.RoundRobinStrategyFactory.INSTANCE);
+                new TestWrappedClusterAddressProvider(getHttpProvider(), container));
 
         assertNotNull(client.getVersion(), "Version must not be null");
         assertTrue(client.getVersion().toString().contains("Tarantool"), "Version must contain Tarantool");

--- a/src/test/java/io/tarantool/driver/integration/ProxyCursorIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyCursorIT.java
@@ -117,8 +117,7 @@ public class ProxyCursorIT extends SharedCartridgeContainer {
                 .build();
 
         ClusterTarantoolTupleClient clusterClient = new ClusterTarantoolTupleClient(
-                config, getClusterAddressProvider(),
-                TarantoolConnectionSelectionStrategies.RoundRobinStrategyFactory.INSTANCE);
+                config, getClusterAddressProvider());
         client = new ProxyTarantoolTupleClient(clusterClient);
     }
 

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
@@ -18,7 +18,6 @@ import io.tarantool.driver.cluster.BinaryClusterDiscoveryEndpoint;
 import io.tarantool.driver.cluster.BinaryDiscoveryClusterAddressProvider;
 import io.tarantool.driver.cluster.TarantoolClusterDiscoveryConfig;
 import io.tarantool.driver.cluster.TestWrappedClusterAddressProvider;
-import io.tarantool.driver.core.TarantoolConnectionSelectionStrategies.RoundRobinStrategyFactory;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
@@ -109,7 +108,7 @@ public class ProxyTarantoolClientIT extends SharedCartridgeContainer {
                 .build();
 
         ClusterTarantoolTupleClient clusterClient = new ClusterTarantoolTupleClient(
-                config, getClusterAddressProvider(), RoundRobinStrategyFactory.INSTANCE);
+                config, getClusterAddressProvider());
         client = new ProxyTarantoolTupleClient(clusterClient);
     }
 

--- a/src/test/java/io/tarantool/driver/integration/RetryingTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/RetryingTarantoolTupleClientIT.java
@@ -1,0 +1,59 @@
+package io.tarantool.driver.integration;
+
+import io.tarantool.driver.ClusterTarantoolTupleClient;
+import io.tarantool.driver.ProxyTarantoolTupleClient;
+import io.tarantool.driver.RetryingTarantoolTupleClient;
+import io.tarantool.driver.TarantoolClientConfig;
+import io.tarantool.driver.TarantoolRequestRetryPolicies;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Alexey Kuzin
+ */
+public class RetryingTarantoolTupleClientIT extends SharedCartridgeContainer {
+
+    public static String USER_NAME;
+    public static String PASSWORD;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        startCluster();
+        USER_NAME = container.getUsername();
+        PASSWORD = container.getPassword();
+    }
+
+    private ProxyTarantoolTupleClient setupClient() {
+        TarantoolClientConfig config = TarantoolClientConfig.builder()
+                .withCredentials(new SimpleTarantoolCredentials(USER_NAME, PASSWORD))
+                .withConnectTimeout(100000)
+                .withReadTimeout(100000)
+                .build();
+
+        ClusterTarantoolTupleClient clusterClient = new ClusterTarantoolTupleClient(
+                config, container.getRouterHost(), container.getRouterPort());
+        return new ProxyTarantoolTupleClient(clusterClient);
+    }
+
+    private RetryingTarantoolTupleClient retrying(ProxyTarantoolTupleClient client, int retries) {
+        return new RetryingTarantoolTupleClient(client,
+                TarantoolRequestRetryPolicies.byNumberOfAttempts(
+                retries, e -> e.getMessage().contains("Unsuccessful attempt")));
+    }
+
+    @Test
+    void testSuccessAfterSeveralRetries() throws Exception {
+        try (ProxyTarantoolTupleClient client = setupClient()) {
+            // The stored function will fail 3 times
+            client.call("setup_retrying_function", Collections.singletonList(3));
+
+            String result = retrying(client, 4).callForSingleResult("retrying_function", String.class).get();
+            assertEquals("Success", result);
+        }
+    }
+}


### PR DESCRIPTION
These changes include:

 - New RetryingTarantoolClient decorator which may be used for specific types of requests
 - A framework for retry policies. The policy can use any stateful or stateless operations for determining if a request should be retried in case of an exception
 - Breaking change: connection selection strategy moved to the TarantoolClientConfig.

Closes #53 