### PR TITLE
Fix #82 - Last tarantool error with exception by retry

### DIFF
--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolAttemptsLimitException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolAttemptsLimitException.java
@@ -1,0 +1,28 @@
+package io.tarantool.driver.exceptions;
+
+import io.tarantool.driver.retry.TarantoolRequestRetryPolicies;
+
+/**
+ * The exception that was thrown from {@link TarantoolRequestRetryPolicies}
+ *
+ * @author Artyom Dubinin
+ */
+public class TarantoolAttemptsLimitException extends TarantoolException {
+    private static final String message = "Attempts limit reached: %s";
+
+    public TarantoolAttemptsLimitException(Throwable cause) {
+        super(cause);
+    }
+
+    public TarantoolAttemptsLimitException(Integer limit) {
+        super(String.format(message, limit));
+    }
+
+    public TarantoolAttemptsLimitException(Integer limit, Throwable cause) {
+        super(String.format(message, limit), cause);
+    }
+
+    public TarantoolAttemptsLimitException(String format, Object... args) {
+        super(String.format(format, args));
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolTimeoutException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolTimeoutException.java
@@ -1,0 +1,28 @@
+package io.tarantool.driver.exceptions;
+
+import io.tarantool.driver.retry.TarantoolRequestRetryPolicies;
+
+/**
+ * The exception that was thrown from {@link TarantoolRequestRetryPolicies}
+ *
+ * @author Artyom Dubinin
+ */
+public class TarantoolTimeoutException extends TarantoolException {
+    private static final String message = "Operation timeout value exceeded after %s ms";
+
+    public TarantoolTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public TarantoolTimeoutException(Long time) {
+        super(String.format(message, time));
+    }
+
+    public TarantoolTimeoutException(Long time, Throwable cause) {
+        super(String.format(message, time), cause);
+    }
+
+    public TarantoolTimeoutException(String format, Object... args) {
+        super(String.format(format, args));
+    }
+}

--- a/src/main/java/io/tarantool/driver/retry/RequestRetryPolicy.java
+++ b/src/main/java/io/tarantool/driver/retry/RequestRetryPolicy.java
@@ -1,6 +1,7 @@
 package io.tarantool.driver.retry;
 
 import io.tarantool.driver.ConnectionSelectionStrategy;
+import io.tarantool.driver.exceptions.TarantoolTimeoutException;
 import io.tarantool.driver.utils.Assert;
 
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/io/tarantool/driver/retry/RequestRetryPolicyTest.java
+++ b/src/test/java/io/tarantool/driver/retry/RequestRetryPolicyTest.java
@@ -1,5 +1,6 @@
 package io.tarantool.driver.retry;
 
+import io.tarantool.driver.exceptions.TarantoolAttemptsLimitException;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import org.junit.jupiter.api.Test;
 
@@ -104,8 +105,10 @@ class RequestRetryPolicyTest {
             wrappedFuture.get();
         } catch (ExecutionException e) {
             thrown = e;
-            assertEquals(RuntimeException.class, e.getCause().getClass());
-            assertEquals("Should fail 1 times", e.getCause().getMessage());
+            assertEquals(TarantoolAttemptsLimitException.class, e.getCause().getClass());
+            assertEquals("Attempts limit reached: 3", e.getCause().getMessage());
+            assertEquals(RuntimeException.class, e.getCause().getCause().getClass());
+            assertEquals("Should fail 1 times", e.getCause().getCause().getMessage());
         }
         assertNotNull(thrown, "No exception has been thrown");
     }
@@ -121,8 +124,10 @@ class RequestRetryPolicyTest {
             wrappedFuture.get();
         } catch (ExecutionException e) {
             thrown = e;
-            assertEquals(RuntimeException.class, e.getCause().getClass());
-            assertEquals("Should fail 1 times", e.getCause().getMessage());
+            assertEquals(TarantoolAttemptsLimitException.class, e.getCause().getClass());
+            assertEquals("Attempts limit reached: 0", e.getCause().getMessage());
+            assertEquals(RuntimeException.class, e.getCause().getCause().getClass());
+            assertEquals("Should fail 1 times", e.getCause().getCause().getMessage());
         }
         assertNotNull(thrown, "No exception has been thrown");
     }
@@ -134,8 +139,10 @@ class RequestRetryPolicyTest {
         try {
             wrappedFuture.get();
         } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof RuntimeException);
-            assertEquals("Fail", e.getCause().getMessage());
+            assertTrue(e.getCause() instanceof TarantoolAttemptsLimitException);
+            assertEquals("Attempts limit reached: 4", e.getCause().getMessage());
+            assertTrue(e.getCause().getCause() instanceof RuntimeException);
+            assertEquals("Fail", e.getCause().getCause().getMessage());
         }
     }
 


### PR DESCRIPTION
An error received from tarantool is wrapped either in `TarantoolTimeoutException` if timeout limit has been reached for retrying, or in `TarantoolAttemptsLimitException` if the retry limit has been reached.
Also tests on retrays were rewritten and supplemented.

Closes: #82