### PR TITLE
Fix checkConverterByTargetType logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.7.3] - unreleased
 
 - Added workflow for performance tests in CI
+- Fixed converting performance with targetType #212
 
 ### Bugfixes
 - Fixed incorrect fieldNumber in the index metadata #209

--- a/src/main/java/io/tarantool/driver/mappers/ConverterWrapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/ConverterWrapper.java
@@ -1,0 +1,37 @@
+package io.tarantool.driver.mappers;
+
+import io.tarantool.driver.mappers.converters.Converter;
+import io.tarantool.driver.mappers.converters.ValueConverter;
+import io.tarantool.driver.mappers.converters.ObjectConverter;
+
+import java.io.Serializable;
+
+/**
+ * Base class for the internal logic of search converters.
+ * It is needed for faster possibility of obtaining a target type of converter.
+ * Target type is the second type parameter in {@link ValueConverter} or {@link ObjectConverter}.
+ *
+ * @param <C> the converter that returns an instance of this target type from an instance of input type
+ * @author Artyom Dubinin
+ */
+class ConverterWrapper<C extends Converter> implements Serializable {
+
+    private static final long serialVersionUID = 20220501L;
+
+    private final C converter;
+    private final Class<?> targetClass;
+
+    ConverterWrapper(C converter, Class<?> targetClass) {
+        this.converter = converter;
+        this.targetClass = targetClass;
+    }
+
+
+    public C getConverter() {
+        return converter;
+    }
+
+    public Class<?> getTargetClass() {
+        return targetClass;
+    }
+}

--- a/src/main/java/io/tarantool/driver/mappers/converters/Converter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/Converter.java
@@ -1,0 +1,13 @@
+package io.tarantool.driver.mappers.converters;
+
+import java.io.Serializable;
+
+/**
+ * Basic interface for converters mapping MessagePack entities and Java objects.
+ * It must contain a method that maps the value of input type to the value of target type.
+ *
+ * @author Artyom Dubinin
+ */
+public interface Converter extends Serializable {
+
+}

--- a/src/main/java/io/tarantool/driver/mappers/converters/ObjectConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/ObjectConverter.java
@@ -7,22 +7,24 @@ import java.io.Serializable;
 /**
  * Basic interface for converters from Java objects to MessagePack entities for a particular class
  *
+ * @param <O> the source object type
+ * @param <V> the target MessagePack entity type
  * @author Alexey Kuzin
  */
-public interface ObjectConverter<T, S extends Value> extends Serializable {
+public interface ObjectConverter<O, V extends Value> extends Converter {
     /**
      * Convert Java object to a MessagePack entity
      * @param object object
      * @return entity
      */
-    S toValue(T object);
+    V toValue(O object);
 
     /**
      * Optional method for determining if this specific object can be converted to the specified {@link Value} type.
      * @param object the object to be converted
      * @return true, if the object csn be converted
      */
-    default boolean canConvertObject(T object) {
+    default boolean canConvertObject(O object) {
         return true;
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/ValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/ValueConverter.java
@@ -6,11 +6,12 @@ import java.io.Serializable;
 
 /**
  * Basic interface for converters from MessagePack entities to Java objects for a particular class
+ *
  * @param <V> the source MessagePack entity type
  * @param <O> the target object type
  * @author Alexey Kuzin
  */
-public interface ValueConverter<V extends Value, O> extends Serializable {
+public interface ValueConverter<V extends Value, O> extends Converter {
     /**
      * Convert MessagePack entity to a Java object
      * @param value entity


### PR DESCRIPTION
Now the connector doesn't search converter's targetType by reflection,
the targetType is stored with the converter. Operations to convert a value with targetType are faster.

You can see result of perfomance tests here:
[master](https://github.com/tarantool/cartridge-java/runs/6320224857?check_suite_focus=true#step:7:1496)
[fix/check_converter_by_target_type](https://github.com/tarantool/cartridge-java/runs/6387468617?check_suite_focus=true#step:7:1975)

I didn't forget about

- [x] Tests (It isn't a new feature, all tests are the same)
- [x] Changelog
- [x] Documentation (It's iternal)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Closes #212
