### PR TITLE
Added methods in client builder

### DIFF
--- a/src/main/java/io/tarantool/driver/api/MessagePackMapperBuilder.java
+++ b/src/main/java/io/tarantool/driver/api/MessagePackMapperBuilder.java
@@ -1,0 +1,136 @@
+package io.tarantool.driver.api;
+
+import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.ObjectConverter;
+import io.tarantool.driver.mappers.ValueConverter;
+import org.msgpack.value.Value;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builder for {@link MessagePackMapper}
+ */
+public interface MessagePackMapperBuilder {
+    /**
+     * Configure the mapper with default {@code MP_MAP} entity to {@link Map} converter
+     *
+     * @return builder
+     */
+    MessagePackMapperBuilder withDefaultMapValueConverter();
+
+    /**
+     * Configure the mapper with default {@link Map} to {@code MP_MAP} entity converter
+     *
+     * @return builder
+     */
+    MessagePackMapperBuilder withDefaultMapObjectConverter();
+
+    /**
+     * Configure the mapper with default {@code MP_ARRAY} entity to {@link List} converter
+     *
+     * @return builder
+     */
+    MessagePackMapperBuilder withDefaultArrayValueConverter();
+
+    /**
+     * Configure the mapper with default {@link List} to {@code MP_ARRAY} entity converter
+     *
+     * @return builder
+     */
+    MessagePackMapperBuilder withDefaultListObjectConverter();
+
+    /**
+     * Configure the mapper with a specified MessagePack entity-to-object and object-to-entity converter
+     *
+     * @param valueClass  MessagePack entity class
+     * @param objectClass object class
+     * @param converter   MessagePack entity-to-object and object-to-entity converter
+     * @param <V>         MessagePack entity type
+     * @param <O>         object type
+     * @param <T>         converter type
+     * @return builder
+     */
+    <V extends Value, O, T extends ValueConverter<V, O> & ObjectConverter<O, V>> MessagePackMapperBuilder withConverter(
+            Class<V> valueClass, Class<O> objectClass, T converter);
+
+    /**
+     * Configure the mapper with a specified MessagePack entity-to-object converter
+     *
+     * @param converter MessagePack entity-to-object and object-to-entity converter
+     * @param <V>       MessagePack entity type
+     * @param <O>       object type
+     * @return builder
+     * @see io.tarantool.driver.mappers.DefaultMessagePackMapper#registerValueConverter(ValueConverter)
+     */
+    <V extends Value, O> MessagePackMapperBuilder withValueConverter(ValueConverter<V, O> converter);
+
+    /**
+     * Configure the mapper with a specified MessagePack entity-to-object converter
+     *
+     * @param valueClass source entity class
+     * @param converter  MessagePack entity-to-object and object-to-entity converter
+     * @param <V>        MessagePack entity type
+     * @param <O>        object type
+     * @return builder
+     * @see io.tarantool.driver.mappers.DefaultMessagePackMapper#registerValueConverter(Class, ValueConverter)
+     */
+    <V extends Value, O> MessagePackMapperBuilder
+    withValueConverter(Class<V> valueClass, ValueConverter<V, O> converter);
+
+    /**
+     * Configure the mapper with a specified MessagePack entity-to-object converter
+     *
+     * @param valueClass  source entity class
+     * @param objectClass target object class
+     * @param converter   MessagePack entity-to-object and object-to-entity converter
+     * @param <V>         MessagePack entity type
+     * @param <O>         object type
+     * @return builder
+     * @see io.tarantool.driver.mappers.DefaultMessagePackMapper#registerValueConverter(Class, Class, ValueConverter)
+     */
+    <V extends Value, O> MessagePackMapperBuilder withValueConverter(Class<V> valueClass, Class<O> objectClass,
+                                                                     ValueConverter<V, O> converter);
+
+    /**
+     * Configure the mapper with a specified MessagePack object-to-entity converter
+     *
+     * @param converter MessagePack entity-to-object and object-to-entity converter
+     * @param <V>       MessagePack entity type
+     * @param <O>       object type
+     * @return builder
+     */
+    <V extends Value, O> MessagePackMapperBuilder withObjectConverter(ObjectConverter<O, V> converter);
+
+    /**
+     * Configure the mapper with a specified MessagePack object-to-entity converter
+     *
+     * @param objectClass source object class
+     * @param converter   MessagePack entity-to-object and object-to-entity converter
+     * @param <V>         MessagePack entity type
+     * @param <O>         object type
+     * @return builder
+     */
+    <V extends Value, O> MessagePackMapperBuilder
+    withObjectConverter(Class<O> objectClass, ObjectConverter<O, V> converter);
+
+    /**
+     * Configure the mapper with a specified MessagePack object-to-entity converter
+     *
+     * @param objectClass source object class
+     * @param valueClass  target object class
+     * @param converter   MessagePack entity-to-object and object-to-entity converter
+     * @param <V>         MessagePack entity type
+     * @param <O>         object type
+     * @return builder
+     */
+    <V extends Value, O> MessagePackMapperBuilder withObjectConverter(Class<O> objectClass, Class<V> valueClass,
+                                                                      ObjectConverter<O, V> converter);
+
+    /**
+     * Build the mapper instance
+     *
+     * @return a new mapper instance
+     */
+    MessagePackMapper build();
+}

