### PR TITLE
Fix problems with TarantoolSpace.update/upsert

### DIFF
--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperation.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperation.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.protocol.Packable;
  * {@link io.tarantool.driver.protocol.requests.TarantoolUpdateRequest} and
  * {@link io.tarantool.driver.protocol.requests.TarantoolUpsertRequest}
  *
+ *
  * @author Sergey Volgin
  */
 public interface TupleOperation extends Packable {
@@ -19,9 +20,9 @@ public interface TupleOperation extends Packable {
 
     Object getValue();
 
-    void setFieldIndex(Integer fieldIndex);
-
     Boolean isProxyOperation();
 
     TupleOperation toProxyTupleOperation();
+
+    TupleOperation cloneWithIndex(int fieldMetadataIndex);
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationAdd.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationAdd.java
@@ -31,4 +31,15 @@ public class TupleOperationAdd extends TupleUpdateOperation {
                 true
         );
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationAdd(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationBitwiseAnd.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationBitwiseAnd.java
@@ -39,4 +39,15 @@ public class TupleOperationBitwiseAnd extends TupleUpdateOperation {
             throw new IllegalArgumentException("Bitwise operations can be performed only with values >= 0");
         }
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationBitwiseAnd(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationBitwiseOr.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationBitwiseOr.java
@@ -39,4 +39,15 @@ public class TupleOperationBitwiseOr extends TupleUpdateOperation {
             throw new IllegalArgumentException("Bitwise operations can be performed only with values >= 0");
         }
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationBitwiseOr(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationBitwiseXor.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationBitwiseXor.java
@@ -39,4 +39,15 @@ public class TupleOperationBitwiseXor extends TupleUpdateOperation {
             throw new IllegalArgumentException("Bitwise operations can be performed only with values >= 0");
         }
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationBitwiseXor(
+                this.getOperationType(),
+                fieldIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationDelete.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationDelete.java
@@ -39,4 +39,15 @@ public class TupleOperationDelete extends TupleUpdateOperation {
             throw new IllegalArgumentException("The number of fields to remove must be greater than zero");
         }
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationDelete(
+                this.getOperationType(),
+                fieldIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationInsert.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationInsert.java
@@ -31,4 +31,15 @@ public class TupleOperationInsert extends TupleUpdateOperation {
                 true
         );
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationInsert(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationSet.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationSet.java
@@ -31,4 +31,15 @@ public class TupleOperationSet extends TupleUpdateOperation {
                 true
         );
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationSet(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationSubtract.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperationSubtract.java
@@ -31,4 +31,15 @@ public class TupleOperationSubtract extends TupleUpdateOperation {
                 true
         );
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleOperationSubtract(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperations.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleOperations.java
@@ -43,19 +43,19 @@ public final class TupleOperations {
      * @return this
      */
     public TupleOperations addOperation(TupleOperation operation) {
-        Integer filedIndex = operation.getFieldIndex();
+        Integer fieldIndex = operation.getFieldIndex();
         String fieldName = operation.getFieldName();
 
         Optional<TupleOperation> existField;
-        if (filedIndex != null) {
-            existField = this.operations.stream().filter(op -> filedIndex.equals(op.getFieldIndex())).findFirst();
+        if (fieldIndex != null) {
+            existField = this.operations.stream().filter(op -> fieldIndex.equals(op.getFieldIndex())).findFirst();
         } else {
             existField = this.operations.stream().filter(op -> fieldName.equals(op.getFieldName())).findFirst();
         }
 
         if (existField.isPresent()) {
             throw new TarantoolSpaceOperationException("Double update of the same field (%s)",
-                    filedIndex != null ? filedIndex : fieldName);
+                    fieldIndex != null ? fieldIndex : fieldName);
         }
 
         addOperationToList(operation);

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleSpliceOperation.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleSpliceOperation.java
@@ -63,4 +63,17 @@ public class TupleSpliceOperation extends TupleUpdateOperation {
     public int getOffset() {
         return offset;
     }
+
+    @Override
+    public TupleOperation cloneWithIndex(int fieldMetadataIndex) {
+        return new TupleSpliceOperation(
+                this.getOperationType(),
+                fieldMetadataIndex,
+                this.getFieldName(),
+                this.getValue(),
+                this.getPosition(),
+                this.getOffset(),
+                this.isProxyOperation()
+        );
+    }
 }

--- a/src/main/java/io/tarantool/driver/api/tuple/operations/TupleUpdateOperation.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/operations/TupleUpdateOperation.java
@@ -18,8 +18,8 @@ abstract class TupleUpdateOperation implements TupleOperation {
 
     protected final boolean isProxyOperation;
     protected final TarantoolUpdateOperationType operationType;
-    protected Integer fieldIndex;
-    protected String fieldName;
+    protected final Integer fieldIndex;
+    protected final String fieldName;
     protected final Object value;
 
     /**
@@ -75,11 +75,6 @@ abstract class TupleUpdateOperation implements TupleOperation {
     @Override
     public Integer getFieldIndex() {
         return fieldIndex;
-    }
-
-    @Override
-    public void setFieldIndex(Integer fieldIndex) {
-        this.fieldIndex = fieldIndex;
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
@@ -257,14 +257,15 @@ public abstract class TarantoolSpace<T extends Packable, R extends Collection<T>
 
     private List<TupleOperation> fillFieldIndexFromMetadata(TupleOperations operations) {
         return operations.asList().stream()
-                .peek(operation -> {
+                .map(operation -> {
                     if (operation.getFieldIndex() == null) {
                         String fieldName = operation.getFieldName();
                         int fieldMetadataIndex = this.spaceMetadata.getFieldByName(fieldName)
                                 .orElseThrow(() -> new TarantoolSpaceFieldNotFoundException(fieldName))
                                 .getFieldPosition();
-                        operation.setFieldIndex(fieldMetadataIndex);
+                        return operation.cloneWithIndex(fieldMetadataIndex);
                     }
+                    return operation;
                 }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequest.java
@@ -12,20 +12,22 @@ import java.util.function.Supplier;
 /**
  * Base class for all kinds of requests to Tarantool server.
  * See <a href="https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests">
- *     https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests</a>
+ * https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests</a>
  *
  * @author Alexey Kuzin
  */
 public class TarantoolRequest {
 
-    private static AtomicLong syncId = new AtomicLong(0);
-    private static Supplier<Long> syncIdSupplier = () -> syncId.updateAndGet(n -> (n >= Long.MAX_VALUE) ? 1 : n + 1);
+    private static final AtomicLong syncId = new AtomicLong(0);
+    private static final Supplier<Long> syncIdSupplier =
+            () -> syncId.updateAndGet(n -> (n >= Long.MAX_VALUE) ? 1 : n + 1);
 
-    private TarantoolHeader header;
-    private TarantoolRequestBody body;
+    private final TarantoolHeader header;
+    private final TarantoolRequestBody body;
 
     /**
      * Basic constructor. Sets an auto-incremented request ID into the Tarantool packet header.
+     *
      * @param type request type code supported by Tarantool
      * @param body request body, may be empty
      * @see TarantoolRequestType
@@ -37,6 +39,7 @@ public class TarantoolRequest {
 
     /**
      * Get header
+     *
      * @return header instance
      */
     public TarantoolHeader getHeader() {
@@ -45,6 +48,7 @@ public class TarantoolRequest {
 
     /**
      * Get body
+     *
      * @return instance of a {@link Packable}
      */
     public Packable getBody() {
@@ -53,6 +57,7 @@ public class TarantoolRequest {
 
     /**
      * Encode incapsulated data using {@link MessagePacker}
+     *
      * @param packer configured {@link MessagePacker}
      * @param mapper object-to-entity mapper
      * @throws TarantoolDecoderException if encoding failed

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpdateRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpdateRequest.java
@@ -1,8 +1,7 @@
 package io.tarantool.driver.protocol.requests;
 
 
-import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
-import io.tarantool.driver.api.tuple.operations.TupleOperations;
+import io.tarantool.driver.api.tuple.operations.TupleOperation;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
@@ -17,7 +16,7 @@ import java.util.Map;
 /**
  * Update request.
  * See <a href="https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests">
- *     https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests</a>
+ * https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests</a>
  *
  * @author Sergey Volgin
  */
@@ -36,11 +35,9 @@ public final class TarantoolUpdateRequest extends TarantoolRequest {
     public static class Builder {
 
         Map<Integer, Object> bodyMap;
-        TarantoolSpaceMetadata metadata;
 
-        public Builder(TarantoolSpaceMetadata metadata) {
+        public Builder() {
             this.bodyMap = new HashMap<>(4, 1);
-            this.metadata = metadata;
         }
 
         public Builder withSpaceId(int spaceId) {
@@ -58,14 +55,8 @@ public final class TarantoolUpdateRequest extends TarantoolRequest {
             return this;
         }
 
-        public Builder withTupleOperations(TupleOperations operations) {
-            operations.asList().forEach(op -> {
-                if (op.getFieldIndex() == null) {
-                    op.setFieldIndex(metadata.getFieldPositionByName(op.getFieldName()));
-                }
-            });
-
-            this.bodyMap.put(TarantoolRequestFieldType.IPROTO_TUPLE.getCode(), operations.asList());
+        public Builder withTupleOperations(List<TupleOperation> operations) {
+            this.bodyMap.put(TarantoolRequestFieldType.IPROTO_TUPLE.getCode(), operations);
             return this;
         }
 

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpsertRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpsertRequest.java
@@ -1,7 +1,6 @@
 package io.tarantool.driver.protocol.requests;
 
-import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
-import io.tarantool.driver.api.tuple.operations.TupleOperations;
+import io.tarantool.driver.api.tuple.operations.TupleOperation;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
 import io.tarantool.driver.protocol.TarantoolProtocolException;
@@ -17,7 +16,7 @@ import java.util.Map;
 /**
  * Upsert request.
  * See <a href="https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests">
- *     https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests</a>
+ * https://www.tarantool.io/en/doc/2.3/dev_guide/internals/box_protocol/#binary-protocol-requests</a>
  *
  * @author Sergey Volgin
  */
@@ -36,11 +35,9 @@ public final class TarantoolUpsertRequest extends TarantoolRequest {
     public static class Builder {
 
         Map<Integer, Object> bodyMap;
-        TarantoolSpaceMetadata metadata;
 
-        public Builder(TarantoolSpaceMetadata metadata) {
+        public Builder() {
             this.bodyMap = new HashMap<>(4, 1);
-            this.metadata = metadata;
         }
 
         public Builder withSpaceId(int spaceId) {
@@ -58,14 +55,8 @@ public final class TarantoolUpsertRequest extends TarantoolRequest {
             return this;
         }
 
-        public Builder withTupleOperations(TupleOperations operations) {
-            operations.asList().forEach(op -> {
-                if (op.getFieldIndex() == null) {
-                    op.setFieldIndex(metadata.getFieldPositionByName(op.getFieldName()));
-                }
-            });
-
-            this.bodyMap.put(TarantoolRequestFieldType.IPROTO_OPS.getCode(), operations.asList());
+        public Builder withTupleOperations(List<TupleOperation> operations) {
+            this.bodyMap.put(TarantoolRequestFieldType.IPROTO_OPS.getCode(), operations);
             return this;
         }
 


### PR DESCRIPTION
This pr resolves two related problems:

1. We use update / upsert from TarantoolSpace, which updates the space via iproto. To specify the field to update, use fieldName. Previously, if we made a mistake in the name, no error occurred and a request was sent to tarantool where fieldIndex = -1, and this is correct for tarantool because it uses reverse index, so -1 is the last element in the Tuple. For now, we'll throw a TarantoolSpaceFieldNotFoundException if the specified fieldName doesn't exist.

2. The user creates operations by fieldName, which are subsequently used by the space.update/upsert functions. After using these functions, a field index field appears in operations that were missing. To remedy this situation, we make TupleOperation non-mutable. And every time we need to change the fields of these operations, for example, in the space.update/upsert functions, then we clone these operations.

Closes #63 