### PR TITLE
remove testcontainers core dependecy that comes transitively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,12 +221,6 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <version>1.15.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>1.15.3</version>
             <scope>test</scope>


### PR DESCRIPTION
It seems that next dependency org.testcontainers:junit-jupiter brings testcontainers transitively and there is no need for separate declaration (with separate version declaration)