### PR TITLE
Implement truncate() method

### DIFF
--- a/src/main/java/io/tarantool/driver/api/TarantoolVoidResult.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolVoidResult.java
@@ -1,0 +1,11 @@
+package io.tarantool.driver.api;
+
+/**
+ * Shortcut for {@link SingleValueCallResult} with void result
+ *
+ * @author Oleg Kuznetsov
+ * @author Ivan Dneprov
+ */
+public interface TarantoolVoidResult extends CallResult<Void> {
+    TarantoolVoidResult INSTANCE = new TarantoolVoidResultImpl();
+}

--- a/src/main/java/io/tarantool/driver/api/TarantoolVoidResultImpl.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolVoidResultImpl.java
@@ -1,0 +1,15 @@
+package io.tarantool.driver.api;
+
+/**
+ * Implementation of Tarantool void result
+ *
+ * @author Oleg Kuznetsov
+ * @author Ivan Dneprov
+ */
+public class TarantoolVoidResultImpl implements TarantoolVoidResult {
+
+    @Override
+    public Void value() {
+        return null;
+    }
+}

--- a/src/main/java/io/tarantool/driver/api/space/RetryingTarantoolSpaceOperations.java
+++ b/src/main/java/io/tarantool/driver/api/space/RetryingTarantoolSpaceOperations.java
@@ -82,6 +82,11 @@ public class RetryingTarantoolSpaceOperations<T extends Packable, R extends Coll
     }
 
     @Override
+    public CompletableFuture<Void> truncate() throws TarantoolClientException {
+        return wrapVoidOperation(spaceOperations::truncate);
+    }
+
+    @Override
     public TarantoolSpaceMetadata getMetadata() {
         return spaceOperations.getMetadata();
     }
@@ -97,6 +102,11 @@ public class RetryingTarantoolSpaceOperations<T extends Packable, R extends Coll
     }
 
     private CompletableFuture<R> wrapOperation(Supplier<CompletableFuture<R>> operation) {
+        RequestRetryPolicy retryPolicy = retryPolicyFactory.create();
+        return retryPolicy.wrapOperation(operation, executor);
+    }
+
+    private CompletableFuture<Void> wrapVoidOperation(Supplier<CompletableFuture<Void>> operation) {
         RequestRetryPolicy retryPolicy = retryPolicyFactory.create();
         return retryPolicy.wrapOperation(operation, executor);
     }

