### PR TITLE
Enable Tarantool CE versions matrix and Docker layers caching in CI

### DIFF
--- a/.github/workflows/ubuntu-master.yml
+++ b/.github/workflows/ubuntu-master.yml
@@ -10,26 +10,41 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  tests-ce:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        tarantool-version: [ "1.10", "2.8" ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+
+    - name: Cache docker images
+      uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
+      with:
+        key: ${{ runner.os }}-docker-layer-cache-${{ matrix.tarantool-version }}
+        restore-keys: |
+          ${{ runner.os }}-docker-layer-cache-
+
     - name: Build with Maven
       run: mvn -B verify --file pom.xml
+
     - name: Run integration tests
       env:
+        TARANTOOL_VERSION: ${{ matrix.tarantool-version }}
         TARANTOOL_SERVER_USER: root
         TARANTOOL_SERVER_GROUP: root
       run: mvn -B test -P integration --file pom.xml

--- a/src/test/java/io/tarantool/driver/integration/TarantoolErrorsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/TarantoolErrorsIT.java
@@ -46,8 +46,8 @@ public class TarantoolErrorsIT extends SharedCartridgeContainer {
     private RetryingTarantoolTupleClient setupRetryingClient(int retries) {
         ProxyTarantoolTupleClient client = setupClient();
         return new RetryingTarantoolTupleClient(client,
-                        TarantoolRequestRetryPolicies
-                            .byNumberOfAttempts(retries).build());
+                TarantoolRequestRetryPolicies
+                        .byNumberOfAttempts(retries).build());
     }
 
     @Test
@@ -58,14 +58,13 @@ public class TarantoolErrorsIT extends SharedCartridgeContainer {
             client.callForSingleResult("box_error_unpack_no_connection", HashMap.class).get();
             fail("Exception must be thrown after last retry attempt.");
         } catch (Throwable e) {
+            String message = e.getCause().getMessage();
+
             assertTrue(e.getCause() instanceof TarantoolInternalNetworkException);
-            assertTrue(e.getCause().getMessage().contains(
-                "code: 77\n" +
-                "message: Connection is not established\n" +
-                "base_type: ClientError\n" +
-                "type: ClientError\n" +
-                "trace:")
-            );
+            assertTrue(message.contains("code: 77"));
+            assertTrue(message.contains("message: Connection is not established"));
+            assertTrue(message.contains("type: ClientError"));
+            assertTrue(message.contains("trace:"));
         }
     }
 
@@ -80,14 +79,13 @@ public class TarantoolErrorsIT extends SharedCartridgeContainer {
                     String.class).get();
             fail("Exception must be thrown after last retry attempt.");
         } catch (Throwable e) {
+            String message = e.getCause().getMessage();
+
             assertTrue(e.getCause() instanceof TarantoolInternalNetworkException);
-            assertTrue(e.getCause().getMessage().contains(
-                "code: 78\n" +
-                "message: Timeout exceeded\n" +
-                "base_type: ClientError\n" +
-                "type: ClientError\n" +
-                "trace:")
-            );
+            assertTrue(message.contains("code: 78"));
+            assertTrue(message.contains("message: Timeout exceeded"));
+            assertTrue(message.contains("type: ClientError"));
+            assertTrue(message.contains("trace:"));
         }
     }
 
@@ -102,12 +100,11 @@ public class TarantoolErrorsIT extends SharedCartridgeContainer {
                     String.class).get();
             fail("Exception must be thrown after last retry attempt.");
         } catch (Throwable e) {
+            String message = e.getCause().getMessage();
+
             assertTrue(e.getCause() instanceof TarantoolInternalNetworkException);
-            assertTrue(e.getCause().getMessage().contains(
-                     "InnerErrorMessage:\n" +
-                     "code: 78\n" +
-                     "message: Timeout exceeded")
-            );
+            assertTrue(message.contains("code: 78"));
+            assertTrue(message.contains("message: Timeout exceeded"));
         }
     }
 
@@ -119,13 +116,13 @@ public class TarantoolErrorsIT extends SharedCartridgeContainer {
             client.callForSingleResult("crud_error_timeout", HashMap.class).get();
             fail("Exception must be thrown after last retry attempt.");
         } catch (Throwable e) {
+            String message = e.getCause().getMessage();
+
             assertTrue(e.getCause() instanceof TarantoolInternalNetworkException);
-            assertTrue(e.getCause().getMessage().contains(
-                    "Function returned an error: {\"code\":78," +
-                            "\"base_type\":\"ClientError\"," +
-                            "\"type\":\"ClientError\"," +
-                            "\"message\":\"Timeout exceeded\","
-            ));
+            assertTrue(message.contains("\"code\":78"));
+            assertTrue(message.contains("\"type\":\"ClientError\""));
+            assertTrue(message.contains("\"message\":\"Timeout exceeded\""));
+            assertTrue(message.contains("\"trace\":"));
         }
     }
 
