### PR TITLE
New ddl.get_schema example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ with sharding via [vshard](https://github.com/tarantool/vshard).
 ## Quickstart
 
 1. Set up your [Cartridge cluster](https://tarantool.io/cartridge). Use an existing Cartridge application or create
-a new one from the available [examples](https://github.com/tarantool/examples). Add the
-[tarantool/crud](https://github.com/tarantool/crud) and [tarantool/ddl](https://github.com/tarantool/ddl) modules to the
-dependencies in the [`rockspec`](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#creating-a-project)
+a new one from the available [examples](https://github.com/tarantool/examples). 
+   
+2. Add the [tarantool/crud](https://github.com/tarantool/crud) and [tarantool/ddl](https://github.com/tarantool/ddl)
+modules to the dependencies in the [`rockspec`](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#creating-a-project)
 file of your application.
 
-2. Add the following lines into any [storage role](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#cluster-roles)
+3. Add the following lines into any [storage role](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#cluster-roles)
 enabled on all storage instances in your cluster. The lines go into role API declaration section; in other words, into the returned table
 
 ```lua
@@ -33,7 +34,7 @@ return {
 }
 ```
 
-3. Add the following lines into any [router role](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#cluster-roles)
+4. Add the following lines into any [router role](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#cluster-roles)
 enabled on all router instances in your cluster to which the driver will be connected to:
 
 ```lua
@@ -61,25 +62,25 @@ local function init(opts)
 end
 ```
 
-4. Check that at least one role enabled on the storage instances depends on the [`crud-storage`](https://github.com/tarantool/crud#api)
+5. Check that at least one role enabled on the storage instances depends on the [`crud-storage`](https://github.com/tarantool/crud#api)
 role from the `tarantool/crud` module and at least one role enabled on the router instances the driver will be connected
 to depends on the [`crud-router`](https://github.com/tarantool/crud#api) role.
 
-5. Start your Cartridge cluster. You may use [`cartridge start`](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_cli/)
+6. Start your Cartridge cluster. You may use [`cartridge start`](https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_cli/)
 for starting it manually or the [Testcontainers for Tarantool](https://github.com/tarantool/cartridge-testcontainers)
 library for starting it automatically in tests.
 
-6. Add the following dependency into your project:
+7. Add the following dependency into your project:
 
 ```xml
 <dependency>
   <groupId>io.tarantool</groupId>
   <artifactId>cartridge-driver</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
 </dependency>
 ```
 
-7. Create a new `TarantoolClient` instance:
+8. Create a new `TarantoolClient` instance:
 
 ```java
 private ProxyTarantoolTupleClient setupClient() {
@@ -93,7 +94,7 @@ private ProxyTarantoolTupleClient setupClient() {
 }
 ```
 
-8. Use the API provided by the Tarantool client, for example:
+9. Use the API provided by the Tarantool client, for example:
 
 ```java
     TarantoolTupleFactory tupleFactory = new DefaultTarantoolTupleFactory(mapperFactory.defaultComplexTypesMapper());
@@ -120,7 +121,8 @@ these variants or create your own discovery provider implementation. In real env
 requirements it is recommended to use an external configuration provider (like etcd), DNS or a balancing proxy for
 connecting to the Tarantool server.
 
-The next example is showing the instantiation of the `ClusterTarantoolClient` with stored function discovery provider:
+The next example is showing the instantiation of the `ClusterTarantoolTupleClient` with stored function discovery 
+provider:
 
 ```java
 class Scratch {
@@ -292,9 +294,15 @@ Java 1.8 or higher is required for building and using this driver.
 
 ## Building
 
-Docker accessible to the current user is required for running integration tests.
-Use `./mvnw verify` to run unit tests and `./mvnw test -Pintegration` to run integration tests.
-Use `./mvnw install` for installing the artifact locally.
+1. Docker accessible to the current user is required for running integration tests.
+2. Set up the right user for running Tarantool with in the container:
+```bash
+export TARANTOOL_SERVER_USER=<current user>
+export TARANTOOL_SERVER_GROUP=<current group>
+```
+Substitute the user and group in these commands with the user and group under which the tests will run.
+3. Use `./mvnw verify` to run unit tests and `./mvnw test -Pintegration` to run integration tests.
+4. Use `./mvnw install` for installing the artifact locally.
 
 ## Contributing
 

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -1,0 +1,335 @@
+package io.tarantool.driver.integration;
+
+import io.tarantool.driver.ClusterTarantoolTupleClient;
+import io.tarantool.driver.DefaultTarantoolTupleFactory;
+import io.tarantool.driver.ProxyTarantoolTupleClient;
+import io.tarantool.driver.TarantoolClientConfig;
+import io.tarantool.driver.TarantoolClusterAddressProvider;
+import io.tarantool.driver.TarantoolServerAddress;
+import io.tarantool.driver.api.SingleValueCallResult;
+import io.tarantool.driver.api.TarantoolTupleFactory;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.cluster.BinaryClusterDiscoveryEndpoint;
+import io.tarantool.driver.cluster.BinaryDiscoveryClusterAddressProvider;
+import io.tarantool.driver.cluster.TarantoolClusterDiscoveryConfig;
+import io.tarantool.driver.cluster.TestWrappedClusterAddressProvider;
+import io.tarantool.driver.mappers.CallResultMapper;
+import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
+import io.tarantool.driver.mappers.MessagePackValueMapper;
+import io.tarantool.driver.metadata.TarantoolIndexMetadata;
+import io.tarantool.driver.metadata.TarantoolIndexType;
+import io.tarantool.driver.metadata.TarantoolMetadataOperations;
+import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
+import io.tarantool.driver.api.tuple.operations.TupleOperations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Sergey Volgin
+ */
+public class ProxyTarantoolClientMixedInstancesIT extends SharedCartridgeContainerMixedInstances {
+
+    private static ProxyTarantoolTupleClient client;
+    private static final DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
+    private static final TarantoolTupleFactory tupleFactory =
+            new DefaultTarantoolTupleFactory(mapperFactory.defaultComplexTypesMapper());
+
+    public static String USER_NAME;
+    public static String PASSWORD;
+
+    private static final String TEST_SPACE_NAME = "test__profile";
+    private static final int DEFAULT_TIMEOUT = 10 * 1000;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        startCluster();
+        USER_NAME = container.getUsername();
+        PASSWORD = container.getPassword();
+        initClient();
+        truncateSpace(TEST_SPACE_NAME);
+    }
+
+    private static void truncateSpace(String spaceName) {
+        client.call("truncate_space", spaceName);
+    }
+
+    private static TarantoolClusterAddressProvider getClusterAddressProvider() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(USER_NAME, PASSWORD);
+        TarantoolClientConfig config = TarantoolClientConfig.builder()
+                .withCredentials(credentials)
+                .withReadTimeout(DEFAULT_TIMEOUT)
+                .withConnectTimeout(DEFAULT_TIMEOUT)
+                .build();
+
+        BinaryClusterDiscoveryEndpoint endpoint = new BinaryClusterDiscoveryEndpoint.Builder()
+                .withClientConfig(config)
+                .withEntryFunction("get_routers")
+                .withEndpointProvider(() -> Collections.singletonList(
+                        new TarantoolServerAddress(container.getRouterHost(), container.getRouterPort())))
+                .build();
+
+        TarantoolClusterDiscoveryConfig clusterDiscoveryConfig = new TarantoolClusterDiscoveryConfig.Builder()
+                .withEndpoint(endpoint)
+                .withDelay(1)
+                .build();
+
+        return new TestWrappedClusterAddressProvider(
+                new BinaryDiscoveryClusterAddressProvider(clusterDiscoveryConfig),
+                container);
+    }
+
+    public static void initClient() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(USER_NAME, PASSWORD);
+
+        TarantoolClientConfig config = new TarantoolClientConfig.Builder()
+                .withCredentials(credentials)
+                .withConnectTimeout(DEFAULT_TIMEOUT)
+                .withReadTimeout(DEFAULT_TIMEOUT)
+                .withRequestTimeout(DEFAULT_TIMEOUT)
+                .build();
+
+        ClusterTarantoolTupleClient clusterClient = new ClusterTarantoolTupleClient(
+                config, getClusterAddressProvider());
+        client = new ProxyTarantoolTupleClient(clusterClient);
+    }
+
+    @Test
+    public void getClusterMetaDataTest() {
+        TarantoolMetadataOperations metadataOperations = client.metadata();
+
+        Optional<TarantoolSpaceMetadata> spaceMeta = metadataOperations.getSpaceByName(TEST_SPACE_NAME);
+        assertTrue(spaceMeta.isPresent());
+        TarantoolSpaceMetadata spaceMetadata = spaceMeta.get();
+        assertEquals(TEST_SPACE_NAME, spaceMetadata.getSpaceName());
+        assertEquals(-1, spaceMetadata.getOwnerId());
+        // FIXME Blocked by https://github.com/tarantool/ddl/issues/52
+//        assertTrue(spaceMetadata.getSpaceId() > 0);
+        assertEquals(5, spaceMetadata.getSpaceFormatMetadata().size());
+        assertEquals(3, spaceMetadata.getFieldPositionByName("age"));
+        assertEquals("unsigned", spaceMetadata.getFieldByName("age").get().getFieldType());
+
+        Optional<TarantoolIndexMetadata> indexMeta = metadataOperations
+                .getIndexByName(TEST_SPACE_NAME, "bucket_id");
+        assertTrue(indexMeta.isPresent());
+        TarantoolIndexMetadata indexMetadata = indexMeta.get();
+        assertEquals("bucket_id", indexMetadata.getIndexName());
+        assertEquals(1, indexMetadata.getIndexId());
+        assertEquals(TarantoolIndexType.TREE, indexMetadata.getIndexType());
+        assertFalse(indexMetadata.getIndexOptions().isUnique());
+    }
+
+    @Test
+    public void clusterInsertSelectTest() throws ExecutionException, InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+                client.space(TEST_SPACE_NAME);
+
+        TarantoolTuple tarantoolTuple;
+
+        List<CompletableFuture<?>> allFutures = new ArrayList<>(20);
+        for (int i = 0; i < 20; i++) {
+            tarantoolTuple = tupleFactory.create(1_000_000 + i, null, "FIO", 50 + i, 100 + i);
+            allFutures.add(profileSpace.insert(tarantoolTuple));
+        }
+        allFutures.forEach(CompletableFuture::join);
+
+        Conditions conditions = Conditions.greaterOrEquals("profile_id", 1_000_000);
+
+        TarantoolResult<TarantoolTuple> selectResult = profileSpace.select(conditions).get();
+        assertEquals(20, selectResult.size());
+
+        TarantoolTuple tuple;
+        for (int i = 0; i < 20; i++) {
+            tuple = selectResult.get(i);
+            assertEquals(5, tuple.size());
+            assertEquals(1_000_000 + i, tuple.getInteger(0));
+            assertNotNull(tuple.getInteger(1)); //bucket_id
+            assertEquals("FIO", tuple.getString(2));
+            assertEquals(50 + i, tuple.getInteger(3));
+            assertEquals(100 + i, tuple.getInteger(4));
+        }
+
+        conditions = conditions.startAfter(tupleFactory.create(1_000_000 + 9, null, "FIO", 59, 109));
+        selectResult = profileSpace.select(conditions).get();
+        assertEquals(10, selectResult.size());
+    }
+
+    @Test
+    public void clusterInsertDeleteTest() throws ExecutionException, InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+                client.space(TEST_SPACE_NAME);
+
+        List<Object> values = Arrays.asList(100, null, "fio", 10, 100);
+        TarantoolTuple tarantoolTuple = tupleFactory.create(values);
+
+        TarantoolResult<TarantoolTuple> insertTuples = profileSpace.insert(tarantoolTuple).get();
+        assertEquals(insertTuples.size(), 1);
+        TarantoolTuple tuple = insertTuples.get(0);
+        assertEquals(tuple.size(), 5);
+        assertEquals(tuple.getInteger(0), 100);
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals(tuple.getString(2), "fio");
+
+        values = Arrays.asList(2, null, "John Doe", 55, 99);
+        tarantoolTuple = tupleFactory.create(values);
+        insertTuples = profileSpace.insert(tarantoolTuple).get();
+        assertEquals(1, insertTuples.size());
+        tuple = insertTuples.get(0);
+        assertEquals(5, tuple.size());
+        assertEquals(2, tuple.getInteger(0));
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals("John Doe", tuple.getString(2));
+
+        Conditions conditions = Conditions.equals(0 , 2);
+        TarantoolResult<TarantoolTuple> deleteResult = profileSpace.delete(conditions).get();
+
+        assertEquals(1, deleteResult.size());
+        tuple = deleteResult.get(0);
+        assertEquals(5, tuple.size());
+        assertEquals(2, tuple.getInteger(0));
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals("John Doe", tuple.getString(2));
+    }
+
+    @Test
+    public void replaceTest() throws ExecutionException, InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+                client.space(TEST_SPACE_NAME);
+
+        List<Object> values = Arrays.asList(123, null, "Jane Doe", 18, 999);
+        TarantoolTuple tarantoolTuple = tupleFactory.create(values);
+
+        TarantoolResult<TarantoolTuple> insertTuples = profileSpace.insert(tarantoolTuple).get();
+        assertEquals(insertTuples.size(), 1);
+        TarantoolTuple tuple = insertTuples.get(0);
+        assertEquals(tuple.size(), 5);
+        assertEquals(tuple.getInteger(0), 123);
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals(tuple.getString(2), "Jane Doe");
+        assertEquals(tuple.getInteger(3), 18);
+        assertEquals(tuple.getInteger(4), 999);
+
+        List<Object> replaceValues = Arrays.asList(123, null, "John Doe", 21, 100);
+        tarantoolTuple = tupleFactory.create(replaceValues);
+        TarantoolResult<TarantoolTuple> replaceResult = profileSpace.replace(tarantoolTuple).get();
+        assertEquals(replaceResult.size(), 1);
+        tuple = replaceResult.get(0);
+        assertEquals(tuple.size(), 5);
+        assertEquals(tuple.getInteger(0), 123);
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals(tuple.getString(2), "John Doe");
+        assertEquals(tuple.getInteger(3), 21);
+        assertEquals(tuple.getInteger(4), 100);
+    }
+
+    @Test
+    public void clusterUpdateTest() throws ExecutionException, InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+                client.space(TEST_SPACE_NAME);
+
+        List<Object> values = Arrays.asList(223, null, "Jane Doe", 10, 10);
+        TarantoolTuple tarantoolTuple = tupleFactory.create(values);
+
+        TarantoolResult<TarantoolTuple> insertTuples = profileSpace.insert(tarantoolTuple).get();
+        assertEquals(insertTuples.size(), 1);
+        TarantoolTuple tuple = insertTuples.get(0);
+        assertEquals(tuple.size(), 5);
+        assertEquals(tuple.getInteger(0), 223);
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+
+        Conditions conditions = Conditions.indexEquals("profile_id", Collections.singletonList(223));
+
+        TarantoolResult<TarantoolTuple> updateResult;
+
+        updateResult = profileSpace.update(conditions, TupleOperations.add(3, 90).andAdd(4, 5)).get();
+        assertEquals(223, updateResult.get(0).getInteger(0));
+        assertEquals(100, updateResult.get(0).getInteger(3));
+        assertEquals(15, updateResult.get(0).getInteger(4));
+    }
+
+    @Test
+    public void clusterUpsertTest() throws ExecutionException, InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+                client.space(TEST_SPACE_NAME);
+
+        List<Object> values = Arrays.asList(301, null, "Jack Sparrow", 30, 0);
+        TarantoolTuple tarantoolTuple = tupleFactory.create(values);
+
+        Conditions conditions = Conditions.equals("profile_id", 301);
+
+        TarantoolResult<TarantoolTuple> upsertResult;
+
+        //first time tuple not exist
+        profileSpace.upsert(conditions,
+                tarantoolTuple, TupleOperations.add(3, 5).andBitwiseOr(4, 7)).get();
+
+        upsertResult = profileSpace.select(conditions).get();
+        assertEquals(1, upsertResult.size());
+        TarantoolTuple tuple = upsertResult.get(0);
+        assertEquals(5, tuple.size());
+        assertEquals(301, tuple.getInteger(0));
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals(30, upsertResult.get(0).getInteger(3));
+        assertEquals(0, upsertResult.get(0).getInteger(4));
+
+        //second time tuple exist
+        profileSpace.upsert(conditions,
+                tarantoolTuple, TupleOperations.add(3, 5).andBitwiseOr(4, 7)).get();
+
+        upsertResult = profileSpace.select(conditions).get();
+        tuple = upsertResult.get(0);
+        assertEquals(tuple.getInteger(0), 301);
+        assertNotNull(tuple.getInteger(1)); //bucket_id
+        assertEquals(35, upsertResult.get(0).getInteger(3));
+        assertEquals(7, upsertResult.get(0).getInteger(4));
+    }
+
+    @Test
+    public void functionAggregateResultViaCallTest() throws ExecutionException, InterruptedException {
+        List<Object> values = Arrays.asList(123000, null, "Jane Doe", 999);
+        TarantoolTuple tarantoolTuple = tupleFactory.create(values);
+        TarantoolResult<TarantoolTuple> tuple1 = client.space("test_space").insert(tarantoolTuple).get();
+
+        values = Arrays.asList(123000, null, true, 123.456);
+        tarantoolTuple = tupleFactory.create(values);
+        TarantoolResult<TarantoolTuple> tuple2 = client.space("test_space_to_join").insert(tarantoolTuple).get();
+
+        MessagePackValueMapper valueMapper = client.getConfig().getMessagePackMapper();
+        CallResultMapper<TestComposite, SingleValueCallResult<TestComposite>> mapper =
+                client.getResultMapperFactoryFactory().singleValueResultMapperFactory(TestComposite.class)
+                        .withSingleValueResultConverter(v -> {
+                            Map<String, Object> valueMap = valueMapper.fromValue(v);
+                            TestComposite composite = new TestComposite();
+                            composite.field1 = (String) valueMap.get("field1");
+                            composite.field2 = (Integer) valueMap.get("field2");
+                            composite.field3 = (Boolean) valueMap.get("field3");
+                            composite.field4 = (Float) valueMap.get("field4");
+                            return composite;
+                        }, TestCompositeCallResult.class);
+        TestComposite actual =
+                client.callForSingleResult("get_composite_data", Collections.singletonList(123000), mapper).get();
+
+        assertEquals("Jane Doe", actual.field1);
+        assertEquals(999, actual.field2);
+        assertEquals(true, actual.field3);
+        assertEquals(123.456F, actual.field4);
+    }
+}

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Sergey Volgin
+ * @author Alexey Andreev
  */
 public class ProxyTarantoolClientMixedInstancesIT extends SharedCartridgeContainerMixedInstances {
 

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -57,7 +57,7 @@ public class ProxyTarantoolClientMixedInstancesIT extends SharedCartridgeContain
     public static String PASSWORD;
 
     private static final String TEST_SPACE_NAME = "test__profile";
-    private static final int DEFAULT_TIMEOUT = 10 * 1000;
+    private static final int DEFAULT_TIMEOUT = 5 * 1000;
 
     @BeforeAll
     public static void setUp() throws Exception {

--- a/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainerMixedInstances.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainerMixedInstances.java
@@ -1,0 +1,28 @@
+package io.tarantool.driver.integration;
+
+import org.junit.ClassRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.TarantoolCartridgeContainer;
+import org.testcontainers.containers.TarantoolContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+abstract class SharedCartridgeContainerMixedInstances {
+
+    private static final Logger logger = LoggerFactory.getLogger(SharedCartridgeContainerMixedInstances.class);
+
+    @ClassRule
+    protected static final TarantoolCartridgeContainer container =
+            new TarantoolCartridgeContainer(
+            "cartridge/instances.yml",
+            "cartridge/topology_mixed.lua")
+            .withDirectoryBinding("cartridge")
+            .withLogConsumer(new Slf4jLogConsumer(logger));
+
+    protected static void startCluster() {
+        if (!container.isRunning()) {
+            container.start();
+        }
+    }
+}

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -4,8 +4,9 @@ local cartridge_rpc = require('cartridge.rpc')
 
 local function get_schema()
     for _, instance_uri in pairs(cartridge_rpc.get_candidates('app.roles.api_storage', { leader_only = true })) do
-        local conn = cartridge_pool.connect(instance_uri)
-        return conn:call('ddl.get_schema', {})
+        return cartridge_rpc.call('app.roles.api_storage', 'get_schema', nil, { uri = instance_uri })
+        -- local conn = cartridge_pool.connect(instance_uri)
+        -- return conn:call('ddl.get_schema', {})
     end
 end
 

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -5,8 +5,6 @@ local cartridge_rpc = require('cartridge.rpc')
 local function get_schema()
     for _, instance_uri in pairs(cartridge_rpc.get_candidates('app.roles.api_storage', { leader_only = true })) do
         return cartridge_rpc.call('app.roles.api_storage', 'get_schema', nil, { uri = instance_uri })
-        -- local conn = cartridge_pool.connect(instance_uri)
-        -- return conn:call('ddl.get_schema', {})
     end
 end
 

--- a/src/test/resources/cartridge/app/roles/api_storage.lua
+++ b/src/test/resources/cartridge/app/roles/api_storage.lua
@@ -107,7 +107,6 @@ local function init(opts)
         init_space()
     end
 
-    rawset(_G, 'ddl', { get_schema = require('ddl').get_schema })
     rawset(_G, 'get_composite_data', get_composite_data)
 
     return true
@@ -117,6 +116,7 @@ return {
     role_name = 'app.roles.api_storage',
     init = init,
     get_composite_data = get_composite_data,
+    get_schema = require('ddl').get_schema,
     dependencies = {
         'cartridge.roles.crud-storage'
     }

--- a/src/test/resources/cartridge/topology_mixed.lua
+++ b/src/test/resources/cartridge/topology_mixed.lua
@@ -1,19 +1,14 @@
 cartridge = require('cartridge')
 replicasets = {{
     alias = 'app-router',
-    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
-    join_servers = {{uri = 'localhost:3301'}}
-}, {
-    alias = 'app-router-second',
-    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
-    join_servers = {{uri = 'localhost:3311'}}
-}, {
-    alias = 's1-storage',
-    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
-    join_servers = {{uri = 'localhost:3302'}, {uri = 'localhost:3303'}}
-}, {
-    alias = 's2-storage',
-    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
-    join_servers = {{uri = 'localhost:3304'}, {uri = 'localhost:3305'}}
+    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage', 'app.roles.custom'},
+    join_servers = {
+        {uri = 'localhost:3301'},
+        {uri = 'localhost:3302'},
+        {uri = 'localhost:3303'},
+        {uri = 'localhost:3304'},
+        {uri = 'localhost:3305'},
+        {uri = 'localhost:3311'},
+    }
 }}
 return cartridge.admin_edit_topology({replicasets = replicasets})

--- a/src/test/resources/cartridge/topology_mixed.lua
+++ b/src/test/resources/cartridge/topology_mixed.lua
@@ -1,0 +1,19 @@
+cartridge = require('cartridge')
+replicasets = {{
+    alias = 'app-router',
+    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
+    join_servers = {{uri = 'localhost:3301'}}
+}, {
+    alias = 'app-router-second',
+    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
+    join_servers = {{uri = 'localhost:3311'}}
+}, {
+    alias = 's1-storage',
+    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
+    join_servers = {{uri = 'localhost:3302'}, {uri = 'localhost:3303'}}
+}, {
+    alias = 's2-storage',
+    roles = {'vshard-router', 'app.roles.api_router', 'vshard-storage', 'app.roles.api_storage'},
+    join_servers = {{uri = 'localhost:3304'}, {uri = 'localhost:3305'}}
+}}
+return cartridge.admin_edit_topology({replicasets = replicasets})


### PR DESCRIPTION
Changes:
- changed ddl.get_schema function declarations in test resources
- made a set of integration tests that use tarantool with mixed topology (router with storage on same node)
- reflected changes in README.md

Fixes #72
Fixes #67