### PR TITLE
Fixed connection manager logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.50.Final</version>
+            <version>4.1.70.Final</version>
         </dependency>
         <dependency>
             <groupId>org.msgpack</groupId>

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -65,11 +65,11 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     private final Bootstrap bootstrap;
     private final TarantoolConnectionFactory connectionFactory;
     private final TarantoolConnectionListeners listeners;
-    private final AtomicReference<TarantoolConnectionManager> connectionManagerHolder = new AtomicReference<>();
     private final AtomicReference<TarantoolMetadata> metadataHolder = new AtomicReference<>();
     private final DefaultResultMapperFactoryFactory mapperFactoryFactory;
     private final SpacesMetadataProvider metadataProvider;
     private final ScheduledExecutorService timeoutScheduler;
+    private TarantoolConnectionManager connectionManager;
 
     /**
      * Create a client.
@@ -138,10 +138,14 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
                                                                     TarantoolConnectionListeners listeners);
 
     private TarantoolConnectionManager connectionManager() {
-        if (this.connectionManagerHolder.get() == null) {
-            this.connectionManagerHolder.compareAndSet(null, connectionManager(config, connectionFactory, listeners));
+        if (this.connectionManager == null) {
+            synchronized (this) {
+                if (this.connectionManager == null) {
+                    this.connectionManager = connectionManager(config, connectionFactory, listeners);
+                }
+            }
         }
-        return connectionManagerHolder.get();
+        return this.connectionManager;
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/connection/AbstractTarantoolConnectionManager.java
+++ b/src/main/java/io/tarantool/driver/core/connection/AbstractTarantoolConnectionManager.java
@@ -200,7 +200,7 @@ public abstract class AbstractTarantoolConnectionManager implements TarantoolCon
                 for (TarantoolConnection aliveConnection : aliveConnections) {
                     if (count-- > 0) {
                         try {
-                            logger.info("Closing connection to {}, connections size greater than {}",
+                            logger.info("Closing connection to {}, connections size is greater than {}",
                                     aliveConnection.getRemoteAddress(), config.getConnections());
                             aliveConnection.close();
                         } catch (Exception e) {
@@ -215,10 +215,8 @@ public abstract class AbstractTarantoolConnectionManager implements TarantoolCon
                         new AbstractMap.SimpleEntry<>(serverAddress, aliveConnections)));
             }
         }
-
         return endpointConnections;
     }
-
 
     private List<TarantoolConnection> getAliveConnections(TarantoolServerAddress serverAddress) {
         List<TarantoolConnection> connections = connectionRegistry.get(serverAddress);

--- a/src/main/java/io/tarantool/driver/core/connection/AbstractTarantoolConnectionManager.java
+++ b/src/main/java/io/tarantool/driver/core/connection/AbstractTarantoolConnectionManager.java
@@ -111,6 +111,7 @@ public abstract class AbstractTarantoolConnectionManager implements TarantoolCon
                 (connectionMode.compareAndSet(ConnectionMode.FULL, ConnectionMode.IN_PROGRESS) ||
                         connectionMode.compareAndSet(ConnectionMode.PARTIAL, ConnectionMode.IN_PROGRESS))) {
 
+            logger.debug("Current connection mode: {}", currentMode);
             // Only one thread can reach to this line because of CAS. Rise up the barrier for 1 thread
             if (currentMode == ConnectionMode.FULL) {
                 // We block the incoming requests until the connections are established and the registry is updated

--- a/src/main/java/io/tarantool/driver/core/connection/AbstractTarantoolConnectionManager.java
+++ b/src/main/java/io/tarantool/driver/core/connection/AbstractTarantoolConnectionManager.java
@@ -220,11 +220,7 @@ public abstract class AbstractTarantoolConnectionManager implements TarantoolCon
     }
 
     private List<TarantoolConnection> getAliveConnections(TarantoolServerAddress serverAddress) {
-        List<TarantoolConnection> connections = connectionRegistry.get(serverAddress);
-        if (connectionRegistry.get(serverAddress) == null) {
-            connections = Collections.emptyList();
-        }
-
+        List<TarantoolConnection> connections = connectionRegistry.getOrDefault(serverAddress, Collections.emptyList());
         return connections.stream().filter(TarantoolConnection::isConnected).collect(Collectors.toList());
     }
 

--- a/src/main/java/io/tarantool/driver/core/connection/ConnectionMode.java
+++ b/src/main/java/io/tarantool/driver/core/connection/ConnectionMode.java
@@ -20,5 +20,8 @@ public enum ConnectionMode {
      */
     OFF,
 
-    IN_PROGRESS;
+    /**
+     * The state in which the connection manager is trying to establish a connection
+     */
+    IN_PROGRESS
 }

--- a/src/main/java/io/tarantool/driver/core/connection/ConnectionMode.java
+++ b/src/main/java/io/tarantool/driver/core/connection/ConnectionMode.java
@@ -18,5 +18,7 @@ public enum ConnectionMode {
     /**
      * Init sequence completed, requests will not block
      */
-    OFF;
+    OFF,
+
+    IN_PROGRESS;
 }


### PR DESCRIPTION
Fixed concurrent access to the creation of a connection manager and its internal logic for establishing connections in the event of a partial or complete failure.
Fixes https://github.com/tarantool/cartridge-java/issues/149