### PR TITLE
Refactoring for RequestRetryPolicies and classes in exceptions.errors package

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,13 @@ TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> retrying(
     TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client, int retries, long delay) {
         return TarantoolClientFactory.configureClient(client)
                     .withRetryingByNumberOfAttempts(
-                        retries,
-                        e -> e.getMessage().contains("Unsuccessful attempt"),
-                        policy -> policy.withDelay(delay))
+                    retries,
+                    // you can use default predicates from TarantoolRequestRetryPolicies for checking errors
+                    TarantoolRequestRetryPolicies.retryNetworkErrors()
+                    // also you can use your own predicates and combine them with each other or with defaults
+                        .or(e -> e.getMessage().contains("Unsuccessful attempt"))
+                        .or(TarantoolRequestRetryPolicies.retryTarantoolNoSuchProcedureErrors()),
+                    policy -> policy.withDelay(delay))
                     .build();
         }
 

--- a/src/main/java/io/tarantool/driver/api/TarantoolClientConfigurator.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolClientConfigurator.java
@@ -5,7 +5,7 @@ import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 /**
@@ -55,7 +55,7 @@ public interface TarantoolClientConfigurator<SELF extends TarantoolClientConfigu
      */
     SELF withRetryingByNumberOfAttempts(
             int numberOfAttempts, UnaryOperator<TarantoolRequestRetryPolicies
-            .AttemptsBoundRetryPolicyFactory.Builder<Function<Throwable, Boolean>>> policy);
+            .AttemptsBoundRetryPolicyFactory.Builder<Predicate<Throwable>>> policy);
 
     /**
      * Configure the attempts bound request retry policy.
@@ -67,7 +67,7 @@ public interface TarantoolClientConfigurator<SELF extends TarantoolClientConfigu
      * @param <T>              callback type for exceptions check
      * @return this instance of builder {@link TarantoolClientConfigurator}
      */
-    <T extends Function<Throwable, Boolean>> SELF withRetryingByNumberOfAttempts(
+    <T extends Predicate<Throwable>> SELF withRetryingByNumberOfAttempts(
             int numberOfAttempts, T exceptionsCheck,
             UnaryOperator<TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicyFactory.Builder<T>> policy);
 
@@ -81,7 +81,7 @@ public interface TarantoolClientConfigurator<SELF extends TarantoolClientConfigu
      */
     SELF withRetryingIndefinitely(
             UnaryOperator<TarantoolRequestRetryPolicies.InfiniteRetryPolicyFactory.Builder
-                    <Function<Throwable, Boolean>>> policy);
+                    <Predicate<Throwable>>> policy);
 
     /**
      * Configure the infinite request retry policy.
@@ -92,7 +92,7 @@ public interface TarantoolClientConfigurator<SELF extends TarantoolClientConfigu
      * @param <T>      callback type for exceptions check
      * @return this instance of builder {@link TarantoolClientConfigurator}
      */
