### PR TITLE
Change the validation credentials of authorization

### DIFF
--- a/src/main/java/io/tarantool/driver/auth/ChapSha1TarantoolAuthenticator.java
+++ b/src/main/java/io/tarantool/driver/auth/ChapSha1TarantoolAuthenticator.java
@@ -36,7 +36,17 @@ public class ChapSha1TarantoolAuthenticator implements TarantoolAuthenticator<Si
      */
     @Override
     public boolean canAuthenticateWith(SimpleTarantoolCredentials credentials) {
-        return !credentials.isEmpty();
+        return credentials.isValid();
+    }
+
+    /**
+     * Check if the passed instance of {@link SimpleTarantoolCredentials} can be used for authentication
+     * @param credentials Tarantool user credentials
+     * @return true, if the guest is implicit
+     */
+    @Override
+    public boolean canSkipAuth(SimpleTarantoolCredentials credentials) {
+        return credentials.isGuest();
     }
 
     /**

--- a/src/main/java/io/tarantool/driver/auth/SimpleTarantoolCredentials.java
+++ b/src/main/java/io/tarantool/driver/auth/SimpleTarantoolCredentials.java
@@ -21,7 +21,7 @@ public class SimpleTarantoolCredentials implements TarantoolCredentials {
      * @param password non-null password
      */
     public SimpleTarantoolCredentials(String user, String password) {
-        Assert.hasText(user, "User must not be empty");
+        Assert.notNull(user, "User must not be null");
         Assert.notNull(password, "Password must not be null");
 
         this.user = user;
@@ -45,7 +45,11 @@ public class SimpleTarantoolCredentials implements TarantoolCredentials {
         return password;
     }
 
-    public boolean isEmpty() {
-        return user.isEmpty() || password.isEmpty();
+    public boolean isValid() {
+        return !user.isEmpty();
+    }
+
+    public boolean isGuest() {
+        return (user.isEmpty() || user.equals(DEFAULT_USER)) && password.isEmpty();
     }
 }

--- a/src/main/java/io/tarantool/driver/auth/TarantoolAuthenticator.java
+++ b/src/main/java/io/tarantool/driver/auth/TarantoolAuthenticator.java
@@ -23,6 +23,13 @@ public interface TarantoolAuthenticator<T extends TarantoolCredentials> {
     boolean canAuthenticateWith(T credentials);
 
     /**
+     * Сheck if we can connect to the Tarantool without authentication
+     * @param credentials Tarantool user credentials
+     * @return {@code true} if the credentials are suitable so as not to use them for authentication
+     */
+    boolean canSkipAuth(T credentials);
+
+    /**
      * Takes the server auth data returned in response for the connect request and user auth data, performs
      * the necessary transformations and writes the serialized authentication data to a byte array
      * @param serverAuthData bytes with auth data from the Tarantool server greeting

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolBadCredentialsException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolBadCredentialsException.java
@@ -1,0 +1,12 @@
+package io.tarantool.driver.exceptions;
+
+/**
+ * This exception is thrown If incorrect credentials are specified
+ *
+ * @author Artyom Dubinin
+ */
+public class TarantoolBadCredentialsException extends TarantoolClientException {
+    public TarantoolBadCredentialsException() {
+        super("Bad credentials");
+    }
+}

--- a/src/test/resources/org/testcontainers/containers/server.lua
+++ b/src/test/resources/org/testcontainers/containers/server.lua
@@ -9,6 +9,9 @@ box.schema.user.create('api_user', { password = 'secret' })
 -- API user will be able to create spaces, add or remove data, execute functions
 box.schema.user.grant('api_user', 'read,write,execute', 'universe')
 
+box.schema.user.create('empty_password_user', { password = '' })
+box.schema.user.grant('empty_password_user', 'read,write,execute', 'universe')
+
 -- create test space
 s = box.schema.space.create('test_space')
 s:format({


### PR DESCRIPTION
Now the connection to Tarantool under the guest user goes according
to the documentation rules: Username = "guest" or "", Password = "".
Previously, logging took place under guest, if you specify any name
without a password, for example:
Username = "notGuestName" or "", Password = ""

Closes #123