@@ -137,33 +134,32 @@ public class TarantoolErrorsIT extends SharedCartridgeContainer {
             client.callForSingleResult("box_error_non_network_error", HashMap.class).get();
             fail("Exception must be thrown after last retry attempt.");
         } catch (Throwable e) {
+            String message = e.getCause().getMessage();
+
             assertTrue(e.getCause() instanceof TarantoolInternalException);
             assertFalse(e.getCause() instanceof TarantoolInternalNetworkException);
-            assertTrue(e.getCause().getMessage().contains(
-                "code: 40\n" +
-                "message: Failed to write to disk\n" +
-                "base_type: ClientError\n" +
-                "type: ClientError\n" +
-                "trace:")
-            );
+            assertTrue(message.contains("code: 40"));
+            assertTrue(message.contains("message: Failed to write to disk"));
+            assertTrue(message.contains("type: ClientError"));
+            assertTrue(message.contains("trace:"));
         }
     }
 
-        @Test
-        void testNonNetworkError_boxError() {
-            try {
-                ProxyTarantoolTupleClient client = setupClient();
+    @Test
+    void testNonNetworkError_boxError() {
+        try {
+            ProxyTarantoolTupleClient client = setupClient();
 
-                client.callForSingleResult("raising_error", HashMap.class).get();
-                fail("Exception must be thrown after last retry attempt.");
-            } catch (Throwable e) {
-                assertTrue(e.getCause() instanceof TarantoolInternalException);
-                assertFalse(e.getCause() instanceof TarantoolInternalNetworkException);
-                assertTrue(e.getCause().getMessage().contains(
-                        "InnerErrorMessage:\n" +
-                        "code: 32\n" +
-                        "message:")
-                );
-            }
+            client.callForSingleResult("raising_error", HashMap.class).get();
+            fail("Exception must be thrown after last retry attempt.");
+        } catch (Throwable e) {
+            String message = e.getCause().getMessage();
+
+            assertTrue(e.getCause() instanceof TarantoolInternalException);
+            assertFalse(e.getCause() instanceof TarantoolInternalNetworkException);
+            assertTrue(message.contains("InnerErrorMessage:"));
+            assertTrue(message.contains("code: 32"));
+            assertTrue(message.contains("message:"));
         }
+    }
 }

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -1,6 +1,7 @@
 local vshard = require('vshard')
 local cartridge_rpc = require('cartridge.rpc')
 local fiber = require('fiber')
+local crud = require('crud')
 local log = require('log')
 
 local function get_schema()
@@ -113,7 +114,10 @@ local function box_error_non_network_error()
 end
 
 local function crud_error_timeout()
-    return crud.get("test_space", ('x'):rep(2^27))
+    return nil, { class_name = 'SelectError',
+                  err = 'Failed to get next object: GetTupleError: Failed to get tuples from storages: UpdateTuplesError: Failed to select tuples from storages: Call: Failed for 07d14fec-f32b-4b90-aa72-e6755273ad56: Function returned an error: {\"code\":78,\"base_type\":\"ClientError\",\"type\":\"ClientError\",\"message\":\"Timeout exceeded\",\"trace\":[{\"file\":\"builtin\\/box\\/net_box.lua\",\"line\":419}]}',
+                  str = 'SelectError: Failed to get next object: GetTupleError: Failed to get tuples from storages: UpdateTuplesError: Failed to select tuples from storages: Call: Failed for 07d14fec-f32b-4b90-aa72-e6755273ad56: Function returned an error: {\"code\":78,\"base_type\":\"ClientError\",\"type\":\"ClientError\",\"message\":\"Timeout exceeded\",\"trace\":[{\"file\":\"builtin\\/box\\/net_box.lua\",\"line\":419}]}'
+    }
 end
 
 local function init(opts)


### PR DESCRIPTION
 - Enable tests in CI for Tarantool versions 1.10 and 2.8
 - Turn on docker layer caching for speeding up the tests and minimizing CI fails from the unavailable Tarantool installer, repositories, or source docker images