--- a/src/main/java/io/tarantool/driver/api/TarantoolClientBuilder.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolClientBuilder.java
@@ -4,10 +4,12 @@ import io.tarantool.driver.api.connection.ConnectionSelectionStrategyFactory;
 import io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategyType;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.mappers.DefaultMessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 /**
  * Tarantool client builder interface.
@@ -105,6 +107,21 @@ public interface TarantoolClientBuilder extends TarantoolClientConfigurator<Tara
     TarantoolClientBuilder withConnections(int connections);
 
     /**
+     * Specify a configuration for mapping between Java objects and MessagePack entities.
+     * <p>
+     * This method takes a lambda as an argument, where the mapperBuilder is {@link DefaultMessagePackMapper.Builder}.
+     * </p>
+     * see {@link io.tarantool.driver.mappers.DefaultMessagePackMapperFactory}.
+     *
+     * @param mapperBuilder builder provider instance, e.g. a lambda function taking the builder
+     *                      for {@link MessagePackMapper} instance
+     * @return this instance of builder {@link TarantoolClientBuilder}
+     * @see TarantoolClientConfig#setMessagePackMapper(MessagePackMapper)
+     */
+    TarantoolClientBuilder
+    withDefaultMessagePackMapperConfiguration(UnaryOperator<MessagePackMapperBuilder> mapperBuilder);
+
+    /**
      * Specify a mapper between Java objects and MessagePack entities.
      * The mapper contains converters for simple and complex tuple field types and for the entire tuples into custom
      * Java objects. This mapper is used by default if a custom mapper is not passed to a specific operation.
@@ -164,6 +181,17 @@ public interface TarantoolClientBuilder extends TarantoolClientConfigurator<Tara
      */
     TarantoolClientBuilder withConnectionSelectionStrategy(
             TarantoolConnectionSelectionStrategyType connectionSelectionStrategyType);