--- a/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
+++ b/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
@@ -88,6 +88,14 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
     CompletableFuture<R> upsert(Conditions conditions, T tuple, TupleOperations operations);
 
     /**
+     * Truncate space if space would be found. Otherwise, throw space not found error.
+     *
+     * @return a future that will contain void.
+     * @throws TarantoolClientException in case if request failed
+     */
+    CompletableFuture<Void> truncate() throws TarantoolClientException;
+
+    /**
      * Get metadata associated with this space
      *
      * @return space metadata

--- a/src/main/java/io/tarantool/driver/proxy/InsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/proxy/InsertProxyOperation.java
@@ -14,6 +14,7 @@ import java.util.List;
  * Proxy operation for insert
  *
  * @param <T> result type
+ * @param <R> result collection type
  * @author Sergey Volgin
  */
 public final class InsertProxyOperation<T extends Packable, R extends Collection<T>> extends AbstractProxyOperation<R> {

--- a/src/main/java/io/tarantool/driver/proxy/ProxyOperationsMappingConfig.java
+++ b/src/main/java/io/tarantool/driver/proxy/ProxyOperationsMappingConfig.java
@@ -16,6 +16,7 @@ public final class ProxyOperationsMappingConfig {
     public static final String SELECT_FUNCTION = CRUD_PREFIX + "select";
     public static final String UPDATE_FUNCTION = CRUD_PREFIX + "update";
     public static final String UPSERT_FUNCTION = CRUD_PREFIX + "upsert";
+    public static final String TRUNCATE_FUNCTION = CRUD_PREFIX + "truncate";
 
     private final String schemaFunctionName;
     private final String deleteFunctionName;
@@ -24,6 +25,7 @@ public final class ProxyOperationsMappingConfig {
     private final String updateFunctionName;
     private final String upsertFunctionName;
     private final String selectFunctionName;
+    private final String truncateFunctionName;
 
     /**
      * Get API function name for getting the spaces and indexes schema. The default value is
@@ -92,10 +94,19 @@ public final class ProxyOperationsMappingConfig {
         return selectFunctionName;
     }
 
+    /**
+     * Get API function name for performing the select operation. The default value is <code>crud.truncate</code>.
+     *
+     * @return a callable API function name
+     */
+    public String getTruncateFunctionName() {
+        return truncateFunctionName;
+    }
+
     private ProxyOperationsMappingConfig(String schemaFunctionName, String deleteFunctionName,
                                          String insertFunctionName, String replaceFunctionName,
                                          String updateFunctionName, String upsertFunctionName,
-                                         String selectFunctionName) {
+                                         String selectFunctionName, String truncateFunctionName) {
         this.schemaFunctionName = schemaFunctionName;
         this.deleteFunctionName = deleteFunctionName;
         this.insertFunctionName = insertFunctionName;
@@ -103,6 +114,7 @@ public final class ProxyOperationsMappingConfig {
         this.updateFunctionName = updateFunctionName;
         this.upsertFunctionName = upsertFunctionName;
         this.selectFunctionName = selectFunctionName;
+        this.truncateFunctionName = truncateFunctionName;
     }
 
     /**
@@ -126,6 +138,7 @@ public final class ProxyOperationsMappingConfig {
         private String updateFunctionName = UPDATE_FUNCTION;
         private String upsertFunctionName = UPSERT_FUNCTION;
         private String selectFunctionName = SELECT_FUNCTION;
+        private String truncateFunctionName = TRUNCATE_FUNCTION;
 
         /**
          * Set API function name for getting the spaces and indexes schema.
@@ -208,13 +221,25 @@ public final class ProxyOperationsMappingConfig {
         }
 
         /**
+         * Get API function name for performing the truncate operation
+         *
+         * @param truncateFunctionName name for stored function performing select operation
+         * @return a callable API function name
+         */
+        public Builder withTruncateFunctionName(String truncateFunctionName) {
+            this.truncateFunctionName = truncateFunctionName;
+            return this;
+        }
+
+        /**
          * Build a new {@link ProxyOperationsMappingConfig} instance
          *
          * @return new config instance
          */
         public ProxyOperationsMappingConfig build() {
             return new ProxyOperationsMappingConfig(schemaFunctionName, deleteFunctionName, insertFunctionName,
-                    replaceFunctionName, updateFunctionName, upsertFunctionName, selectFunctionName);
+                    replaceFunctionName, updateFunctionName, upsertFunctionName, selectFunctionName,
+                    truncateFunctionName);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/proxy/ReplaceProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/proxy/ReplaceProxyOperation.java
@@ -14,6 +14,7 @@ import java.util.List;
  * Proxy operation for replace
  *
  * @param <T> result type
+ * @param <R> result collection type
  * @author Sergey Volgin
  */
 public final class ReplaceProxyOperation<T extends Packable, R extends Collection<T>>

--- a/src/main/java/io/tarantool/driver/proxy/TruncateProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/proxy/TruncateProxyOperation.java
@@ -1,0 +1,117 @@
+package io.tarantool.driver.proxy;
+
+import io.tarantool.driver.api.TarantoolCallOperations;
+import io.tarantool.driver.api.TarantoolVoidResult;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Proxy operation for truncate
+ *
+ * @author Ivan Dneprov
+ */
+public final class TruncateProxyOperation implements ProxyOperation<Void> {
+
+    private final TarantoolCallOperations client;
+    private final String functionName;
+    private final List<?> arguments;
+
+    private TruncateProxyOperation(TarantoolCallOperations client,
+                                   String functionName,
+                                   List<?> arguments) {
+        this.client = client;
+        this.arguments = arguments;
+        this.functionName = functionName;
+    }
+
+    public TarantoolCallOperations getClient() {
+        return client;
+    }
+
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    public List<?> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public CompletableFuture<Void> execute() {
+        return client.callForSingleResult(functionName, arguments, Boolean.class)
+                .thenApply(v -> TarantoolVoidResult.INSTANCE.value());
+    }
+
+    /**
+     * Create a builder instance.
+     *
+     * @return a builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private TarantoolCallOperations client;
+        private String spaceName;
+        private String functionName;
+        private int requestTimeout;
+
+        public Builder() {
+        }
+
+        /**
+         * Specify a client for sending and receiving requests from Tarantool server
+         * @param client Tarantool server client
+         * @return builder
+         */
+        public Builder withClient(TarantoolCallOperations client) {
+            this.client = client;
+            return this;
+        }
+
+        /**
+         * Specify name of Tarantool server space to work with
+         * @param spaceName name of Tarantool server space
+         * @return builder
+         */
+        public Builder withSpaceName(String spaceName) {
+            this.spaceName = spaceName;
+            return this;
+        }
+
+        /**
+         * Specify name of the Tarantool server function called through preparing request
+         * @param functionName name of Tarantool server function
+         * @return builder
+         */
+        public Builder withFunctionName(String functionName) {
+            this.functionName = functionName;
+            return this;
+        }
+
+        /**
+         * Specify response reading timeout.
+         * @param requestTimeout the timeout for reading the responses from Tarantool server, in milliseconds
+         * @return builder
+         */
+        public Builder withRequestTimeout(int requestTimeout) {
+            this.requestTimeout = requestTimeout;
+            return this;
+        }
+
+        /**
+         * Prepare request of truncate operation to Tarantool server
+         * @return TruncateProxyOperation instance
+         */
+        public TruncateProxyOperation build() {
+            CRUDOperationOptions options = CRUDOperationOptions.builder().withTimeout(requestTimeout).build();
+
+            List<?> arguments = Arrays.asList(spaceName, options.asMap());
+
+            return new TruncateProxyOperation(this.client, this.functionName, arguments);
+        }
+    }
+}

--- a/src/main/java/io/tarantool/driver/proxy/UpsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/proxy/UpsertProxyOperation.java
@@ -15,6 +15,7 @@ import java.util.List;
  * Proxy operation for upsert
  *
  * @param <T> result type
+ * @param <R> result collection type
  * @author Sergey Volgin
  */
 public final class UpsertProxyOperation<T extends Packable, R extends Collection<T>> extends AbstractProxyOperation<R> {

--- a/src/test/java/io/tarantool/driver/integration/ClusterTruncateIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTruncateIT.java
@@ -1,0 +1,116 @@
+package io.tarantool.driver.integration;
+
+
+import io.tarantool.driver.ClusterTarantoolTupleClient;
+import io.tarantool.driver.TarantoolClientConfig;
+import io.tarantool.driver.TarantoolServerAddress;
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.api.tuple.TarantoolTupleImpl;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.TarantoolContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static io.tarantool.driver.integration.Utils.checkSpaceIsEmpty;
+
+@Testcontainers
+public class ClusterTruncateIT {
+
+    private static final String TEST_SPACE_NAME = "test_space";
+    private static final Logger log = LoggerFactory.getLogger(ClusterTruncateIT.class);
+
+    @Container
+    private static TarantoolContainer tarantoolContainer = new TarantoolContainer()
+            .withScriptFileName("org/testcontainers/containers/server.lua");
+
+    private static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
+    private static DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
+
+    @BeforeAll
+    public static void setUp() {
+        assertTrue(tarantoolContainer.isRunning());
+        initClient();
+    }
+
+    public static void tearDown() throws Exception {
+        client.close();
+        assertThrows(TarantoolClientException.class, () -> client.metadata().getSpaceByName("_space"));
+    }
+
+    private static void initClient() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
+
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+                tarantoolContainer.getHost(), tarantoolContainer.getPort());
+
+        TarantoolClientConfig config = new TarantoolClientConfig.Builder()
+                .withCredentials(credentials)
+                .withConnectTimeout(1000 * 5)
+                .withReadTimeout(1000 * 5)
+                .withRequestTimeout(1000 * 5)
+                .build();
+
+        log.info("Attempting connect to Tarantool");
+        client = new ClusterTarantoolTupleClient(config, serverAddress);
+        log.info("Successfully connected to Tarantool, version = {}", client.getVersion());
+    }
+
+    @Test
+    public void test_truncate2TimesOneSpace_shouldNotThrowExceptionsAndSpaceShouldBeEmptyAfterEtchCall() {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(TEST_SPACE_NAME);
+
+        // call truncate then space is empty
+        testSpace.truncate().join();
+        checkSpaceIsEmpty(testSpace);
+
+        for (int j = 0; j < 2; j++) {
+            // prepare values to insert
+            List<Object> values = Arrays.asList(1, "a", "Nineteen Eighty-Four", "George Orwell", 1984);
+            TarantoolTuple tarantoolTuple = new TarantoolTupleImpl(values, mapperFactory.defaultComplexTypesMapper());
+
+            // then insert prepared values
+            testSpace.insert(tarantoolTuple).join();
+
+            // when values are inserted check that space isn't empty
+            TarantoolResult<TarantoolTuple>  selectResult = testSpace.select(Conditions.any()).join();
+            assertEquals(1, selectResult.size());
+
+            // after that truncate space
+            testSpace.truncate().join();
+            checkSpaceIsEmpty(testSpace);
+        }
+    }
+
+    @Test
+    public void test_truncateEmptySpace_shouldNotThrowExceptionsAndSpaceShouldBeEmpty() {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(TEST_SPACE_NAME);
+
+        // truncate space to make sure it is empty
+        testSpace.truncate().join();
+
+        // when truncate empty space and check that now exceptions was thrown and space is empty
+        assertDoesNotThrow(() -> testSpace.truncate().join());
+        checkSpaceIsEmpty(testSpace);
+    }
+}

--- a/src/test/java/io/tarantool/driver/integration/ProxyCursorIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyCursorIT.java
@@ -72,8 +72,8 @@ public class ProxyCursorIT extends SharedCartridgeContainer {
         }
     }
 
-    private static void truncateSpace(String spaceName) throws ExecutionException, InterruptedException {
-        client.call("truncate_space", spaceName).get();
+    private static void truncateSpace(String spaceName) {
+        client.space(spaceName).truncate().join();
     }
 
     public static void tearDown() throws Exception {

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
@@ -75,7 +75,9 @@ public class ProxyTarantoolClientIT extends SharedCartridgeContainer {
     }
 
     private static void truncateSpace(String spaceName) {
-        client.call("truncate_space", spaceName);
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(spaceName);
+        testSpace.truncate().join();
     }
 
     private static TarantoolClusterAddressProvider getClusterAddressProvider() {

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -69,7 +69,7 @@ public class ProxyTarantoolClientMixedInstancesIT extends SharedCartridgeContain
     }
 
     private static void truncateSpace(String spaceName) {
-        client.call("truncate_space", spaceName);
+        client.space(spaceName).truncate().join();
     }
 
     private static TarantoolClusterAddressProvider getClusterAddressProvider() {

--- a/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
@@ -1,0 +1,137 @@
+package io.tarantool.driver.integration;
+
+import io.tarantool.driver.ClusterTarantoolTupleClient;
+import io.tarantool.driver.DefaultTarantoolTupleFactory;
+import io.tarantool.driver.ProxyTarantoolTupleClient;
+import io.tarantool.driver.TarantoolClientConfig;
+import io.tarantool.driver.TarantoolClusterAddressProvider;
+import io.tarantool.driver.TarantoolServerAddress;
+import io.tarantool.driver.api.TarantoolTupleFactory;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.cluster.BinaryClusterDiscoveryEndpoint;
+import io.tarantool.driver.cluster.BinaryDiscoveryClusterAddressProvider;
+import io.tarantool.driver.cluster.TarantoolClusterDiscoveryConfig;
+import io.tarantool.driver.cluster.TestWrappedClusterAddressProvider;
+
+import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import java.util.Collections;
+
+import static io.tarantool.driver.integration.Utils.checkSpaceIsEmpty;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Ivan Dneprov
+ */
+public class ProxyTruncateIT extends SharedCartridgeContainer {
+
+    private static ProxyTarantoolTupleClient client;
+    private static final DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
+    private static final TarantoolTupleFactory tupleFactory =
+            new DefaultTarantoolTupleFactory(mapperFactory.defaultComplexTypesMapper());
+
+    public static String USER_NAME;
+    public static String PASSWORD;
+
+    private static final String TEST_SPACE_NAME = "test__profile";
+    private static final int DEFAULT_TIMEOUT = 5 * 1000;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        startCluster();
+        USER_NAME = container.getUsername();
+        PASSWORD = container.getPassword();
+        initClient();
+        truncateSpace(TEST_SPACE_NAME);
+    }
+
+    private static TarantoolClusterAddressProvider getClusterAddressProvider() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(USER_NAME, PASSWORD);
+        TarantoolClientConfig config = TarantoolClientConfig.builder()
+                .withCredentials(credentials)
+                .withReadTimeout(DEFAULT_TIMEOUT)
+                .withConnectTimeout(DEFAULT_TIMEOUT)
+                .build();
+
+        BinaryClusterDiscoveryEndpoint endpoint = new BinaryClusterDiscoveryEndpoint.Builder()
+                .withClientConfig(config)
+                .withEntryFunction("get_routers")
+                .withEndpointProvider(() -> Collections.singletonList(
+                        new TarantoolServerAddress(container.getRouterHost(), container.getRouterPort())))
+                .build();
+
+        TarantoolClusterDiscoveryConfig clusterDiscoveryConfig = new TarantoolClusterDiscoveryConfig.Builder()
+                .withEndpoint(endpoint)
+                .withDelay(1)
+                .build();
+
+        return new TestWrappedClusterAddressProvider(
+                new BinaryDiscoveryClusterAddressProvider(clusterDiscoveryConfig),
+                container);
+    }
+
+    public static void initClient() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(USER_NAME, PASSWORD);
+
+        TarantoolClientConfig config = new TarantoolClientConfig.Builder()
+                .withCredentials(credentials)
+                .withConnectTimeout(DEFAULT_TIMEOUT)
+                .withReadTimeout(DEFAULT_TIMEOUT)
+                .withRequestTimeout(DEFAULT_TIMEOUT)
+                .build();
+
+        ClusterTarantoolTupleClient clusterClient = new ClusterTarantoolTupleClient(
+                config, getClusterAddressProvider());
+        client = new ProxyTarantoolTupleClient(clusterClient);
+    }
+
+    @Test
+    public void test_truncate2TimesOneSpace_shouldNotThrowExceptionsAndSpaceShouldBeEmptyAfterItchCall() {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(TEST_SPACE_NAME);
+
+        // call truncate then space is empty
+        testSpace.truncate().join();
+        checkSpaceIsEmpty(testSpace);
+
+        for (int i = 0; i < 2; i++) {
+            // prepare values to insert
+            TarantoolTuple tarantoolTuple = tupleFactory.create(1_000_000, null, "FIO", 50, 100);
+
+            // then insert prepared values
+            testSpace.insert(tarantoolTuple).join();
+
+            // when values are inserted check that space isn't empty
+            TarantoolResult<TarantoolTuple> selectResult = testSpace.select(Conditions.any()).join();
+            assertEquals(1, selectResult.size());
+
+            // after that truncate space
+            testSpace.truncate().join();
+            checkSpaceIsEmpty(testSpace);
+        }
+    }
+
+    @Test
+    public void test_truncateEmptySpace_shouldNotThrowExceptionsAndSpaceShouldBeEmpty() {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(TEST_SPACE_NAME);
+
+        // truncate space to make sure it is empty
+        testSpace.truncate().join();
+
+        // when truncate empty space and check that now exceptions was thrown and space is empty
+        assertDoesNotThrow(() -> testSpace.truncate().join());
+        checkSpaceIsEmpty(testSpace);
+    }
+
+    private static void truncateSpace(String spaceName) {
+        client.space(spaceName).truncate().join();
+    }
+}

--- a/src/test/java/io/tarantool/driver/integration/Utils.java
+++ b/src/test/java/io/tarantool/driver/integration/Utils.java
@@ -1,0 +1,30 @@
+package io.tarantool.driver.integration;
+
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.exceptions.TarantoolClientException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author Ivan Dneprov
+ */
+public final class Utils {
+    private Utils() {
+    }
+
+    /**
+    * Checks if the space is empty.
+    *
+    * @param testSpace space to check
+    */
+    static void checkSpaceIsEmpty(TarantoolSpaceOperations<TarantoolTuple,
+            TarantoolResult<TarantoolTuple>> testSpace) {
+        assertEquals(0, testSpace.select(Conditions.any()).thenApply(List::size).join());
+    }
+}

--- a/src/test/java/io/tarantool/driver/proxy/ProxyOperationBuildersTest.java
+++ b/src/test/java/io/tarantool/driver/proxy/ProxyOperationBuildersTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProxyOperationBuildersTest {
 
@@ -210,5 +209,26 @@ public class ProxyOperationBuildersTest {
                 TupleOperations.add(3, 90).andAdd(4, 5).asProxyOperationList(), options),
                 operation.getArguments());
         assertEquals(defaultResultMapper, operation.getResultMapper());
+    }
+
+    @Test
+    public void test_truncateOperationBuilder_shouldReturnTruncateOperationObjectsWithAllProperties() {
+        // build truncateOperation
+        TruncateProxyOperation truncateOperation =
+                TruncateProxyOperation.builder()
+                        .withClient(client)
+                        .withSpaceName("space1")
+                        .withFunctionName("function1")
+                        .withRequestTimeout(client.getConfig().getRequestTimeout())
+                        .build();
+
+        // when prepare HashMap with options
+        Map<String, Object> options = new HashMap<>();
+        options.put(CRUDOperationOptions.TIMEOUT, client.getConfig().getRequestTimeout());
+
+        // then data is prepared check that is equals that we submitted to the builder
+        assertEquals(client, truncateOperation.getClient());
+        assertEquals("function1", truncateOperation.getFunctionName());
+        assertEquals(Arrays.asList("space1", options), truncateOperation.getArguments());
     }
 }


### PR DESCRIPTION
Closes #93
The method calls crud.truncate of box.space.<space_obj>:truncate() for cluster and standalone client implementations.

I think that I should also add tests with truncate on different spaces and for a non-existent space.
Also I should return boolean not in array in TarantoolResultLmpl.java:58.