-    <T extends Function<Throwable, Boolean>> SELF withRetryingIndefinitely(
+    <T extends Predicate<Throwable>> SELF withRetryingIndefinitely(
             T callback,
             UnaryOperator<TarantoolRequestRetryPolicies.InfiniteRetryPolicyFactory.Builder<T>> policy);
 

--- a/src/main/java/io/tarantool/driver/api/retry/RequestRetryPolicy.java
+++ b/src/main/java/io/tarantool/driver/api/retry/RequestRetryPolicy.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 /**
- * Request retry policy contains an algorithm of deciding whether an exception is retriable and settings for
+ * Request retry policy contains an algorithm of deciding whether an exception is retryable and settings for
  * limiting the retry attempts
  *
  * @author Alexey Kuzin

--- a/src/main/java/io/tarantool/driver/api/retry/TarantoolRequestRetryPolicies.java
+++ b/src/main/java/io/tarantool/driver/api/retry/TarantoolRequestRetryPolicies.java
@@ -31,23 +31,12 @@ public final class TarantoolRequestRetryPolicies {
     public static final long DEFAULT_ONE_HOUR_TIMEOUT = TimeUnit.HOURS.toMillis(1); //ms
 
     /**
-     * Check all known network exceptions and the user-specified exceptions
-     *
-     * @param exceptionCheck specified predicate for checking exceptions
-     * @param <T>            type of user specified predicate for checking exceptions
-     * @return predicate for checking all networks exceptions
-     */
-    public static <T extends Predicate<Throwable>> Predicate<Throwable> withRetryingNetworkErrors(T exceptionCheck) {
-        return exceptionCheck.or(TarantoolRequestRetryPolicies::isNetworkError);
-    }
-
-    /**
      * Check all known network exceptions
      *
      * @return predicate for checking all network exceptions
      */
     public static Predicate<Throwable> retryNetworkErrors() {
-        return withRetryingNetworkErrors(retryNone);
+        return TarantoolRequestRetryPolicies::isNetworkError;
     }
 
     /**

--- a/src/main/java/io/tarantool/driver/api/retry/TarantoolRequestRetryPolicies.java
+++ b/src/main/java/io/tarantool/driver/api/retry/TarantoolRequestRetryPolicies.java
@@ -38,7 +38,7 @@ public final class TarantoolRequestRetryPolicies {
      * @return predicate for checking all networks exceptions
      */
     public static <T extends Predicate<Throwable>> Predicate<Throwable> withRetryingNetworkErrors(T exceptionCheck) {
-        return exceptionCheck.or((TarantoolRequestRetryPolicies::isNetworkError));
+        return exceptionCheck.or(TarantoolRequestRetryPolicies::isNetworkError);
     }
 
     /**

--- a/src/main/java/io/tarantool/driver/api/retry/TarantoolRequestRetryPolicies.java
+++ b/src/main/java/io/tarantool/driver/api/retry/TarantoolRequestRetryPolicies.java
@@ -4,6 +4,7 @@ import io.tarantool.driver.exceptions.TarantoolAttemptsLimitException;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.exceptions.TarantoolConnectionException;
 import io.tarantool.driver.exceptions.TarantoolInternalNetworkException;
+import io.tarantool.driver.exceptions.TarantoolNoSuchProcedureException;
 import io.tarantool.driver.exceptions.TarantoolTimeoutException;
 import io.tarantool.driver.utils.Assert;
 
@@ -13,7 +14,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -21,41 +22,47 @@ import java.util.function.Supplier;
  *
  * @author Alexey Kuzin
  * @author Artyom Dubinin
+ * @author Oleg Kuznetsov
  */
 public final class TarantoolRequestRetryPolicies {
 
-    public static final Function<Throwable, Boolean> retryAll = t -> true;
-    public static final Function<Throwable, Boolean> retryNone = t -> false;
+    public static final Predicate<Throwable> retryAll = t -> true;
+    public static final Predicate<Throwable> retryNone = t -> false;
     public static final long DEFAULT_ONE_HOUR_TIMEOUT = TimeUnit.HOURS.toMillis(1); //ms
 
     /**
      * Check all known network exceptions and the user-specified exceptions
      *
-     * @param exceptionCheck specified callback for checking exceptions
-     * @param <T>            type of user specified callback for checking exceptions
-     * @return callback for checking all networks exceptions
+     * @param exceptionCheck specified predicate for checking exceptions
+     * @param <T>            type of user specified predicate for checking exceptions
+     * @return predicate for checking all networks exceptions
      */
-    public static <T extends Function<Throwable, Boolean>> Function<Throwable, Boolean>
-    withRetryingNetworkErrors(T exceptionCheck) {
-        return e -> {
-            boolean retryRequest = false;
-            Boolean userExceptionCheck = exceptionCheck.apply(e);
-            if (e instanceof TimeoutException ||
-                    e instanceof TarantoolConnectionException ||
-                    e instanceof TarantoolInternalNetworkException) {
-                retryRequest = true;
-            }
-            return retryRequest || userExceptionCheck;
-        };
+    public static <T extends Predicate<Throwable>> Predicate<Throwable> withRetryingNetworkErrors(T exceptionCheck) {
+        return exceptionCheck.or((TarantoolRequestRetryPolicies::isNetworkError));
     }
 
     /**
      * Check all known network exceptions
      *
-     * @return callback for checking all network exceptions
+     * @return predicate for checking all network exceptions
      */
-    public static Function<Throwable, Boolean> retryNetworkErrors() {
+    public static Predicate<Throwable> retryNetworkErrors() {
         return withRetryingNetworkErrors(retryNone);
+    }
+
+    /**
+     * Check {@link TarantoolNoSuchProcedureException}
+     *
+     * @return predicate for checking {@link TarantoolNoSuchProcedureException}
+     */
+    public static Predicate<Throwable> retryTarantoolNoSuchProcedureErrors() {
+        return throwable -> throwable instanceof TarantoolNoSuchProcedureException;
+    }
+
+    private static boolean isNetworkError(Throwable e) {
+        return e instanceof TimeoutException ||
+                e instanceof TarantoolConnectionException ||
+                e instanceof TarantoolInternalNetworkException;
     }
 
     private TarantoolRequestRetryPolicies() {
@@ -67,13 +74,12 @@ public final class TarantoolRequestRetryPolicies {
      *
      * @param <T> exception checking callback function type
      */
-    public static final class InfiniteRetryPolicy<T extends Function<Throwable, Boolean>>
-            implements RequestRetryPolicy {
+    public static final class InfiniteRetryPolicy<T extends Predicate<Throwable>> implements RequestRetryPolicy {
 
         private final long requestTimeout; //ms
         private final long operationTimeout; //ms
         private final long delay; //ms
-        private final T callback;
+        private final T predicate;
 
         /**
          * Basic constructor
@@ -81,7 +87,7 @@ public final class TarantoolRequestRetryPolicies {
          * @param requestTimeout   timeout for one retry attempt, in milliseconds
          * @param operationTimeout timeout for the whole operation, in milliseconds
          * @param delay            delay between attempts, in milliseconds
-         * @param exceptionCheck   function checking whether the given exception may be retried
+         * @param exceptionCheck   predicate checking whether the given exception may be retried
          */
         public InfiniteRetryPolicy(long requestTimeout, long operationTimeout, long delay, T exceptionCheck) {
             Assert.state(requestTimeout >= 0, "Timeout must be greater or equal than 0!");
@@ -93,12 +99,12 @@ public final class TarantoolRequestRetryPolicies {
             this.requestTimeout = requestTimeout;
             this.operationTimeout = operationTimeout;
             this.delay = delay;
-            this.callback = exceptionCheck;
+            this.predicate = exceptionCheck;
         }
 
         @Override
         public boolean canRetryRequest(Throwable throwable) {
-            if (callback.apply(throwable)) {
+            if (predicate.test(throwable)) {
                 if (delay > 0) {
                     try {
                         TimeUnit.MILLISECONDS.sleep(delay);
@@ -121,7 +127,7 @@ public final class TarantoolRequestRetryPolicies {
         }
 
         @Override
-        public <T> CompletableFuture<T> wrapOperation(Supplier<CompletableFuture<T>> operation, Executor executor) {
+        public <R> CompletableFuture<R> wrapOperation(Supplier<CompletableFuture<R>> operation, Executor executor) {
 
             Assert.notNull(operation, "Operation must not be null");
             Assert.notNull(executor, "Executor must not be null");
@@ -155,9 +161,9 @@ public final class TarantoolRequestRetryPolicies {
     /**
      * Factory for {@link InfiniteRetryPolicy}
      *
-     * @param <T> exception checking callback function type
+     * @param <T> exception checking predicate type
      */
-    public static final class InfiniteRetryPolicyFactory<T extends Function<Throwable, Boolean>>
+    public static final class InfiniteRetryPolicyFactory<T extends Predicate<Throwable>>
             implements RequestRetryPolicyFactory {
 
         private final T callback;
@@ -171,7 +177,7 @@ public final class TarantoolRequestRetryPolicies {
          * @param requestTimeout   timeout for one retry attempt, in milliseconds
          * @param operationTimeout timeout for the whole operation, in milliseconds
          * @param delay            delay between retry attempts, in milliseconds
-         * @param callback         function checking whether the given exception may be retried
+         * @param callback         predicate checking whether the given exception may be retried
          */
         public InfiniteRetryPolicyFactory(long requestTimeout, long operationTimeout, long delay, T callback) {
             this.callback = callback;
@@ -183,11 +189,11 @@ public final class TarantoolRequestRetryPolicies {
         /**
          * Create a builder for this factory
          *
-         * @param callback function checking whether the given exception may be retried
+         * @param callback predicate checking whether the given exception may be retried
          * @param <T>      exception checking callback function type
          * @return new builder instance
          */
-        public static <T extends Function<Throwable, Boolean>> Builder<T> builder(T callback) {
+        public static <T extends Predicate<Throwable>> Builder<T> builder(T callback) {
             return new Builder<>(callback);
         }
 
@@ -201,7 +207,7 @@ public final class TarantoolRequestRetryPolicies {
          *
          * @param <T> exception checking callback function type
          */
-        public static class Builder<T extends Function<Throwable, Boolean>> {
+        public static class Builder<T extends Predicate<Throwable>> {
 
             private long requestTimeout = DEFAULT_ONE_HOUR_TIMEOUT; //ms
             private long delay; //ms
@@ -211,7 +217,7 @@ public final class TarantoolRequestRetryPolicies {
             /**
              * Basic constructor
              *
-             * @param callback function checking whether the given exception may be retried
+             * @param callback predicate checking whether the given exception may be retried
              */
             public Builder(T callback) {
                 this.callback = callback;
@@ -292,13 +298,12 @@ public final class TarantoolRequestRetryPolicies {
     }
 
     /**
-     * Retry policy that accepts a maximum number of attempts and an exception checking callback.
+     * Retry policy that accepts a maximum number of attempts and an exception checking predicate.
      * If the exception check passes and there are any attempts left, the policy returns {@code true}.
      *
-     * @param <T> exception checking callback function type
+     * @param <T> exception checking predicate type
      */
-    public static final class AttemptsBoundRetryPolicy<T extends Function<Throwable, Boolean>>
-            implements RequestRetryPolicy {
+    public static final class AttemptsBoundRetryPolicy<T extends Predicate<Throwable>> implements RequestRetryPolicy {
 
         private int attempts;
         private final int limit;
@@ -317,7 +322,7 @@ public final class TarantoolRequestRetryPolicies {
          * @param attempts       maximum number of retry attempts
          * @param requestTimeout timeout for one retry attempt, in milliseconds
          * @param delay          delay between attempts, in milliseconds
-         * @param exceptionCheck function checking whether the given exception may be retried
+         * @param exceptionCheck predicate checking whether the given exception may be retried
          */
         public AttemptsBoundRetryPolicy(int attempts, long requestTimeout, long delay, T exceptionCheck) {
             Assert.state(attempts >= 0, "Attempts must be greater or equal than 0!");
@@ -334,7 +339,7 @@ public final class TarantoolRequestRetryPolicies {
 
         @Override
         public boolean canRetryRequest(Throwable throwable) {
-            if (exceptionCheck.apply(throwable) && attempts > 0) {
+            if (exceptionCheck.test(throwable) && attempts > 0) {
                 attempts--;
                 if (delay > 0) {
                     try {
@@ -349,7 +354,7 @@ public final class TarantoolRequestRetryPolicies {
         }
 
         @Override
-        public <T> CompletableFuture<T> wrapOperation(Supplier<CompletableFuture<T>> operation, Executor executor) {
+        public <R> CompletableFuture<R> wrapOperation(Supplier<CompletableFuture<R>> operation, Executor executor) {
 
             Assert.notNull(operation, "Operation must not be null");
             Assert.notNull(executor, "Executor must not be null");
@@ -379,9 +384,9 @@ public final class TarantoolRequestRetryPolicies {
     /**
      * Factory for {@link AttemptsBoundRetryPolicy}
      *
-     * @param <T> exception checking callback function type
+     * @param <T> exception checking predicate type
      */
-    public static final class AttemptsBoundRetryPolicyFactory<T extends Function<Throwable, Boolean>>
+    public static final class AttemptsBoundRetryPolicyFactory<T extends Predicate<Throwable>>
             implements RequestRetryPolicyFactory {
 
         private final int numberOfAttempts;
@@ -395,7 +400,7 @@ public final class TarantoolRequestRetryPolicies {
          * @param numberOfAttempts maximum number of retry attempts
          * @param requestTimeout   timeout for one retry attempt, in milliseconds
          * @param delay            delay between retry attempts, in milliseconds
-         * @param exceptionCheck   function checking whether the given exception may be retried
+         * @param exceptionCheck   predicate checking whether the given exception may be retried
          */
         public AttemptsBoundRetryPolicyFactory(int numberOfAttempts,
                                                long requestTimeout,
@@ -412,10 +417,10 @@ public final class TarantoolRequestRetryPolicies {
          *
          * @param attempts       maximum number of attempts
          * @param exceptionCheck function checking whether the given exception may be retried
-         * @param <T>            exception checking callback function type
+         * @param <T>            exception checking predicate type
          * @return new builder instance
          */
-        public static <T extends Function<Throwable, Boolean>> Builder<T> builder(int attempts, T exceptionCheck) {
+        public static <T extends Predicate<Throwable>> Builder<T> builder(int attempts, T exceptionCheck) {
             return new Builder<>(attempts, exceptionCheck);
         }
 
@@ -427,9 +432,9 @@ public final class TarantoolRequestRetryPolicies {
         /**
          * Builder for {@link AttemptsBoundRetryPolicyFactory}
          *
-         * @param <T> exception checking callback function type
+         * @param <T> exception checking predicate type
          */
-        public static class Builder<T extends Function<Throwable, Boolean>> {
+        public static class Builder<T extends Predicate<Throwable>> {
             private final int numberOfAttempts;
             private long requestTimeout = DEFAULT_ONE_HOUR_TIMEOUT; //ms
             private long delay; //ms
@@ -439,7 +444,7 @@ public final class TarantoolRequestRetryPolicies {
              * Basic constructor
              *
              * @param numberOfAttempts maximum number of retry attempts
-             * @param exceptionCheck   function checking whether the given exception may be retried
+             * @param exceptionCheck   predicate checking whether the given exception may be retried
              */
             public Builder(int numberOfAttempts, T exceptionCheck) {
                 this.numberOfAttempts = numberOfAttempts;
@@ -522,7 +527,7 @@ public final class TarantoolRequestRetryPolicies {
      * @param numberOfAttempts maximum number of retries, zero value means no retries
      * @return new factory instance
      */
-    public static AttemptsBoundRetryPolicyFactory.Builder<Function<Throwable, Boolean>>
+    public static AttemptsBoundRetryPolicyFactory.Builder<Predicate<Throwable>>
     byNumberOfAttempts(int numberOfAttempts) {
         return byNumberOfAttempts(numberOfAttempts, retryNetworkErrors());
     }
@@ -531,11 +536,11 @@ public final class TarantoolRequestRetryPolicies {
      * Create a factory for retry policy bound by retry attempts
      *
      * @param numberOfAttempts maximum number of retries, zero value means no retries
-     * @param exceptionCheck   function callback, checking the given exception whether the request may be retried
-     * @param <T>              exception checking callback function type
+     * @param exceptionCheck   predicate, checking the given exception whether the request may be retried
+     * @param <T>              exception checking predicate type
      * @return new factory instance
      */
-    public static <T extends Function<Throwable, Boolean>> AttemptsBoundRetryPolicyFactory.Builder<T>
+    public static <T extends Predicate<Throwable>> AttemptsBoundRetryPolicyFactory.Builder<T>
     byNumberOfAttempts(int numberOfAttempts, T exceptionCheck) {
         return AttemptsBoundRetryPolicyFactory.builder(numberOfAttempts, exceptionCheck);
     }
@@ -544,22 +549,22 @@ public final class TarantoolRequestRetryPolicies {
      * Create a factory for retry policy with unbounded number of attempts.
      * {@link #retryNetworkErrors} is used for checking exceptions by default.
      *
-     * @param <T> exception checking callback function type
+     * @param <T> exception checking predicate type
      * @return new factory instance
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Function<Throwable, Boolean>> InfiniteRetryPolicyFactory.Builder<T> unbound() {
+    public static <T extends Predicate<Throwable>> InfiniteRetryPolicyFactory.Builder<T> unbound() {
         return unbound((T) retryNetworkErrors());
     }
 
     /**
      * Create a factory for retry policy with unbounded number of attempts
      *
-     * @param exceptionCheck function callback, checking the given exception whether the request may be retried
-     * @param <T>            exception checking callback function type
+     * @param exceptionCheck predicate, checking the given exception whether the request may be retried
+     * @param <T>            exception checking predicate type
      * @return new factory instance
      */
-    public static <T extends Function<Throwable, Boolean>> InfiniteRetryPolicyFactory.Builder<T>
+    public static <T extends Predicate<Throwable>> InfiniteRetryPolicyFactory.Builder<T>
     unbound(T exceptionCheck) {
         return InfiniteRetryPolicyFactory.builder(exceptionCheck);
     }

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -150,7 +150,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
 
     @Override
     public boolean establishLackingConnections() {
-        return connectionManager.establishLackingConnections();
+        return connectionManager().establishLackingConnections();
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/TarantoolClientConfiguratorImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolClientConfiguratorImpl.java
@@ -8,7 +8,7 @@ import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies.retryNetworkErrors;
@@ -54,12 +54,12 @@ public class TarantoolClientConfiguratorImpl<SELF extends TarantoolClientConfigu
     @Override
     public SELF withRetryingByNumberOfAttempts(
             int numberOfAttempts, UnaryOperator<TarantoolRequestRetryPolicies
-            .AttemptsBoundRetryPolicyFactory.Builder<Function<Throwable, Boolean>>> policy) {
+            .AttemptsBoundRetryPolicyFactory.Builder<Predicate<Throwable>>> policy) {
         return withRetryingByNumberOfAttempts(numberOfAttempts, retryNetworkErrors(), policy);
     }
 
     @Override
-    public <T extends Function<Throwable, Boolean>> SELF withRetryingByNumberOfAttempts(
+    public <T extends Predicate<Throwable>> SELF withRetryingByNumberOfAttempts(
             int numberOfAttempts, T exceptionsCheck,
             UnaryOperator<TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicyFactory.Builder<T>> policy) {
         return withRetrying(policy.apply(TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicyFactory
@@ -68,12 +68,12 @@ public class TarantoolClientConfiguratorImpl<SELF extends TarantoolClientConfigu
 
     @Override
     public SELF withRetryingIndefinitely(UnaryOperator<TarantoolRequestRetryPolicies
-            .InfiniteRetryPolicyFactory.Builder<Function<Throwable, Boolean>>> policy) {
+            .InfiniteRetryPolicyFactory.Builder<Predicate<Throwable>>> policy) {
         return withRetryingIndefinitely(retryNetworkErrors(), policy);
     }
 
     @Override
-    public <T extends Function<Throwable, Boolean>> SELF withRetryingIndefinitely(
+    public <T extends Predicate<Throwable>> SELF withRetryingIndefinitely(
             T callback, UnaryOperator<TarantoolRequestRetryPolicies.InfiniteRetryPolicyFactory.Builder<T>> policy) {
         return withRetrying(policy.apply(TarantoolRequestRetryPolicies.InfiniteRetryPolicyFactory.builder(callback))
                 .build());

--- a/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionFactory.java
+++ b/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionFactory.java
@@ -75,7 +75,7 @@ public class TarantoolConnectionFactory {
         timeoutScheduler.schedule(() -> {
             if (!connectionFuture.isDone()) {
                 connectionFuture.completeExceptionally(new TimeoutException(
-                        String.format("Failed to to the Tarantool server at %s within %d ms",
+                        String.format("Failed to connect to the Tarantool server at %s within %d ms",
                                 serverAddress, config.getConnectTimeout())));
             }
         }, config.getConnectTimeout(), TimeUnit.MILLISECONDS);

--- a/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
@@ -221,7 +221,7 @@ public class DDLTarantoolSpaceMetadataConverter implements ValueConverter<Value,
                     .map(parts -> {
                         if (!parts.isMapValue()) {
                             throw new TarantoolClientException(
-                                "Unsupported index metadata format: index part metadata is not a map");
+                                    "Unsupported index metadata format: index part metadata is not a map");
                         }
 
                         Map<Value, Value> partsMap = parts.asMapValue().map();

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
@@ -3,8 +3,8 @@ package io.tarantool.driver.exceptions;
 /**
  * An exception occurs when the procedure has not (yet) been defined.
  * <p></p>
- * For example: the tarantool/crud role may not have time to rise with the necessary functions.
- * You can use this exception as a sign that it's worth trying a few more times until the role rises.
+ * For example: this exception can be raised when a role is not up yet or being reloaded at the moment. This can happen when the tarantool 'router' node is restarted or hot-reloaded but the cluster is under load at the moment. If CRUD module is used in the cluster then 'cartridge.roles.crud-router' may have not been initialized yet and all requests to CRUD will fail with this exception.
+ * You can use this exception as a sign that it's worth trying a few more times until the role is up.
  *
  * @author Oleg Kuznetsov
  */

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
@@ -1,0 +1,7 @@
+package io.tarantool.driver.exceptions;
+
+public class TarantoolNoSuchProcedureException extends TarantoolException {
+    public TarantoolNoSuchProcedureException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
@@ -3,7 +3,11 @@ package io.tarantool.driver.exceptions;
 /**
  * An exception occurs when the procedure has not (yet) been defined.
  * <p></p>
- * For example: this exception can be raised when a role is not up yet or being reloaded at the moment. This can happen when the tarantool 'router' node is restarted or hot-reloaded but the cluster is under load at the moment. If CRUD module is used in the cluster then 'cartridge.roles.crud-router' may have not been initialized yet and all requests to CRUD will fail with this exception.
+ * For example: this exception can be raised when a role is not up yet or being reloaded at the moment.
+ * This can happen when the tarantool 'router' node is restarted or hot-reloaded but the cluster is under
+ * load at the moment. If CRUD module is used in the cluster then 'cartridge.roles.crud-router' may
+ * have not been initialized yet and all requests to CRUD will fail with this exception.
+ *
  * You can use this exception as a sign that it's worth trying a few more times until the role is up.
  *
  * @author Oleg Kuznetsov

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
@@ -1,5 +1,13 @@
 package io.tarantool.driver.exceptions;
 
+/**
+ * An exception occurs when the procedure has not (yet) been defined.
+ * <p></p>
+ * For example: the tarantool/crud role may not have time to rise with the necessary functions.
+ * You can use this exception as a sign that it's worth trying a few more times until the role rises.
+ *
+ * @author Oleg Kuznetsov
+ */
 public class TarantoolNoSuchProcedureException extends TarantoolException {
     public TarantoolNoSuchProcedureException(String errorMessage) {
         super(errorMessage);

--- a/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
+++ b/src/main/java/io/tarantool/driver/exceptions/TarantoolNoSuchProcedureException.java
@@ -1,14 +1,14 @@
 package io.tarantool.driver.exceptions;
 
 /**
- * An exception occurs when the procedure has not (yet) been defined.
+ * Corresponds to an exception that occurs when the procedure has not (yet) been defined in the Tarantool instance.
  * <p></p>
- * For example: this exception can be raised when a role is not up yet or being reloaded at the moment.
+ * For example: this exception can be raised when a Cartridge role is not up yet or is being reloaded at the moment.
  * This can happen when the tarantool 'router' node is restarted or hot-reloaded but the cluster is under
  * load at the moment. If CRUD module is used in the cluster then 'cartridge.roles.crud-router' may
  * have not been initialized yet and all requests to CRUD will fail with this exception.
  *
- * You can use this exception as a sign that it's worth trying a few more times until the role is up.
+ * You can use this exception when you are sure that it's worth trying a few more times until the role is up.
  *
  * @author Oleg Kuznetsov
  */

--- a/src/main/java/io/tarantool/driver/exceptions/errors/BoxErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/BoxErrorKey.java
@@ -3,7 +3,12 @@ package io.tarantool.driver.exceptions.errors;
 import org.msgpack.value.StringValue;
 import org.msgpack.value.ValueFactory;
 
-public enum BoxErrorKey implements ErrorKey {
+/**
+ * Errors keys for error message in box error
+ *
+ * @author Oleg Kuznetsov
+ */
+enum BoxErrorKey implements ErrorKey {
     CODE("code", ValueFactory.newString("code")),
     BASE_TYPE("base_type", ValueFactory.newString("base_type")),
     TYPE("type", ValueFactory.newString("type")),

--- a/src/main/java/io/tarantool/driver/exceptions/errors/BoxErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/BoxErrorKey.java
@@ -1,0 +1,30 @@
+package io.tarantool.driver.exceptions.errors;
+
+import org.msgpack.value.StringValue;
+import org.msgpack.value.ValueFactory;
+
+public enum BoxErrorKey implements ErrorKey {
+    CODE("code", ValueFactory.newString("code")),
+    BASE_TYPE("base_type", ValueFactory.newString("base_type")),
+    TYPE("type", ValueFactory.newString("type")),
+    MESSAGE("message", ValueFactory.newString("message")),
+    TRACE("trace", ValueFactory.newString("trace"));
+
+    private final String key;
+    private final StringValue msgPackKey;
+
+    BoxErrorKey(String key, StringValue msgPackKey) {
+        this.key = key;
+        this.msgPackKey = msgPackKey;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public StringValue getMsgPackKey() {
+        return msgPackKey;
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorCode.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorCode.java
@@ -2,6 +2,9 @@ package io.tarantool.driver.exceptions.errors;
 
 /**
  * Error codes used to classify errors
+ * <a href="https://github.com/tarantool/tarantool/blob/master/src/box/errcode.h">Tarantool error codes</a>
+ *
+ * @author Oleg Kuznetsov
  */
 enum ErrorCode {
     NO_SUCH_PROCEDURE(33L), NO_CONNECTION(77L), TIMEOUT(78L);

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorCode.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorCode.java
@@ -1,0 +1,17 @@
+package io.tarantool.driver.exceptions.errors;
+
+/**
+ * Error codes used to classify errors
+ */
+enum ErrorCode {
+    NO_SUCH_PROCEDURE(33L), NO_CONNECTION(77L), TIMEOUT(78L);
+    private final Long code;
+
+    ErrorCode(Long code) {
+        this.code = code;
+    }
+
+    public Long getCode() {
+        return code;
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorKey.java
@@ -1,0 +1,9 @@
+package io.tarantool.driver.exceptions.errors;
+
+import org.msgpack.value.StringValue;
+
+public interface ErrorKey {
+    String getKey();
+
+    StringValue getMsgPackKey();
+}

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorKey.java
@@ -2,7 +2,12 @@ package io.tarantool.driver.exceptions.errors;
 
 import org.msgpack.value.StringValue;
 
-public interface ErrorKey {
+/**
+ * Representations for error key
+ *
+ * @author Oleg Kuznetsov
+ */
+interface ErrorKey {
     String getKey();
 
     StringValue getMsgPackKey();

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorMessageBuilder.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorMessageBuilder.java
@@ -5,19 +5,24 @@ import org.msgpack.value.Value;
 
 import java.util.Map;
 
-public class ErrorMessageBuilder {
+/**
+ * This class can create error message by keys from msgPack error response
+ *
+ * @author Oleg Kuznetsov
+ */
+class ErrorMessageBuilder {
 
     private final StringBuilder stringBuilder;
     private final Map<Value, Value> values;
     private final ErrorKey[] keys;
 
-    public ErrorMessageBuilder(String startsWith, ErrorKey[] keys, Map<Value, Value> values) {
+    ErrorMessageBuilder(String startsWith, ErrorKey[] keys, Map<Value, Value> values) {
         this.stringBuilder = new StringBuilder(startsWith);
         this.values = values;
         this.keys = keys;
     }
 
-    public String build() {
+    String build() {
         for (ErrorKey key : keys) {
             final StringValue stringValue = key.getMsgPackKey();
             final String s = values.containsKey(stringValue) ? values.get(stringValue).toString() : null;

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorMessageBuilder.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorMessageBuilder.java
@@ -1,0 +1,31 @@
+package io.tarantool.driver.exceptions.errors;
+
+import org.msgpack.value.StringValue;
+import org.msgpack.value.Value;
+
+import java.util.Map;
+
+public class ErrorMessageBuilder {
+
+    private final StringBuilder stringBuilder;
+    private final Map<Value, Value> values;
+    private final ErrorKey[] keys;
+
+    public ErrorMessageBuilder(String startsWith, ErrorKey[] keys, Map<Value, Value> values) {
+        this.stringBuilder = new StringBuilder(startsWith);
+        this.values = values;
+        this.keys = keys;
+    }
+
+    public String build() {
+        for (ErrorKey key : keys) {
+            final StringValue stringValue = key.getMsgPackKey();
+            final String s = values.containsKey(stringValue) ? values.get(stringValue).toString() : null;
+            if (s != null && s.length() != 0) {
+                stringBuilder.append("\n").append(key.getKey().toLowerCase()).append(": ").append(s);
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorsErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorsErrorKey.java
@@ -3,7 +3,12 @@ package io.tarantool.driver.exceptions.errors;
 import org.msgpack.value.StringValue;
 import org.msgpack.value.ValueFactory;
 
-public enum ErrorsErrorKey implements ErrorKey {
+/**
+ * Errors keys for error message from tarantool/errors library
+ *
+ * @author Oleg Kuznetsov
+ */
+enum ErrorsErrorKey implements ErrorKey {
     LINE("line", ValueFactory.newString("line")),
     CLASS_NAME("class_name", ValueFactory.newString("line")),
     ERR("err", ValueFactory.newString("err")),

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorsErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorsErrorKey.java
@@ -1,0 +1,31 @@
+package io.tarantool.driver.exceptions.errors;
+
+import org.msgpack.value.StringValue;
+import org.msgpack.value.ValueFactory;
+
+public enum ErrorsErrorKey implements ErrorKey {
+    LINE("line", ValueFactory.newString("line")),
+    CLASS_NAME("class_name", ValueFactory.newString("line")),
+    ERR("err", ValueFactory.newString("err")),
+    FILE("file", ValueFactory.newString("file")),
+    ERROR_MESSAGE("str", ValueFactory.newString("str")),
+    STACKTRACE("stack", ValueFactory.newString("stack"));
+
+    private final String key;
+    private final StringValue msgPackKey;
+
+    ErrorsErrorKey(String key, StringValue msgPackKey) {
+        this.key = key;
+        this.msgPackKey = msgPackKey;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public StringValue getMsgPackKey() {
+        return msgPackKey;
+    }
+}

--- a/src/main/java/io/tarantool/driver/exceptions/errors/ErrorsErrorKey.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/ErrorsErrorKey.java
@@ -10,7 +10,7 @@ import org.msgpack.value.ValueFactory;
  */
 enum ErrorsErrorKey implements ErrorKey {
     LINE("line", ValueFactory.newString("line")),
-    CLASS_NAME("class_name", ValueFactory.newString("line")),
+    CLASS_NAME("class_name", ValueFactory.newString("class_name")),
     ERR("err", ValueFactory.newString("err")),
     FILE("file", ValueFactory.newString("file")),
     ERROR_MESSAGE("str", ValueFactory.newString("str")),

--- a/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
@@ -95,7 +95,7 @@ public class TarantoolErrors {
      * Produces {@link TarantoolInternalException} subclasses from the serialized representation
      * in the format of <code>box.error:unpack</code>,
      *
-     * @see <a href="https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_error/error/">box_error</a>
+     * @see <a href="https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_error/">box_error</a>
      */
     public static class TarantoolBoxErrorFactory implements TarantoolErrorFactory {
         private static final int ERROR_INDICATOR_OFFSET = 32768;

--- a/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
@@ -50,8 +50,7 @@ public class TarantoolErrors {
                 return Optional.empty();
             }
 
-            String exceptionMessage =
-                    new ErrorMessageBuilder("InnerErrorMessage:", ErrorsErrorKey.values(), errorMap).build();
+            String exceptionMessage = getExceptionMessage(ErrorsErrorKey.values(), errorMap);
 
             if (isNetworkError(errorMap)) {
                 return Optional.of(new TarantoolInternalNetworkException(exceptionMessage));
@@ -115,8 +114,7 @@ public class TarantoolErrors {
                 return Optional.empty();
             }
 
-            String exceptionMessage =
-                    new ErrorMessageBuilder("InnerErrorMessage:", BoxErrorKey.values(), errorMap).build();
+            String exceptionMessage = getExceptionMessage(BoxErrorKey.values(), errorMap);
 
             if (isNetworkError(errorMap)) {
                 return Optional.of(new TarantoolInternalNetworkException(exceptionMessage));
@@ -183,6 +181,10 @@ public class TarantoolErrors {
             return errorMap.containsKey(BoxErrorKey.CODE.getMsgPackKey())
                     && errorMap.containsKey(BoxErrorKey.MESSAGE.getMsgPackKey());
         }
+    }
+
+    private static String getExceptionMessage(ErrorKey[] errorKeys, Map<Value, Value> errorMap) {
+        return new ErrorMessageBuilder("InnerErrorMessage:", errorKeys, errorMap).build();
     }
 
     /**

--- a/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
@@ -98,7 +98,7 @@ public class TarantoolErrors {
      * @see <a href="https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_error/">box_error</a>
      */
     public static class TarantoolBoxErrorFactory implements TarantoolErrorFactory {
-        private static final int ERROR_INDICATOR_OFFSET = 32768;
+        private static final long ERROR_INDICATOR_OFFSET = 32768L;
 
         public TarantoolBoxErrorFactory() {
         }

--- a/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrors.java
@@ -3,10 +3,9 @@ package io.tarantool.driver.exceptions.errors;
 import io.tarantool.driver.exceptions.TarantoolException;
 import io.tarantool.driver.exceptions.TarantoolInternalException;
 import io.tarantool.driver.exceptions.TarantoolInternalNetworkException;
+import io.tarantool.driver.exceptions.TarantoolNoSuchProcedureException;
 import io.tarantool.driver.protocol.TarantoolErrorResult;
-import org.msgpack.value.StringValue;
 import org.msgpack.value.Value;
-import org.msgpack.value.ValueFactory;
 
 import java.util.Map;
 import java.util.Optional;
@@ -17,26 +16,11 @@ import java.util.regex.Pattern;
  * Class-container for built-in tarantool errors factories
  *
  * @author Artyom Dubinin
+ * @author Oleg Kuznetsov
  */
 public class TarantoolErrors {
 
-    /**
-     * Error codes used to classify errors
-     */
-    private enum ErrorsCodes {
-        NO_CONNECTION("77"), TIMEOUT("78");
-        private final String code;
-
-        ErrorsCodes(String code) {
-            this.code = code;
-        }
-
-        public String getCode() {
-            return code;
-        }
-    }
-
-    private static final String CLIENT_ERROR = "ClientError";
+    private static final String CLIENT_ERROR_TYPE = "ClientError";
 
     /**
      * Produces {@link TarantoolInternalException} subclasses
@@ -45,16 +29,10 @@ public class TarantoolErrors {
      * @see <a href="https://github.com/tarantool/errors">tarantool/errors</a>
      */
     public static class TarantoolErrorsErrorFactory implements TarantoolErrorFactory {
-        private static final StringValue LINE = ValueFactory.newString("line");
-        private static final StringValue CLASS_NAME = ValueFactory.newString("class_name");
-        private static final StringValue ERR = ValueFactory.newString("err");
-        private static final StringValue FILE = ValueFactory.newString("file");
-        private static final StringValue ERROR_MESSAGE = ValueFactory.newString("str");
-        private static final StringValue STACKTRACE = ValueFactory.newString("stack");
         private static final Pattern NETWORK_ERROR_PATTERN = Pattern.compile(
-                "(?=.*\"type\":\"" + CLIENT_ERROR + "\")"
+                "(?=.*\"type\":\"" + CLIENT_ERROR_TYPE + "\")"
                         + "(?=.*\"code\":"
-                        + "[" + ErrorsCodes.NO_CONNECTION.getCode() + "|" + ErrorsCodes.TIMEOUT.getCode() + "])",
+                        + "[" + ErrorCode.NO_CONNECTION.getCode() + "|" + ErrorCode.TIMEOUT.getCode() + "])",
                 Pattern.DOTALL);
 
         public TarantoolErrorsErrorFactory() {
@@ -65,56 +43,39 @@ public class TarantoolErrors {
             if (error == null || !error.isMapValue()) {
                 return Optional.empty();
             }
-            Map<Value, Value> map = error.asMapValue().map();
 
-            String exceptionMessage = "";
-            String errorMessage = map.containsKey(ERROR_MESSAGE) ? map.get(ERROR_MESSAGE).toString() : null;
-            String err = map.containsKey(ERR) ? map.get(ERR).toString() : null;
-            String line = map.containsKey(LINE) ? map.get(LINE).toString() : null;
-            String className = map.containsKey(CLASS_NAME) ? map.get(CLASS_NAME).toString() : null;
-            String file = map.containsKey(FILE) ? map.get(FILE).toString() : null;
-            String stacktrace = map.containsKey(STACKTRACE) ? map.get(STACKTRACE).toString() : null;
+            final Map<Value, Value> errorMap = error.asMapValue().map();
 
-            StringBuilder sb = new StringBuilder("InnerErrorMessage:");
-            if (errorMessage != null) {
-                sb.append("\n").append(ERROR_MESSAGE).append(": ").append(errorMessage);
-            }
-            if (line != null) {
-                sb.append("\n").append(LINE).append(": ").append(line);
-            }
-            if (className != null) {
-                sb.append("\n").append(CLASS_NAME).append(": ").append(className);
-            }
-            if (err != null) {
-                sb.append("\n").append(ERR).append(": ").append(file);
-            }
-            if (stacktrace != null) {
-                sb.append("\n").append(STACKTRACE).append(": ").append(stacktrace);
-            }
-            exceptionMessage = sb.toString();
-
-            if (!isErrorsError(errorMessage)) {
+            if (!isErrorsError(errorMap)) {
                 return Optional.empty();
             }
 
-            if (isNetworkError(err)) {
+            String exceptionMessage =
+                    new ErrorMessageBuilder("InnerErrorMessage:", ErrorsErrorKey.values(), errorMap).build();
+
+            if (isNetworkError(errorMap)) {
                 return Optional.of(new TarantoolInternalNetworkException(exceptionMessage));
             }
+
             return Optional.of(new TarantoolInternalException(exceptionMessage));
         }
 
         /**
          * Check code from tarantool/errors is network code or not
          *
-         * @param err error message from tarantool/errors
+         * @param errorMap map which contain info about error from tarantool/errors
          * @return an {@link Boolean}
          */
-        private Boolean isNetworkError(String err) {
-            // 77 or 78 code
-            // FIXME: Blocked by https://github.com/tarantool/crud/issues/186
+        private Boolean isNetworkError(Map<Value, Value> errorMap) {
+            String err = errorMap.containsKey(ErrorsErrorKey.ERR.getMsgPackKey()) ?
+                    errorMap.get(ErrorsErrorKey.ERR.getMsgPackKey()).toString() : null;
+
             if (err == null) {
                 return false;
             }
+
+            // 77 or 78 code
+            // FIXME: Blocked by https://github.com/tarantool/crud/issues/186
             Matcher matcher = NETWORK_ERROR_PATTERN.matcher(err);
             return matcher.find();
         }
@@ -123,11 +84,11 @@ public class TarantoolErrors {
          * Check the error message contains field of str,
          * which contains an error in tarantool/errors
          *
-         * @param errorMessage string message from tarantool/errors
+         * @param errorMap string message from tarantool/errors
          * @return an {@link Boolean}
          */
-        private Boolean isErrorsError(String errorMessage) {
-            return errorMessage != null;
+        private Boolean isErrorsError(Map<Value, Value> errorMap) {
+            return errorMap.containsKey(ErrorsErrorKey.ERROR_MESSAGE.getMsgPackKey());
         }
     }
 
@@ -138,12 +99,7 @@ public class TarantoolErrors {
      * @see <a href="https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_error/error/">box_error</a>
      */
     public static class TarantoolBoxErrorFactory implements TarantoolErrorFactory {
-        private static final StringValue CODE = ValueFactory.newString("code");
-        private static final StringValue BASE_TYPE = ValueFactory.newString("base_type");
-        private static final StringValue TYPE = ValueFactory.newString("type");
-        private static final StringValue MESSAGE = ValueFactory.newString("message");
-        private static final StringValue TRACE = ValueFactory.newString("trace");
-        private static final Long ERROR_INDICATOR_OFFSET = 32768L;
+        private static final int ERROR_INDICATOR_OFFSET = 32768;
 
         public TarantoolBoxErrorFactory() {
         }
@@ -153,38 +109,16 @@ public class TarantoolErrors {
             if (error == null || !error.isMapValue()) {
                 return Optional.empty();
             }
-            Map<Value, Value> map = error.asMapValue().map();
+            Map<Value, Value> errorMap = error.asMapValue().map();
 
-            String exceptionMessage = "";
-            String code = map.containsKey(CODE) ? map.get(CODE).toString() : null;
-            String message = map.containsKey(MESSAGE) ? map.get(MESSAGE).toString() : null;
-            String type = map.containsKey(TYPE) ? map.get(TYPE).toString() : null;
-            String baseType = map.containsKey(BASE_TYPE) ? map.get(BASE_TYPE).toString() : null;
-            String trace = map.containsKey(TRACE) ? map.get(TRACE).toString() : null;
-
-            StringBuilder sb = new StringBuilder("InnerErrorMessage:");
-            if (code != null) {
-                sb.append("\n").append(CODE).append(": ").append(code);
-            }
-            if (message != null) {
-                sb.append("\n").append(MESSAGE).append(": ").append(message);
-            }
-            if (baseType != null) {
-                sb.append("\n").append(BASE_TYPE).append(": ").append(baseType);
-            }
-            if (type != null) {
-                sb.append("\n").append(TYPE).append(": ").append(type);
-            }
-            if (trace != null) {
-                sb.append("\n").append(TRACE).append(": ").append(trace);
-            }
-            exceptionMessage = sb.toString();
-
-            if (!isBoxError(code, message)) {
+            if (!isBoxError(errorMap)) {
                 return Optional.empty();
             }
 
-            if (isNetworkError(code, type)) {
+            String exceptionMessage =
+                    new ErrorMessageBuilder("InnerErrorMessage:", BoxErrorKey.values(), errorMap).build();
+
+            if (isNetworkError(errorMap)) {
                 return Optional.of(new TarantoolInternalNetworkException(exceptionMessage));
             }
             return Optional.of(new TarantoolInternalException(exceptionMessage));
@@ -195,31 +129,36 @@ public class TarantoolErrors {
             String message = error.getErrorMessage();
 
             StringBuilder sb = new StringBuilder("InnerErrorMessage:");
-            sb.append("\n").append(CODE).append(": ").append(code);
+            sb.append("\n").append(BoxErrorKey.CODE.getKey()).append(": ").append(code);
             if (message != null) {
-                sb.append("\n").append(MESSAGE).append(": ").append(message);
+                sb.append("\n").append(BoxErrorKey.MESSAGE.getKey()).append(": ").append(message);
             }
             String exceptionMessage = sb.toString();
 
-            if (isNetworkError(code.toString())) {
+            if (isNetworkError(code)) {
                 return new TarantoolInternalNetworkException(exceptionMessage);
             }
+
+            if (ErrorCode.NO_SUCH_PROCEDURE.getCode().equals(code)) {
+                return new TarantoolNoSuchProcedureException(exceptionMessage);
+            }
+
             return new TarantoolInternalException(exceptionMessage);
         }
 
         /**
          * Check code from box.error is network code or not
          *
-         * @param code code from box.error
-         * @param type type from box.error
+         * @param errorMap map which contain info about error
          * @return an {@link Boolean}
          */
-        private Boolean isNetworkError(String code, String type) {
+        private Boolean isNetworkError(Map<Value, Value> errorMap) {
+            long code = errorMap.get(BoxErrorKey.CODE.getMsgPackKey()).asIntegerValue().asLong();
+            String type = errorMap.get(BoxErrorKey.TYPE.getMsgPackKey()).toString();
+
             // 77 or 78 code
-            return (code.equals(ErrorsCodes.NO_CONNECTION.getCode()) ||
-                    code.equals(ErrorsCodes.TIMEOUT.getCode())) &&
-                    type != null &&
-                    type.equals(CLIENT_ERROR);
+            return (code == ErrorCode.NO_CONNECTION.getCode() || code == ErrorCode.TIMEOUT.getCode())
+                    && type != null && type.equals(CLIENT_ERROR_TYPE);
         }
 
         /**
@@ -228,21 +167,21 @@ public class TarantoolErrors {
          * @param code code from box.error
          * @return an {@link Boolean}
          */
-        private Boolean isNetworkError(String code) {
+        private Boolean isNetworkError(Long code) {
             // 77 or 78 code
-            return code.equals(ErrorsCodes.NO_CONNECTION.getCode()) ||
-                    code.equals(ErrorsCodes.TIMEOUT.getCode());
+            return code.equals(ErrorCode.NO_CONNECTION.getCode())
+                    || code.equals(ErrorCode.TIMEOUT.getCode());
         }
 
         /**
          * Check the error message contains fields of code and message
          *
-         * @param code    code from box.error
-         * @param message string message from box.error
+         * @param errorMap map which contain info about error
          * @return an {@link Boolean}
          */
-        private Boolean isBoxError(String code, String message) {
-            return code != null && message != null;
+        private Boolean isBoxError(Map<Value, Value> errorMap) {
+            return errorMap.containsKey(BoxErrorKey.CODE.getMsgPackKey())
+                    && errorMap.containsKey(BoxErrorKey.MESSAGE.getMsgPackKey());
         }
     }
 

--- a/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrorsParser.java
+++ b/src/main/java/io/tarantool/driver/exceptions/errors/TarantoolErrorsParser.java
@@ -8,7 +8,6 @@ import org.msgpack.value.Value;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A parser that pushes the error into different types of tarantool errors
@@ -17,13 +16,14 @@ import java.util.stream.Collectors;
  * As a result, an exception of the desired type and with the desired message is thrown.
  *
  * @author Artyom Dubinin
+ * @author Oleg Kuznetsov
  */
 public final class TarantoolErrorsParser {
     private static final List<TarantoolErrorFactory> errorsFactories = Arrays.asList(
-                    new TarantoolErrors.TarantoolBoxErrorFactory(),
-                    new TarantoolErrors.TarantoolErrorsErrorFactory(),
-                    new TarantoolErrors.TarantoolUnrecognizedErrorFactory()
-            );
+            new TarantoolErrors.TarantoolBoxErrorFactory(),
+            new TarantoolErrors.TarantoolErrorsErrorFactory(),
+            new TarantoolErrors.TarantoolUnrecognizedErrorFactory()
+    );
 
     private TarantoolErrorsParser() {
     }
@@ -41,8 +41,9 @@ public final class TarantoolErrorsParser {
                     .map(factory -> factory.create(error))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .collect(Collectors.toList())
-                    .get(0);
+                    .findFirst()
+                    .orElseThrow(() -> new TarantoolClientException("Failed to parse internal error"));
+
         } catch (MessagePackException e) {
             throw new TarantoolClientException("Failed to unpack internal error", e);
         }

--- a/src/main/java/io/tarantool/driver/handlers/TarantoolResponseHandler.java
+++ b/src/main/java/io/tarantool/driver/handlers/TarantoolResponseHandler.java
@@ -25,7 +25,7 @@ public class TarantoolResponseHandler extends SimpleChannelInboundHandler<Tarant
     private final Logger log = LoggerFactory.getLogger(TarantoolResponseHandler.class);
     private final TarantoolErrors.TarantoolBoxErrorFactory boxErrorFactory
             = new TarantoolErrors.TarantoolBoxErrorFactory();
-    private RequestFutureManager futureManager;
+    private final RequestFutureManager futureManager;
 
     public TarantoolResponseHandler(RequestFutureManager futureManager) {
         super();

--- a/src/test/java/io/tarantool/driver/core/ProxyTarantoolClientBuilderTest.java
+++ b/src/test/java/io/tarantool/driver/core/ProxyTarantoolClientBuilderTest.java
@@ -12,7 +12,7 @@ import io.tarantool.driver.auth.TarantoolCredentials;
 import io.tarantool.driver.mappers.DefaultMessagePackMapper;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategyType.PARALLEL_ROUND_ROBIN;
 import static io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategyType.ROUND_ROBIN;
@@ -176,8 +176,7 @@ public class ProxyTarantoolClientBuilderTest {
         int expectedRequestTimeout = 123;
         String expectedReplaceFunctionName = "hello";
         String expectedTruncateFunctionName = "create";
-        Function<Throwable, Boolean> expectedCallback =
-                throwable -> throwable.getMessage().equals("Hello World");
+        Predicate<Throwable> expectedCallback = throwable -> throwable.getMessage().equals("Hello World");
 
         //when
         TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client =

--- a/src/test/java/io/tarantool/driver/core/RetryTarantoolClientBuilderTest.java
+++ b/src/test/java/io/tarantool/driver/core/RetryTarantoolClientBuilderTest.java
@@ -13,7 +13,7 @@ import io.tarantool.driver.auth.TarantoolCredentials;
 import io.tarantool.driver.mappers.DefaultMessagePackMapper;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategyType.PARALLEL_ROUND_ROBIN;
 import static io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategyType.ROUND_ROBIN;
@@ -39,7 +39,7 @@ public class RetryTarantoolClientBuilderTest {
         int expectedRequestTimeout = 123;
         String expectedReplaceFunctionName = "hello";
         String expectedTruncateFunctionName = "create";
-        Function<Throwable, Boolean> expectedCallback =
+        Predicate<Throwable> expectedCallback =
                 throwable -> throwable.getMessage().equals("Hello World");
 
         //when
@@ -121,7 +121,7 @@ public class RetryTarantoolClientBuilderTest {
         int expectedRequestTimeoutMs = 230;
         String expectedUserName = "test";
         String expectedPassword = "passwordTest";
-        Function<Throwable, Boolean> expectedCallback = t -> t.getMessage().equals("Test");
+        Predicate<Throwable> expectedCallback = t -> t.getMessage().equals("Test");
 
         TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client = TarantoolClientFactory.createClient()
                 .withCredentials(expectedUserName, expectedPassword)
@@ -203,7 +203,7 @@ public class RetryTarantoolClientBuilderTest {
         int expectedDelay = 100;
         int expectedNumberOfAttempts = 10;
         String expectedMappedFunctionName = "crud.delete";
-        Function<Throwable, Boolean> expectedExceptionCheck = t -> true;
+        Predicate<Throwable> expectedExceptionCheck = t -> true;
 
         //when
         TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client =
@@ -243,7 +243,7 @@ public class RetryTarantoolClientBuilderTest {
         int expectedDelay = 100;
         int expectedRequestTimeout = 10;
         int expectedNumberOfAttempts = 10;
-        Function<Throwable, Boolean> expectedExceptionCheck = t -> true;
+        Predicate<Throwable> expectedExceptionCheck = t -> true;
 
         //when
         TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client =

--- a/src/test/java/io/tarantool/driver/integration/ClientFactoryIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClientFactoryIT.java
@@ -1,8 +1,8 @@
 package io.tarantool.driver.integration;
 
 import io.tarantool.driver.api.TarantoolClient;
-import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.TarantoolClientFactory;
+import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.RetryingTarantoolTupleClient;
@@ -12,7 +12,7 @@ import org.testcontainers.containers.output.WaitingConsumer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,8 +42,7 @@ public class ClientFactoryIT extends SharedCartridgeContainer {
         int expectedDelay = 500;
         int expectedRequestTimeout = 123;
         String expectedSelectFunctionName = "custom_crud_select";
-        Function<Throwable, Boolean> expectedCallback =
-                throwable -> throwable.getMessage().equals("Hello World");
+        Predicate<Throwable> expectedCallback = throwable -> throwable.getMessage().equals("Hello World");
 
         //when
         TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client =

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -65,11 +65,6 @@ public class ClusterTarantoolTupleClientIT {
         initClient();
     }
 
-    @BeforeEach
-    public void beforeEach() {
-        client.space(TEST_SPACE_NAME).truncate().join();
-    }
-
     public static void tearDown() throws Exception {
         client.close();
         assertThrows(TarantoolClientException.class, () -> client.metadata().getSpaceByName("_space"));

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -120,7 +120,7 @@ public class ProxyTarantoolClientMixedInstancesIT extends SharedCartridgeContain
                 TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicyFactory
                         .builder(10, thr -> thr instanceof TarantoolNoSuchProcedureException)
                         .withDelay(100)
-                        .build());;
+                        .build());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
@@ -1,6 +1,8 @@
 package io.tarantool.driver.integration;
 
+import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
+import io.tarantool.driver.api.TarantoolClientFactory;
 import io.tarantool.driver.api.TarantoolClusterAddressProvider;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.TarantoolServerAddress;
@@ -16,10 +18,6 @@ import io.tarantool.driver.cluster.BinaryClusterDiscoveryEndpoint;
 import io.tarantool.driver.cluster.BinaryDiscoveryClusterAddressProvider;
 import io.tarantool.driver.cluster.TarantoolClusterDiscoveryConfig;
 import io.tarantool.driver.cluster.TestWrappedClusterAddressProvider;
-import io.tarantool.driver.core.ClusterTarantoolTupleClient;
-import io.tarantool.driver.core.ProxyTarantoolTupleClient;
-import io.tarantool.driver.core.RetryingTarantoolTupleClient;
-import io.tarantool.driver.exceptions.TarantoolNoSuchProcedureException;
 import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class ProxyTruncateIT extends SharedCartridgeContainer {
 
-    private static RetryingTarantoolTupleClient client;
+    private static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
     private static final DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
     private static final TarantoolTupleFactory tupleFactory =
             new DefaultTarantoolTupleFactory(mapperFactory.defaultComplexTypesMapper());
@@ -86,22 +84,17 @@ public class ProxyTruncateIT extends SharedCartridgeContainer {
     }
 
     public static void initClient() {
-        TarantoolCredentials credentials = new SimpleTarantoolCredentials(USER_NAME, PASSWORD);
-
-        TarantoolClientConfig config = new TarantoolClientConfig.Builder()
-                .withCredentials(credentials)
+        client = TarantoolClientFactory.createClient()
+                .withCredentials(USER_NAME, PASSWORD)
+                .withAddressProvider(getClusterAddressProvider())
                 .withConnectTimeout(DEFAULT_TIMEOUT)
                 .withReadTimeout(DEFAULT_TIMEOUT)
                 .withRequestTimeout(DEFAULT_TIMEOUT)
+                .withProxyMethodMapping()
+                .withRetryingByNumberOfAttempts(10,
+                        TarantoolRequestRetryPolicies.retryTarantoolNoSuchProcedureErrors(),
+                        b -> b.withDelay(100))
                 .build();
-
-        ClusterTarantoolTupleClient clusterClient = new ClusterTarantoolTupleClient(
-                config, getClusterAddressProvider());
-        client = new RetryingTarantoolTupleClient(new ProxyTarantoolTupleClient(clusterClient),
-                TarantoolRequestRetryPolicies.AttemptsBoundRetryPolicyFactory
-                        .builder(10, thr -> thr instanceof TarantoolNoSuchProcedureException)
-                        .withDelay(100)
-                        .build());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
@@ -98,7 +98,7 @@ public class ProxyTruncateIT extends SharedCartridgeContainer {
     }
 
     @Test
-    public void test_truncate2TimesOneSpace_shouldNotThrowExceptionsAndSpaceShouldBeEmptyAfterItchCall() {
+    public void test_truncate2TimesOneSpace_shouldNotThrowExceptionsAndSpaceShouldBeEmptyAfterEachCall() {
         TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
                 client.space(TEST_SPACE_NAME);
 

--- a/src/test/java/io/tarantool/driver/integration/ReconnectIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ReconnectIT.java
@@ -4,9 +4,13 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientFactory;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.TarantoolServerAddress;
+import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.exceptions.TarantoolNoSuchProcedureException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.WaitingConsumer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -15,9 +19,12 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Testcontainers
 public class ReconnectIT extends SharedCartridgeContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReconnectIT.class);
 
     private static String USER_NAME;
     private static String PASSWORD;
@@ -34,19 +41,36 @@ public class ReconnectIT extends SharedCartridgeContainer {
         PASSWORD = container.getPassword();
     }
 
+    private boolean crudProcedureIsNotDefined;
+
     @Test
-    public void test_should_reconnect_ifReconnectIsInvoked() throws Exception {
+    public void test_should_reconnect_ifReconnectIsInvoked() throws InterruptedException {
         //when
-        TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client =
-                TarantoolClientFactory.createClient()
-                        .withAddresses(
-                                new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3301)),
-                                new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3311)),
-                                new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3312))
-                        )
-                        .withCredentials(USER_NAME, PASSWORD)
-                        .withConnections(10)
-                        .build();
+        TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client = getTarantoolClient();
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable.getMessage().contains("Procedure 'crud.select' is not defined")) {
+                logger.error(throwable.getMessage());
+                crudProcedureIsNotDefined = true;
+            }
+        });
+        new Thread(() -> {
+            for (int i = 0; i < 10000; i++) {
+                client.space("test_space").select(Conditions.any()).join();
+            }
+        }).start();
+
+        client.eval("rawset(_G, 'crud', nil)").join();
+        Thread.sleep(500);
+        client.eval("rawset(_G, 'crud', require('crud'))").join();
+        Thread.sleep(500);
+
+        assertFalse(crudProcedureIsNotDefined);
+    }
+
+    @Test
+    public void test_should_reconnect_ifCrudProcedureIsNotDefined() throws Exception {
+        //when
+        TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client = getTarantoolClient();
 
         // getting all routers uuids
         final Set<String> routerUuids = getInstancesUuids(client);
@@ -69,6 +93,23 @@ public class ReconnectIT extends SharedCartridgeContainer {
 
         // check that amount of routers is equal initial amount
         assertEquals(routerUuids.size(), uuidsAfterReconnect.size());
+    }
+
+    private TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> getTarantoolClient() {
+        return TarantoolClientFactory.createClient()
+                .withAddresses(
+                        new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3301)),
+                        new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3311)),
+                        new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3312))
+                )
+                .withCredentials(USER_NAME, PASSWORD)
+                .withConnections(10)
+                .withProxyMethodMapping()
+                .withRetryingByNumberOfAttempts(5,
+                        throwable -> throwable instanceof TarantoolNoSuchProcedureException,
+                        factory -> factory.withDelay(100)
+                )
+                .build();
     }
 
     /**

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -117,6 +117,10 @@ local function box_error_non_network_error()
     return nil, box.error.new(box.error.WAL_IO):unpack()
 end
 
+local function test_no_such_procedure()
+    return 'test_no_such_procedure'
+end
+
 local function crud_error_timeout()
     return nil, { class_name = 'SelectError',
                   err = 'Failed to get next object: GetTupleError: Failed to get tuples from storages: UpdateTuplesError: Failed to select tuples from storages: Call: Failed for 07d14fec-f32b-4b90-aa72-e6755273ad56: Function returned an error: {\"code\":78,\"base_type\":\"ClientError\",\"type\":\"ClientError\",\"message\":\"Timeout exceeded\",\"trace\":[{\"file\":\"builtin\\/box\\/net_box.lua\",\"line\":419}]}',
@@ -154,6 +158,7 @@ local function init(opts)
     rawset(_G, 'box_error_non_network_error', box_error_non_network_error)
     rawset(_G, 'crud_error_timeout', crud_error_timeout)
     rawset(_G, 'custom_crud_select', custom_crud_select)
+    rawset(_G, 'test_no_such_procedure', test_no_such_procedure)
 
     return true
 end


### PR DESCRIPTION
Added refactoring for RequestRetryPolicies and classes in `exceptions.errors` package

Added new Exception called `TarantoolNoSuchProcedureException` for this message, so that the user can specify it in the retry policy
```
InnerErrorMessage:
code: 33
message: Procedure '*' is not defined
```
Closes https://github.com/tarantool/cartridge-java/issues/159