### PR TITLE
Prevent multiple call of TarantoolClusterDiscoveryConfig.Builder().withEndpoint()

### DIFF
--- a/src/main/java/io/tarantool/driver/cluster/TarantoolClusterDiscoveryConfig.java
+++ b/src/main/java/io/tarantool/driver/cluster/TarantoolClusterDiscoveryConfig.java
@@ -88,6 +88,9 @@ public final class TarantoolClusterDiscoveryConfig {
          */
         public Builder withEndpoint(TarantoolClusterDiscoveryEndpoint endpoint) {
             Assert.notNull(endpoint, "Cluster discovery endpoint config should not be null");
+            if (this.config.getEndpoint() != null) {
+                throw new TarantoolClientException("Cluster discovery endpoint already set");
+            }
             this.config.setEndpoint(endpoint);
             return this;
         }

--- a/src/test/java/io/tarantool/driver/cluster/TarantoolClusterDiscoveryConfigTest.java
+++ b/src/test/java/io/tarantool/driver/cluster/TarantoolClusterDiscoveryConfigTest.java
@@ -1,0 +1,39 @@
+package io.tarantool.driver.cluster;
+
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Dmitry Kasimovskiy
+ */
+public class TarantoolClusterDiscoveryConfigTest {
+
+    @Test
+    public void test_withEndpoint_shouldReturnConfig() {
+        // given
+        TarantoolClusterDiscoveryEndpoint endpoint = new TarantoolClusterDiscoveryEndpoint() { };
+
+        // when
+        TarantoolClusterDiscoveryConfig cfg = new TarantoolClusterDiscoveryConfig.Builder()
+                .withEndpoint(endpoint)
+                .build();
+
+        // then
+        assertNotNull(cfg);
+        assertEquals(endpoint, cfg.getEndpoint());
+    }
+
+    @Test
+    public void test_withEndpoint_shouldThrowException_ifCalledMultipleTimes() {
+        // given
+        TarantoolClusterDiscoveryEndpoint endpoint = new TarantoolClusterDiscoveryEndpoint() { };
+
+        // then
+        assertThrows(TarantoolClientException.class, () -> new TarantoolClusterDiscoveryConfig.Builder()
+                .withEndpoint(endpoint)
+                .withEndpoint(endpoint)
+                .build());
+    }
+}


### PR DESCRIPTION
Throw exception if TarantoolClusterDiscoveryConfig.Builder().withEndpoint() called multiple times
Closes #173