### PR TITLE
Make conditions and tuples serializable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.7.0-M1</version>
+            <version>5.7.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -222,19 +222,19 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.1</version>
+            <version>1.15.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.15.1</version>
+            <version>1.15.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.tarantool</groupId>
             <artifactId>testcontainers-java-tarantool</artifactId>
-            <version>0.4.2</version>
+            <version>0.4.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/tarantool/driver/api/conditions/Condition.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/Condition.java
@@ -3,6 +3,7 @@ package io.tarantool.driver.api.conditions;
 import io.tarantool.driver.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -10,7 +11,7 @@ import java.util.List;
  *
  * @author Alexey Kuzin
  */
-public interface Condition {
+public interface Condition extends Serializable {
     /**
      * Filtering operator (&lt;. &lt;=, =, =&gt;, &gt;)
      *

--- a/src/main/java/io/tarantool/driver/api/conditions/Conditions.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/Conditions.java
@@ -16,6 +16,7 @@ import io.tarantool.driver.utils.Assert;
 import org.msgpack.value.ArrayValue;
 import org.msgpack.value.Value;
 
+import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -36,8 +38,9 @@ import java.util.stream.Collectors;
  *
  * @author Alexey Kuzin
  */
-public final class Conditions {
+public final class Conditions implements Serializable {
 
+    private static final long serialVersionUID = 20200708L;
     private static final long MAX_LIMIT = 0xff_ff_ff_ffL;
     private static final long MAX_OFFSET = 0xff_ff_ff_ffL;
 
@@ -59,6 +62,7 @@ public final class Conditions {
         this.startTuple = conditions.startTuple;
         this.conditions.addAll(conditions.conditions);
     }
+
     private Conditions(Condition condition) {
         conditions.add(condition);
     }
@@ -115,6 +119,7 @@ public final class Conditions {
      * @return this {@link Conditions} instance
      */
     public Conditions withAscending() {
+        this.descending = false;
         return this;
     }
 
@@ -208,9 +213,9 @@ public final class Conditions {
     /**
      * Start collecting tuples into result after the specified tuple. The tuple itself will not be added to the result.
      *
-     * @param tuple last tuple value from the previous result, may be null
+     * @param tuple          last tuple value from the previous result, may be null
      * @param tupleConverter converter of the specified tuple type into a MessagePack array
-     * @param <T> tuple type
+     * @param <T>            tuple type
      * @return new {@link Conditions} instance
      */
     public static <T> Conditions after(T tuple, ObjectConverter<T, ArrayValue> tupleConverter) {
@@ -229,12 +234,13 @@ public final class Conditions {
         this.startTuple = tuple;
         return this;
     }
+
     /**
      * Start collecting tuples into result after the specified tuple. The tuple itself will not be added to the result.
      *
-     * @param tuple last tuple value from the previous result, may be null
+     * @param tuple          last tuple value from the previous result, may be null
      * @param tupleConverter converter of the specified tuple type into a MessagePack array
-     * @param <T> tuple type
+     * @param <T>            tuple type
      * @return new {@link Conditions} instance
      */
     public <T> Conditions startAfter(T tuple, ObjectConverter<T, ArrayValue> tupleConverter) {
@@ -256,7 +262,7 @@ public final class Conditions {
     /**
      * Create new Conditions instance with filter by the specified index
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -267,7 +273,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -279,7 +285,7 @@ public final class Conditions {
     /**
      * Create new Conditions instance with filter by the specified index
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -290,7 +296,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return this {@link Conditions} instance
      */
@@ -302,7 +308,7 @@ public final class Conditions {
     /**
      * Create new Conditions instance with filter by the specified index, with values greater than the specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -313,7 +319,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values greater than the specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -325,7 +331,7 @@ public final class Conditions {
     /**
      * Create new Conditions instance with filter by the specified index, with values greater than the specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -336,7 +342,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values greater than the specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return this {@link Conditions} instance
      */
@@ -349,7 +355,7 @@ public final class Conditions {
      * Create new Conditions instance with filter by the specified index, with values greater or equal than the
      * specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -360,7 +366,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values greater or equal than the specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -373,7 +379,7 @@ public final class Conditions {
      * Create new Conditions instance with filter by the specified index, with values greater or equal than the
      * specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -384,7 +390,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values greater or equal than the specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return this {@link Conditions} instance
      */
@@ -396,7 +402,7 @@ public final class Conditions {
     /**
      * Create new Conditions instance with filter by the specified index, with values less than the specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -407,7 +413,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values less than the specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -419,7 +425,7 @@ public final class Conditions {
     /**
      * Create new Conditions instance with filter by the specified index, with values less than the specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -430,7 +436,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values less than the specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return this {@link Conditions} instance
      */
@@ -443,7 +449,7 @@ public final class Conditions {
      * Create new Conditions instance with filter by the specified index, with values less or equal than the
      * specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -454,7 +460,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values less or equal than the specified value
      *
-     * @param indexName index name
+     * @param indexName       index name
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -467,7 +473,7 @@ public final class Conditions {
      * Create new Conditions instance with filter by the specified index, with values less or equal than the
      * specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return new {@link Conditions} instance
      */
@@ -478,7 +484,7 @@ public final class Conditions {
     /**
      * Filter tuples by the specified index, with values less or equal than the specified value
      *
-     * @param indexId index id
+     * @param indexId         index id
      * @param indexPartValues index parts values
      * @return this {@link Conditions} instance
      */
@@ -491,7 +497,7 @@ public final class Conditions {
      * Filter tuples by the specified field
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return new {@link Conditions} instance
      */
     public static Conditions equals(String fieldName, Object value) {
@@ -502,7 +508,7 @@ public final class Conditions {
      * Filter tuples by the specified field
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return this {@link Conditions} instance
      */
     public Conditions andEquals(String fieldName, Object value) {
@@ -514,7 +520,7 @@ public final class Conditions {
      * Filter tuples by the specified field
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return new {@link Conditions} instance
      */
     public static Conditions equals(int fieldPosition, Object value) {
@@ -525,7 +531,7 @@ public final class Conditions {
      * Filter tuples by the specified field
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return this {@link Conditions} instance
      */
     public Conditions andEquals(int fieldPosition, Object value) {
@@ -537,7 +543,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return new {@link Conditions} instance
      */
     public static Conditions greaterThan(String fieldName, Object value) {
@@ -548,7 +554,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return this {@link Conditions} instance
      */
     public Conditions andGreaterThan(String fieldName, Object value) {
@@ -560,7 +566,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return new {@link Conditions} instance
      */
     public static Conditions greaterThan(int fieldPosition, Object value) {
@@ -571,7 +577,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return this {@link Conditions} instance
      */
     public Conditions andGreaterThan(int fieldPosition, Object value) {
@@ -583,7 +589,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater or equal than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return new {@link Conditions} instance
      */
     public static Conditions greaterOrEquals(String fieldName, Object value) {
@@ -594,7 +600,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater or equal than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return this {@link Conditions} instance
      */
     public Conditions andGreaterOrEquals(String fieldName, Object value) {
@@ -606,7 +612,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater or equal than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return new {@link Conditions} instance
      */
     public static Conditions greaterOrEquals(int fieldPosition, Object value) {
@@ -617,7 +623,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values greater or equal than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return this {@link Conditions} instance
      */
     public Conditions andGreaterOrEquals(int fieldPosition, Object value) {
@@ -629,7 +635,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return new {@link Conditions} instance
      */
     public static Conditions lessThan(String fieldName, Object value) {
@@ -640,7 +646,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return this {@link Conditions} instance
      */
     public Conditions andLessThan(String fieldName, Object value) {
@@ -652,7 +658,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return new {@link Conditions} instance
      */
     public static Conditions lessThan(int fieldPosition, Object value) {
@@ -663,7 +669,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return this {@link Conditions} instance
      */
     public Conditions andLessThan(int fieldPosition, Object value) {
@@ -675,7 +681,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less or equal than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return new {@link Conditions} instance
      */
     public static Conditions lessOrEquals(String fieldName, Object value) {
@@ -686,7 +692,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less or equal than the specified value
      *
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @return this {@link Conditions} instance
      */
     public Conditions andLessOrEquals(String fieldName, Object value) {
@@ -698,7 +704,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less or equal than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return new {@link Conditions} instance
      */
     public static Conditions lessOrEquals(int fieldPosition, Object value) {
@@ -709,7 +715,7 @@ public final class Conditions {
      * Filter tuples by the specified field, with values less or equal than the specified value
      *
      * @param fieldPosition field position
-     * @param value field value
+     * @param value         field value
      * @return this {@link Conditions} instance
      */
     public Conditions andLessOrEquals(int fieldPosition, Object value) {
@@ -790,8 +796,8 @@ public final class Conditions {
     }
 
     private List<List<?>> conditionsListToLists(List<? extends Condition> conditionsList,
-                                                     TarantoolMetadataOperations operations,
-                                                     TarantoolSpaceMetadata spaceMetadata) {
+                                                TarantoolMetadataOperations operations,
+                                                TarantoolSpaceMetadata spaceMetadata) {
         return conditionsList.stream().map(c -> c.toList(operations, spaceMetadata)).collect(Collectors.toList());
     }
 
@@ -902,16 +908,17 @@ public final class Conditions {
                 .withKeyValues(fieldValues);
     }
 
-    private static Optional<TarantoolIndexMetadata> findCoveringIndex(TarantoolMetadataOperations operations,
-                                                                  TarantoolSpaceMetadata spaceMetadata,
-                                                                  Collection<TarantoolFieldMetadata> selectedFields) {
+    private static Optional<TarantoolIndexMetadata> findCoveringIndex(
+            TarantoolMetadataOperations operations,
+            TarantoolSpaceMetadata spaceMetadata,
+            Collection<TarantoolFieldMetadata> selectedFields) {
         Map<String, TarantoolIndexMetadata> allIndexes = operations.getSpaceIndexes(spaceMetadata.getSpaceName())
                 .orElseThrow(() -> new TarantoolClientException(
                         "Metadata for space %s not found", spaceMetadata.getSpaceName()));
 
         Optional<TarantoolIndexMetadata> coveringIndex = allIndexes.values().stream()
                 .map(metadata -> new AbstractMap.SimpleEntry<Long, TarantoolIndexMetadata>(
-                                calculateCoverage(metadata, selectedFields), metadata))
+                        calculateCoverage(metadata, selectedFields), metadata))
                 .filter(entry -> entry.getKey() > 0)
                 .max(Comparator.comparingLong(AbstractMap.SimpleEntry::getKey))
                 .map(AbstractMap.SimpleEntry::getValue);
@@ -920,7 +927,7 @@ public final class Conditions {
     }
 
     private static long calculateCoverage(TarantoolIndexMetadata metadata,
-                                         Collection<TarantoolFieldMetadata> selectedFields) {
+                                          Collection<TarantoolFieldMetadata> selectedFields) {
         AtomicBoolean firstFieldIsSet = new AtomicBoolean(false);
         long count = selectedFields.stream()
                 .map(f -> metadata.getIndexPartPositionByFieldPosition(f.getFieldPosition()))
@@ -981,5 +988,26 @@ public final class Conditions {
         public Value toMessagePackValue(MessagePackObjectMapper mapper) {
             return tupleConverter.toValue(tuple);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Conditions that = (Conditions) o;
+        return isDescending() == that.isDescending() &&
+                getLimit() == that.getLimit() &&
+                getOffset() == that.getOffset()
+                && conditions.equals(that.conditions) &&
+                Objects.equals(getStartTuple(), that.getStartTuple());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(conditions, isDescending(), getLimit(), getOffset(), getStartTuple());
     }
 }

--- a/src/main/java/io/tarantool/driver/api/conditions/FieldIdentifier.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/FieldIdentifier.java
@@ -3,13 +3,15 @@ package io.tarantool.driver.api.conditions;
 import io.tarantool.driver.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 
+import java.io.Serializable;
+
 /**
  * Represents filtering operand in conditions, it may be an index or a field
  *
  * @param <T> metadata type
  * @author Alexey Kuzin
  */
-public interface FieldIdentifier<T, O> {
+public interface FieldIdentifier<T, O> extends Serializable {
     /**
      * Returns metadata object corresponding to the field identifier type
      *

--- a/src/main/java/io/tarantool/driver/api/conditions/FieldValueCondition.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/FieldValueCondition.java
@@ -1,11 +1,15 @@
 package io.tarantool.driver.api.conditions;
 
+import java.util.Objects;
+
 /**
  * Tuple filtering condition which accepts a field value
  *
  * @author Alexey Kuzin
  */
 public class FieldValueCondition extends BaseCondition {
+
+    private static final long serialVersionUID = 20200708L;
 
     private final Object value;
 
@@ -24,5 +28,24 @@ public class FieldValueCondition extends BaseCondition {
     @Override
     public Object value() {
         return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldValueCondition that = (FieldValueCondition) o;
+        return Objects.equals(value, that.value) &&
+                operator() == that.operator() &&
+                Objects.equals(field(), that.field());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, operator(), field());
     }
 }

--- a/src/main/java/io/tarantool/driver/api/conditions/IdIndex.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/IdIndex.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.utils.Assert;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -14,6 +15,8 @@ import java.util.Optional;
  * @author Alexey Kuzin
  */
 public class IdIndex implements FieldIdentifier<TarantoolIndexMetadata, Integer> {
+
+    private static final long serialVersionUID = 20200708L;
 
     private int position;
 
@@ -43,5 +46,22 @@ public class IdIndex implements FieldIdentifier<TarantoolIndexMetadata, Integer>
     @Override
     public Integer toIdentifier() {
         return position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdIndex idIndex = (IdIndex) o;
+        return position == idIndex.position;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(position);
     }
 }

--- a/src/main/java/io/tarantool/driver/api/conditions/IndexValueCondition.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/IndexValueCondition.java
@@ -1,6 +1,7 @@
 package io.tarantool.driver.api.conditions;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Tuple filtering condition which accepts index key parts values
@@ -8,6 +9,8 @@ import java.util.List;
  * @author Alexey Kuzin
  */
 public class IndexValueCondition extends BaseCondition {
+
+    private static final long serialVersionUID = 20200708L;
 
     private final List<?> indexValues;
 
@@ -26,5 +29,24 @@ public class IndexValueCondition extends BaseCondition {
     @Override
     public List<?> value() {
         return indexValues;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IndexValueCondition that = (IndexValueCondition) o;
+        return indexValues.equals(that.indexValues) &&
+                operator() == that.operator() &&
+                field().equals(that.field());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexValues, operator(), field());
     }
 }

--- a/src/main/java/io/tarantool/driver/api/conditions/NamedField.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/NamedField.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.utils.Assert;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -14,6 +15,8 @@ import java.util.Optional;
  * @author Alexey Kuzin
  */
 public class NamedField implements FieldIdentifier<TarantoolFieldMetadata, String> {
+
+    private static final long serialVersionUID = 20200708L;
 
     private String name;
 
@@ -43,5 +46,22 @@ public class NamedField implements FieldIdentifier<TarantoolFieldMetadata, Strin
     @Override
     public String toIdentifier() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NamedField that = (NamedField) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/src/main/java/io/tarantool/driver/api/conditions/NamedIndex.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/NamedIndex.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.utils.Assert;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -14,6 +15,8 @@ import java.util.Optional;
  * @author Alexey Kuzin
  */
 public class NamedIndex implements FieldIdentifier<TarantoolIndexMetadata, String> {
+
+    private static final long serialVersionUID = 20200708L;
 
     private final String name;
 
@@ -43,5 +46,22 @@ public class NamedIndex implements FieldIdentifier<TarantoolIndexMetadata, Strin
     @Override
     public String toIdentifier() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NamedIndex that = (NamedIndex) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/src/main/java/io/tarantool/driver/api/conditions/PositionField.java
+++ b/src/main/java/io/tarantool/driver/api/conditions/PositionField.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.utils.Assert;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -14,6 +15,8 @@ import java.util.Optional;
  * @author Alexey Kuzin
  */
 public class PositionField implements FieldIdentifier<TarantoolFieldMetadata, Integer> {
+
+    private static final long serialVersionUID = 20200708L;
 
     private int position;
 
@@ -43,5 +46,22 @@ public class PositionField implements FieldIdentifier<TarantoolFieldMetadata, In
     @Override
     public Integer toIdentifier() {
         return position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PositionField that = (PositionField) o;
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(position);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/DefaultBigDecimalConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultBigDecimalConverter.java
@@ -2,7 +2,6 @@ package io.tarantool.driver.mappers;
 
 import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;
-import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
 import org.msgpack.value.ExtensionValue;
 import org.msgpack.value.ValueFactory;
@@ -19,6 +18,8 @@ import java.nio.ByteBuffer;
  */
 public class DefaultBigDecimalConverter implements
         ValueConverter<ExtensionValue, BigDecimal>, ObjectConverter<BigDecimal, ExtensionValue> {
+
+    private static final long serialVersionUID = 20200708L;
 
     private static final byte DECIMAL_TYPE = 0x01;
     private static final int DECIMAL_MAX_DIGITS = 38;
@@ -142,7 +143,7 @@ public class DefaultBigDecimalConverter implements
             return fromBytes(value.getData());
         } catch (IOException e) {
             throw new MessagePackValueMapperException(
-                    String.format("Failed to unpack BigDecimal from MessagePack entity %s", value.toString()), e);
+                    String.format("Failed to unpack BigDecimal from MessagePack entity %s", value), e);
         }
     }
 

--- a/src/main/java/io/tarantool/driver/mappers/DefaultBooleanConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultBooleanConverter.java
@@ -10,6 +10,9 @@ import org.msgpack.value.ValueFactory;
  */
 public class DefaultBooleanConverter implements
         ValueConverter<BooleanValue, Boolean>, ObjectConverter<Boolean, BooleanValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public BooleanValue toValue(Boolean object) {
         return ValueFactory.newBoolean(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultByteArrayConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultByteArrayConverter.java
@@ -10,6 +10,9 @@ import org.msgpack.value.ValueFactory;
  */
 public class DefaultByteArrayConverter implements
         ValueConverter<BinaryValue, byte[]>, ObjectConverter<byte[], BinaryValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public BinaryValue toValue(byte[] object) {
         return ValueFactory.newBinary(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultDoubleConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultDoubleConverter.java
@@ -9,6 +9,9 @@ import org.msgpack.value.ValueFactory;
  * @author Alexey Kuzin
  */
 public class DefaultDoubleConverter implements ValueConverter<FloatValue, Double>, ObjectConverter<Double, FloatValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public FloatValue toValue(Double object) {
         return ValueFactory.newFloat(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultFloatConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultFloatConverter.java
@@ -9,6 +9,9 @@ import org.msgpack.value.ValueFactory;
  * @author Alexey Kuzin
  */
 public class DefaultFloatConverter implements ValueConverter<FloatValue, Float>, ObjectConverter<Float, FloatValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public FloatValue toValue(Float object) {
         return ValueFactory.newFloat(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultIntegerConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultIntegerConverter.java
@@ -10,6 +10,9 @@ import org.msgpack.value.ValueFactory;
  */
 public class DefaultIntegerConverter implements
         ValueConverter<IntegerValue, Integer>, ObjectConverter<Integer, IntegerValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public IntegerValue toValue(Integer object) {
         return ValueFactory.newInteger(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultIntegerValueToDoubleConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultIntegerValueToDoubleConverter.java
@@ -10,6 +10,8 @@ import org.msgpack.value.IntegerValue;
  */
 public class DefaultIntegerValueToDoubleConverter implements ValueConverter<IntegerValue, Double> {
 
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public Double fromValue(IntegerValue value) {
         return value.toDouble();

--- a/src/main/java/io/tarantool/driver/mappers/DefaultIntegerValueToFloatConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultIntegerValueToFloatConverter.java
@@ -10,6 +10,8 @@ import org.msgpack.value.IntegerValue;
  */
 public class DefaultIntegerValueToFloatConverter implements ValueConverter<IntegerValue, Float> {
 
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public Float fromValue(IntegerValue value) {
         return value.toFloat();

--- a/src/main/java/io/tarantool/driver/mappers/DefaultListObjectConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultListObjectConverter.java
@@ -15,7 +15,9 @@ import java.util.stream.Stream;
  */
 public class DefaultListObjectConverter implements ObjectConverter<List<?>, ArrayValue> {
 
-    private MessagePackObjectMapper mapper;
+    private static final long serialVersionUID = 20200708L;
+
+    private final MessagePackObjectMapper mapper;
 
     public DefaultListObjectConverter(MessagePackObjectMapper mapper) {
         this.mapper = mapper;

--- a/src/main/java/io/tarantool/driver/mappers/DefaultListValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultListValueConverter.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
  */
 public class DefaultListValueConverter implements ValueConverter<ArrayValue, List<?>> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private MessagePackValueMapper mapper;
 
     public DefaultListValueConverter(MessagePackValueMapper mapper) {

--- a/src/main/java/io/tarantool/driver/mappers/DefaultLongConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultLongConverter.java
@@ -9,6 +9,9 @@ import org.msgpack.value.ValueFactory;
  * @author Alexey Kuzin
  */
 public class DefaultLongConverter implements ValueConverter<IntegerValue, Long>, ObjectConverter<Long, IntegerValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public IntegerValue toValue(Long object) {
         return ValueFactory.newInteger(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultMapObjectConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultMapObjectConverter.java
@@ -14,7 +14,9 @@ import java.util.stream.Collectors;
  */
 public class DefaultMapObjectConverter implements ObjectConverter<Map<?, ?>, MapValue> {
 
-    private MessagePackObjectMapper mapper;
+    private static final long serialVersionUID = 20200708L;
+
+    private final MessagePackObjectMapper mapper;
 
     public DefaultMapObjectConverter(MessagePackObjectMapper mapper) {
         this.mapper = mapper;

--- a/src/main/java/io/tarantool/driver/mappers/DefaultMapValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultMapValueConverter.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
  */
 public class DefaultMapValueConverter implements ValueConverter<MapValue, Map<?, ?>> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private MessagePackValueMapper mapper;
 
     public DefaultMapValueConverter(MessagePackValueMapper mapper) {

--- a/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
@@ -22,6 +22,8 @@ import static io.tarantool.driver.mappers.MapperReflectionUtils.getInterfacePara
  */
 public class DefaultMessagePackMapper implements MessagePackMapper {
 
+    private static final long serialVersionUID = 20200708L;
+
     private final Map<String, List<ValueConverter<? extends Value, ?>>> valueConverters;
     private final Map<String, List<ObjectConverter<?, ? extends Value>>> objectConverters;
     private final Map<String, ValueConverter<? extends Value, ?>> valueConvertersByTarget;

--- a/src/main/java/io/tarantool/driver/mappers/DefaultNilConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultNilConverter.java
@@ -10,6 +10,8 @@ import org.msgpack.value.ValueFactory;
  */
 public class DefaultNilConverter implements ValueConverter<NilValue, Object>, ObjectConverter<Object, NilValue> {
 
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public Object fromValue(NilValue value) {
         return null;

--- a/src/main/java/io/tarantool/driver/mappers/DefaultPackableObjectConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultPackableObjectConverter.java
@@ -9,7 +9,10 @@ import org.msgpack.value.Value;
  * @author Alexey Kuzin
  */
 public class DefaultPackableObjectConverter implements ObjectConverter<Packable, Value> {
-    private MessagePackObjectMapper mapper;
+
+    private static final long serialVersionUID = 20200708L;
+
+    private final MessagePackObjectMapper mapper;
 
     public DefaultPackableObjectConverter(MessagePackObjectMapper mapper) {
         this.mapper = mapper;

--- a/src/main/java/io/tarantool/driver/mappers/DefaultStringConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultStringConverter.java
@@ -10,6 +10,9 @@ import org.msgpack.value.ValueFactory;
  */
 public class DefaultStringConverter implements
         ValueConverter<StringValue, String>, ObjectConverter<String, StringValue> {
+
+    private static final long serialVersionUID = 20200708L;
+
     @Override
     public StringValue toValue(String object) {
         return ValueFactory.newString(object);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultTarantoolTupleValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultTarantoolTupleValueConverter.java
@@ -12,8 +12,10 @@ import org.msgpack.value.ArrayValue;
  */
 public class DefaultTarantoolTupleValueConverter implements ValueConverter<ArrayValue, TarantoolTuple> {
 
-    private MessagePackMapper mapper;
-    private TarantoolSpaceMetadata spaceMetadata;
+    private static final long serialVersionUID = 20200708L;
+
+    private final MessagePackMapper mapper;
+    private final TarantoolSpaceMetadata spaceMetadata;
 
     public DefaultTarantoolTupleValueConverter(MessagePackMapper mapper, TarantoolSpaceMetadata spaceMetadata) {
         this.mapper = mapper;

--- a/src/main/java/io/tarantool/driver/mappers/DefaultUUIDConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultUUIDConverter.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 public class DefaultUUIDConverter implements
         ValueConverter<ExtensionValue, UUID>, ObjectConverter<UUID, ExtensionValue> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private static final byte UUID_TYPE = 0x02;
 
     private byte[] toBytes(UUID value) {

--- a/src/main/java/io/tarantool/driver/mappers/MessagePackMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/MessagePackMapper.java
@@ -1,11 +1,14 @@
 package io.tarantool.driver.mappers;
 
+import java.io.Serializable;
+
 /**
  * Combines both ObjectMapper and ValueMapper interfaces
  *
  * @author Alexey Kuzin
  */
-public interface MessagePackMapper extends MessagePackObjectMapper, MessagePackValueMapper {
+public interface MessagePackMapper
+        extends MessagePackObjectMapper, MessagePackValueMapper, Serializable {
     /**
      * Makes a shallow copy of this mapper instance
      *

--- a/src/main/java/io/tarantool/driver/mappers/MultiValueCallResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/MultiValueCallResultConverter.java
@@ -14,6 +14,8 @@ import java.util.List;
 public class MultiValueCallResultConverter<T, R extends List<T>>
         implements ValueConverter<ArrayValue, MultiValueCallResult<T, R>> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private final ValueConverter<ArrayValue, R> valueConverter;
 
     /**

--- a/src/main/java/io/tarantool/driver/mappers/MultiValueListConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/MultiValueListConverter.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
  */
 public class MultiValueListConverter<T, R extends List<T>, V extends Value> implements ValueConverter<ArrayValue, R> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private final ValueConverter<V, T> valueConverter;
     private final Supplier<R> containerSupplier;
 

--- a/src/main/java/io/tarantool/driver/mappers/ObjectConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/ObjectConverter.java
@@ -2,12 +2,14 @@ package io.tarantool.driver.mappers;
 
 import org.msgpack.value.Value;
 
+import java.io.Serializable;
+
 /**
  * Basic interface for converters from Java objects to MessagePack entities for a particular class
  *
  * @author Alexey Kuzin
  */
-public interface ObjectConverter<T, S extends Value> {
+public interface ObjectConverter<T, S extends Value> extends Serializable {
     /**
      * Convert Java object to a MessagePack entity
      * @param object object

--- a/src/main/java/io/tarantool/driver/mappers/SingleValueCallResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/SingleValueCallResultConverter.java
@@ -12,6 +12,8 @@ import org.msgpack.value.Value;
  */
 public class SingleValueCallResultConverter<T> implements ValueConverter<ArrayValue, SingleValueCallResult<T>> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private final ValueConverter<Value, T> valueConverter;
 
     public SingleValueCallResultConverter(ValueConverter<Value, T> valueConverter) {

--- a/src/main/java/io/tarantool/driver/mappers/TarantoolResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/TarantoolResultConverter.java
@@ -10,6 +10,8 @@ import org.msgpack.value.Value;
  */
 public class TarantoolResultConverter<V extends Value, T> implements ValueConverter<V, TarantoolResult<T>> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private final ValueConverter<ArrayValue, T> tupleConverter;
 
     public TarantoolResultConverter(ValueConverter<ArrayValue, T> tupleConverter) {

--- a/src/main/java/io/tarantool/driver/mappers/ValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/ValueConverter.java
@@ -2,13 +2,15 @@ package io.tarantool.driver.mappers;
 
 import org.msgpack.value.Value;
 
+import java.io.Serializable;
+
 /**
  * Basic interface for converters from MessagePack entities to Java objects for a particular class
  * @param <V> the source MessagePack entity type
  * @param <O> the target object type
  * @author Alexey Kuzin
  */
-public interface ValueConverter<V extends Value, O> {
+public interface ValueConverter<V extends Value, O> extends Serializable {
     /**
      * Convert MessagePack entity to a Java object
      * @param value entity

--- a/src/main/java/io/tarantool/driver/metadata/DDLTarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/metadata/DDLTarantoolSpaceMetadataConverter.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
  */
 public class DDLTarantoolSpaceMetadataConverter implements ValueConverter<Value, TarantoolMetadataContainer> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private static final int ID_UNKNOWN = -1;
 
     private static final StringValue SPACES_KEY = ValueFactory.newString("spaces");

--- a/src/main/java/io/tarantool/driver/metadata/TarantoolFieldMetadata.java
+++ b/src/main/java/io/tarantool/driver/metadata/TarantoolFieldMetadata.java
@@ -1,12 +1,16 @@
 package io.tarantool.driver.metadata;
 
+import java.io.Serializable;
+
 /**
  * Tarantool space field format metadata
  *
  * @author Sergey Volgin
  * @author Artyom Dubinin
  */
-public class TarantoolFieldMetadata {
+public class TarantoolFieldMetadata implements Serializable {
+
+    private static final long serialVersionUID = 20200708L;
 
     private final String fieldName;
     private final String fieldType;

--- a/src/main/java/io/tarantool/driver/metadata/TarantoolIndexMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/metadata/TarantoolIndexMetadataConverter.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
  */
 public class TarantoolIndexMetadataConverter implements ValueConverter<ArrayValue, TarantoolIndexMetadata> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private static final ImmutableStringValue INDEX_FIELD_KEY = new ImmutableStringValueImpl("field");
     private static final ImmutableStringValue INDEX_TYPE_KEY = new ImmutableStringValueImpl("type");
 

--- a/src/main/java/io/tarantool/driver/metadata/TarantoolSpaceMetadata.java
+++ b/src/main/java/io/tarantool/driver/metadata/TarantoolSpaceMetadata.java
@@ -1,5 +1,6 @@
 package io.tarantool.driver.metadata;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +12,9 @@ import java.util.Optional;
  *
  * @author Alexey Kuzin
  */
-public class TarantoolSpaceMetadata {
+public class TarantoolSpaceMetadata implements Serializable {
+
+    private static final long serialVersionUID = 20200708L;
 
     private int spaceId;
     private int ownerId;

--- a/src/main/java/io/tarantool/driver/metadata/TarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/metadata/TarantoolSpaceMetadataConverter.java
@@ -20,6 +20,8 @@ import java.util.Optional;
  */
 public class TarantoolSpaceMetadataConverter implements ValueConverter<ArrayValue, TarantoolSpaceMetadata> {
 
+    private static final long serialVersionUID = 20200708L;
+
     private static final ImmutableStringValue FORMAT_FIELD_NAME = new ImmutableStringValueImpl("name");
     private static final ImmutableStringValue FORMAT_FIELD_TYPE = new ImmutableStringValueImpl("type");
     private static final ImmutableStringValue FORMAT_FIELD_IS_NULLABLE = new ImmutableStringValueImpl("is_nullable");

--- a/src/main/java/io/tarantool/driver/protocol/Packable.java
+++ b/src/main/java/io/tarantool/driver/protocol/Packable.java
@@ -3,12 +3,14 @@ package io.tarantool.driver.protocol;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import org.msgpack.value.Value;
 
+import java.io.Serializable;
+
 /**
  * Classes implementing this interface can be converted into MessagePack representation
  *
  * @author Alexey Kuzin
  */
-public interface Packable {
+public interface Packable extends Serializable {
     /**
      * Convert this instance into a corresponding MessagePack {@link Value}
      * @param mapper configured Java objects to entities mapper


### PR DESCRIPTION
It's necessary for Spark connector implementation (call parameters are passed to Spark nodes in serialized format).