### PR TITLE
Set correct fieldNumber in indexMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.3] - unreleased
+
+### Bugfixes
+- Fixed incorrect fieldNumber in the index metadata #209
+
 ## [0.7.2] - 2022-04-06
 
 ### Bugfixes

--- a/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
@@ -20,8 +20,7 @@ import java.util.stream.Collectors;
 /**
  * Populates metadata from results of a call to proxy API function in Tarantool instance. The function result is
  * expected to have the format which is returned by DDL module.
- * See <a href="https://github.com/tarantool/ddl#input-data-format">
- * https://github.com/tarantool/ddl#input-data-format</a>
+ * See <a href="https://github.com/tarantool/ddl#input-data-format">https://github.com/tarantool/ddl#input-data-format</a>
  *
  * @author Sergey Volgin
  * @author Artyom Dubinin
@@ -233,7 +232,7 @@ public class DDLTarantoolSpaceMetadataConverter implements ValueConverter<Value,
                         }
                         String fieldType = fieldTypeValue.asStringValue().asString();
 
-                        return new TarantoolIndexPartMetadataImpl(fieldNumber - 1, fieldType, fieldPath);
+                        return new TarantoolIndexPartMetadataImpl(fieldNumber, fieldType, fieldPath);
                     })
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
There are two aspects of this issue:
1) Incorrect fieldNumber in the index part metadata. All fieldNumber decreased by one for all indexes.
2) When the driver try to find suitable index by field name it compares fieldNumber in the indexPartMetadata and selected fields. This can lead to a situation where the driver will select the wrong index or will not be able to find the index at all.

Closes #203