+
+    /**
+     * Specify a tarantool client config
+     * <p>
+     * It overrides previous settings for config
+     * </p>
+     *
+     * @param config tarantool client config
+     * @return this instance of builder {@link TarantoolClientBuilder}
+     */
+    TarantoolClientBuilder withTarantoolClientConfig(TarantoolClientConfig config);
 
     /**
      * Build the configured Tarantool client instance. Call this when you have specified all necessary settings.

--- a/src/main/java/io/tarantool/driver/core/TarantoolClientConfiguratorImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolClientConfiguratorImpl.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.api.proxy.ProxyOperationsMappingConfig;
 import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.utils.Assert;
 
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -31,7 +32,7 @@ public class TarantoolClientConfiguratorImpl<SELF extends TarantoolClientConfigu
     }
 
     protected TarantoolClientConfiguratorImpl() {
-        this.client = new ClusterTarantoolTupleClient();
+        this.client = null;
     }
 
     @Override
@@ -99,6 +100,7 @@ public class TarantoolClientConfiguratorImpl<SELF extends TarantoolClientConfigu
      */
     protected TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>>
     decorate(TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client) {
+        Assert.notNull(client, "Tarantool client must not be null!");
 
         if (this.mappingConfig != null) {
             client = new ProxyTarantoolTupleClient(client, this.mappingConfig);

--- a/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
@@ -1,5 +1,6 @@
 package io.tarantool.driver.mappers;
 
+import io.tarantool.driver.api.MessagePackMapperBuilder;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import org.msgpack.value.NilValue;
 import org.msgpack.value.Value;
@@ -42,6 +43,7 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
 
     /**
      * Copying constructor
+     *
      * @param mapper another mapper instance
      */
     public DefaultMessagePackMapper(DefaultMessagePackMapper mapper) {
@@ -128,9 +130,10 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
     /**
      * Perform {@link ValueConverter} converter registration. The source entity class and target object class for
      * registration are determined automatically
+     *
      * @param converter entity-to-object converter
-     * @param <V> MessagePack entity type
-     * @param <O> object type
+     * @param <V>       MessagePack entity type
+     * @param <O>       object type
      * @see ValueConverter
      */
     public <V extends Value, O> void registerValueConverter(ValueConverter<V, ? extends O> converter) {
@@ -147,10 +150,11 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
     /**
      * Perform {@link ValueConverter} converter registration. The target object class for registration is determined
      * automatically
+     *
      * @param valueClass source entity class
-     * @param converter entity-to-object converter
-     * @param <V> MessagePack entity type
-     * @param <O> object type
+     * @param converter  entity-to-object converter
+     * @param <V>        MessagePack entity type
+     * @param <O>        object type
      * @see ValueConverter
      */
     public <V extends Value, O> void registerValueConverter(Class<V> valueClass,
@@ -182,7 +186,7 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         try {
             ValueConverter<? extends Value, ?> exactMatch = valueConvertersByTarget.get(targetClass.getTypeName());
             return exactMatch == converter ||
-                getInterfaceParameterClass(converter, converter.getClass(), 1).isAssignableFrom(targetClass);
+                    getInterfaceParameterClass(converter, converter.getClass(), 1).isAssignableFrom(targetClass);
         } catch (InterfaceParameterClassNotFoundException | InterfaceParameterTypeNotFoundException e) {
             return false;
         }
@@ -217,9 +221,10 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
     /**
      * Perform {@link ObjectConverter} converter registration. The source object class and target entity class for
      * registration are determined automatically
+     *
      * @param converter object-to-entity converter
-     * @param <V> MessagePack entity type
-     * @param <O> object type
+     * @param <V>       MessagePack entity type
+     * @param <O>       object type
      * @see ObjectConverter
      */
     public <V extends Value, O> void registerObjectConverter(ObjectConverter<O, V> converter) {
@@ -236,10 +241,11 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
     /**
      * Adds a Java object converter to this mappers instance. The target value class for registration is determined
      * automatically
+     *
      * @param objectClass object class to register the converter for
-     * @param converter entity-to-object converter
-     * @param <V> the target MessagePack entity type
-     * @param <O> the source object type
+     * @param converter   entity-to-object converter
+     * @param <V>         the target MessagePack entity type
+     * @param <O>         the source object type
      * @see ObjectConverter
      */
     public <V extends Value, O> void registerObjectConverter(Class<O> objectClass, ObjectConverter<O, V> converter) {
@@ -277,12 +283,13 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
 
     /**
      * Convenience method for registering classes implementing both types of converters.
-     * @param converter object-to-entity and entity-to-object converter
-     * @param valueClass entity class
+     *
+     * @param converter   object-to-entity and entity-to-object converter
+     * @param valueClass  entity class
      * @param objectClass object class
-     * @param <V> MessagePack entity type
-     * @param <O> object type
-     * @param <T> converter type
+     * @param <V>         MessagePack entity type
+     * @param <O>         object type
+     * @param <T>         converter type
      */
     public <V extends Value, O, T extends ValueConverter<V, O> & ObjectConverter<O, V>> void registerConverter(
             Class<V> valueClass, Class<O> objectClass, T converter) {
@@ -298,7 +305,7 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
     /**
      * Builder for {@link DefaultMessagePackMapper}
      */
-    public static class Builder {
+    public static class Builder implements MessagePackMapperBuilder {
         private final DefaultMessagePackMapper mapper;
 
         /**
@@ -310,151 +317,83 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
 
         /**
          * Basic constructor, initialized with the specified mapper
+         *
          * @param mapper a mapper instance
          */
         public Builder(DefaultMessagePackMapper mapper) {
             this.mapper = new DefaultMessagePackMapper(mapper);
         }
 
-        /**
-         * Configure the mapper with default {@code MP_MAP} entity to {@link Map} converter
-         * @return builder
-         */
+        @Override
         public Builder withDefaultMapValueConverter() {
             mapper.registerValueConverter(new DefaultMapValueConverter(mapper));
             return this;
         }
 
-        /**
-         * Configure the mapper with default {@link Map} to {@code MP_MAP} entity converter
-         * @return builder
-         */
+        @Override
         public Builder withDefaultMapObjectConverter() {
             mapper.registerObjectConverter(new DefaultMapObjectConverter(mapper));
             return this;
         }
 
-        /**
-         * Configure the mapper with default {@code MP_ARRAY} entity to {@link List} converter
-         * @return builder
-         */
+        @Override
         public Builder withDefaultArrayValueConverter() {
             mapper.registerValueConverter(new DefaultListValueConverter(mapper));
             return this;
         }
 
-        /**
-         * Configure the mapper with default {@link List} to {@code MP_ARRAY} entity converter
-         * @return builder
-         */
+        @Override
         public Builder withDefaultListObjectConverter() {
             mapper.registerObjectConverter(new DefaultListObjectConverter(mapper));
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack entity-to-object and object-to-entity converter
-         * @param valueClass MessagePack entity class
-         * @param objectClass object class
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @param <T> converter type
-         * @return builder
-         */
+        @Override
         public <V extends Value, O, T extends ValueConverter<V, O> & ObjectConverter<O, V>> Builder withConverter(
                 Class<V> valueClass, Class<O> objectClass, T converter) {
             mapper.registerConverter(valueClass, objectClass, converter);
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack entity-to-object converter
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @return builder
-         * @see #registerValueConverter(ValueConverter)
-         */
+        @Override
         public <V extends Value, O> Builder withValueConverter(ValueConverter<V, O> converter) {
             mapper.registerValueConverter(converter);
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack entity-to-object converter
-         * @param valueClass source entity class
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @return builder
-         * @see #registerValueConverter(Class, ValueConverter)
-         */
+        @Override
         public <V extends Value, O> Builder withValueConverter(Class<V> valueClass, ValueConverter<V, O> converter) {
             mapper.registerValueConverter(valueClass, converter);
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack entity-to-object converter
-         * @param valueClass source entity class
-         * @param objectClass target object class
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @return builder
-         * @see #registerValueConverter(Class, Class, ValueConverter)
-         */
+        @Override
         public <V extends Value, O> Builder withValueConverter(Class<V> valueClass, Class<O> objectClass,
                                                                ValueConverter<V, O> converter) {
             mapper.registerValueConverter(valueClass, objectClass, converter);
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack object-to-entity converter
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @return builder
-         */
+        @Override
         public <V extends Value, O> Builder withObjectConverter(ObjectConverter<O, V> converter) {
             mapper.registerObjectConverter(converter);
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack object-to-entity converter
-         * @param objectClass source object class
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @return builder
-         */
+        @Override
         public <V extends Value, O> Builder withObjectConverter(Class<O> objectClass, ObjectConverter<O, V> converter) {
             mapper.registerObjectConverter(objectClass, converter);
             return this;
         }
 
-        /**
-         * Configure the mapper with a specified MessagePack object-to-entity converter
-         * @param objectClass source object class
-         * @param valueClass target object class
-         * @param converter MessagePack entity-to-object and object-to-entity converter
-         * @param <V> MessagePack entity type
-         * @param <O> object type
-         * @return builder
-         */
+        @Override
         public <V extends Value, O> Builder withObjectConverter(Class<O> objectClass, Class<V> valueClass,
                                                                 ObjectConverter<O, V> converter) {
             mapper.registerObjectConverter(objectClass, valueClass, converter);
             return this;
         }
 
-        /**
-         * Build the mapper instance
-         * @return a new mapper instance
-         */
+        @Override
         public DefaultMessagePackMapper build() {
             return mapper;
         }


### PR DESCRIPTION
A new method has been added to simplify messagepack mapper configuration.

The user no longer needs to know about the default mapper and look for it. Now it is provided with a lambda with an interface for a simple mapper configuration. There is also a method for advanced users to allow them to pass their own mapper.

Also added method for specifying TarantoolClientConfig in TarantoolClient builder