### PR TITLE
Support insert_many and replace_many CRUD operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ### Features
 - Added options parameter to Tarantool Space API ([#266](https://github.com/tarantool/cartridge-java/pull/266))
+- Added support for insert_many and replace_many CRUD operations ([#259](https://github.com/tarantool/cartridge-java/issues/259))
 
 ## [0.8.2] - 2022-09-16
 
 ### Features
-- Removed code duplication in *ProxyOperations builders ([#256](https://github.com/tarantool/cartridge-java/issues/256))
 - Added client EventLoopThreadsNumber property for control netty work threads ([#253](https://github.com/tarantool/cartridge-java/pull/253))
+
+### Misc
+- Removed code duplication in *ProxyOperations builders ([#256](https://github.com/tarantool/cartridge-java/issues/256))
 - Refactor CRUDOperationOptions to a hierarchy of classes ([#258](https://github.com/tarantool/cartridge-java/issues/258))
 
 ## [0.8.1] - 2022-08-18

--- a/src/main/java/io/tarantool/driver/api/proxy/ProxyOperationsMappingConfig.java
+++ b/src/main/java/io/tarantool/driver/api/proxy/ProxyOperationsMappingConfig.java
@@ -12,7 +12,9 @@ public final class ProxyOperationsMappingConfig {
     public static final String SCHEMA_FUNCTION = "ddl.get_schema";
     public static final String DELETE_FUNCTION = CRUD_PREFIX + "delete";
     public static final String INSERT_FUNCTION = CRUD_PREFIX + "insert";
+    public static final String INSERT_MANY_FUNCTION = CRUD_PREFIX + "insert_many";
     public static final String REPLACE_FUNCTION = CRUD_PREFIX + "replace";
+    public static final String REPLACE_MANY_FUNCTION = CRUD_PREFIX + "replace_many";
     public static final String SELECT_FUNCTION = CRUD_PREFIX + "select";
     public static final String UPDATE_FUNCTION = CRUD_PREFIX + "update";
     public static final String UPSERT_FUNCTION = CRUD_PREFIX + "upsert";
@@ -21,7 +23,9 @@ public final class ProxyOperationsMappingConfig {
     private final String schemaFunctionName;
     private final String deleteFunctionName;
     private final String insertFunctionName;
+    private final String insertManyFunctionName;
     private final String replaceFunctionName;
+    private final String replaceManyFunctionName;
     private final String updateFunctionName;
     private final String upsertFunctionName;
     private final String selectFunctionName;
@@ -59,12 +63,32 @@ public final class ProxyOperationsMappingConfig {
     }
 
     /**
+     * Get API function name for performing the insert_many operation.
+     * The default value is <code>crud.insert_many</code>.
+     *
+     * @return a callable API function name
+     */
+    public String getInsertManyFunctionName() {
+        return insertManyFunctionName;
+    }
+
+    /**
      * Get API function name for performing the replace operation. The default value is <code>crud.replace</code>.
      *
      * @return a callable API function name
      */
     public String getReplaceFunctionName() {
         return replaceFunctionName;
+    }
+
+    /**
+     * Get API function name for performing the replace_many operation.
+     * The default value is <code>crud.replace_many</code>.
+     *
+     * @return a callable API function name
+     */
+    public String getReplaceManyFunctionName() {
+        return replaceManyFunctionName;
     }
 
     /**
@@ -104,13 +128,16 @@ public final class ProxyOperationsMappingConfig {
     }
 
     private ProxyOperationsMappingConfig(String schemaFunctionName, String deleteFunctionName,
-                                         String insertFunctionName, String replaceFunctionName,
+                                         String insertFunctionName, String insertManyFunctionName,
+                                         String replaceFunctionName, String replaceManyFunctionName,
                                          String updateFunctionName, String upsertFunctionName,
                                          String selectFunctionName, String truncateFunctionName) {
         this.schemaFunctionName = schemaFunctionName;
         this.deleteFunctionName = deleteFunctionName;
         this.insertFunctionName = insertFunctionName;
+        this.insertManyFunctionName = insertManyFunctionName;
         this.replaceFunctionName = replaceFunctionName;
+        this.replaceManyFunctionName = replaceManyFunctionName;
         this.updateFunctionName = updateFunctionName;
         this.upsertFunctionName = upsertFunctionName;
         this.selectFunctionName = selectFunctionName;
@@ -134,7 +161,9 @@ public final class ProxyOperationsMappingConfig {
         private String schemaFunctionName = SCHEMA_FUNCTION;
         private String deleteFunctionName = DELETE_FUNCTION;
         private String insertFunctionName = INSERT_FUNCTION;
+        private String insertManyFunctionName = INSERT_MANY_FUNCTION;
         private String replaceFunctionName = REPLACE_FUNCTION;
+        private String replaceManyFunctionName = REPLACE_MANY_FUNCTION;
         private String updateFunctionName = UPDATE_FUNCTION;
         private String upsertFunctionName = UPSERT_FUNCTION;
         private String selectFunctionName = SELECT_FUNCTION;
@@ -177,6 +206,17 @@ public final class ProxyOperationsMappingConfig {
         }
 
         /**
+         * Get API function name for performing the insert_many operation
+         *
+         * @param insertManyFunctionName name for stored function performing insert_many operation
+         * @return a callable API function name
+         */
+        public Builder withInsertManyFunctionName(String insertManyFunctionName) {
+            this.insertManyFunctionName = insertManyFunctionName;
+            return this;
+        }
+
+        /**
          * Get API function name for performing the replace operation
          *
          * @param replaceFunctionName name for stored function performing replace operation
@@ -184,6 +224,17 @@ public final class ProxyOperationsMappingConfig {
          */
         public Builder withReplaceFunctionName(String replaceFunctionName) {
             this.replaceFunctionName = replaceFunctionName;
+            return this;
+        }
+
+        /**
+         * Get API function name for performing the replace_many operation
+         *
+         * @param replaceManyFunctionName name for stored function performing replace_many operation
+         * @return a callable API function name
+         */
+        public Builder withReplaceManyFunctionName(String replaceManyFunctionName) {
+            this.replaceManyFunctionName = replaceManyFunctionName;
             return this;
         }
 
@@ -238,8 +289,8 @@ public final class ProxyOperationsMappingConfig {
          */
         public ProxyOperationsMappingConfig build() {
             return new ProxyOperationsMappingConfig(schemaFunctionName, deleteFunctionName, insertFunctionName,
-                    replaceFunctionName, updateFunctionName, upsertFunctionName, selectFunctionName,
-                    truncateFunctionName);
+                    insertManyFunctionName, replaceFunctionName, replaceManyFunctionName, updateFunctionName,
+                    upsertFunctionName, selectFunctionName, truncateFunctionName);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
+++ b/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
@@ -4,7 +4,9 @@ import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.cursor.TarantoolCursor;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.space.options.DeleteOptions;
+import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.InsertOptions;
+import io.tarantool.driver.api.space.options.ReplaceManyOptions;
 import io.tarantool.driver.api.space.options.ReplaceOptions;
 import io.tarantool.driver.api.space.options.SelectOptions;
 import io.tarantool.driver.api.space.options.UpdateOptions;
@@ -38,7 +40,7 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      * Delete a tuple. Only a single primary index value condition is supported.
      *
      * @param conditions query with options
-     * @param options    specified options
+     * @param options    operation options
      * @return a future that will contain removed tuple once completed
      * @throws TarantoolClientException in case if the request failed
      */
@@ -59,12 +61,36 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      * Inserts tuple into the space, if no tuple with same unique keys exists. Otherwise throw duplicate key error.
      *
      * @param tuple   new data
-     * @param options specified options
+     * @param options operation options
      * @return a future that will contain all corresponding tuples once completed
      * @throws TarantoolClientException in case if request failed
      */
     default CompletableFuture<R> insert(T tuple, InsertOptions options) throws TarantoolClientException {
         return insert(tuple);
+    }
+
+    /**
+     * Inserts several tuples into the space at once. If writing of any tuple fails,
+     * all tuples will not be saved.
+     *
+     * @param tuples new data
+     * @return a future that will contain all corresponding tuples once completed
+     * @throws TarantoolClientException in case if request failed
+     */
+    CompletableFuture<R> insertMany(Collection<T> tuples) throws TarantoolClientException;
+
+    /**
+     * Inserts several tuples into the space at once. If writing of any tuple fails,
+     * all tuples will not be saved.
+     *
+     * @param tuples new data
+     * @param options operation options
+     * @return a future that will contain all corresponding tuples once completed
+     * @throws TarantoolClientException in case if request failed
+     */
+    default CompletableFuture<R> insertMany(Collection<T> tuples, InsertManyOptions options)
+            throws TarantoolClientException {
+        return insertMany(tuples);
     }
 
     /**
@@ -80,7 +106,7 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      * Insert a tuple into the space or replace an existing one.
      *
      * @param tuple   new data
-     * @param options specified options
+     * @param options operation options
      * @return a future that will contain all corresponding tuples once completed
      * @throws TarantoolClientException in case if request failed
      */
@@ -89,7 +115,31 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
     }
 
     /**
-     * Select tuples matching the specified query with specified conditions.
+     * Insert or replace several tuples into the space at once. If writing of any tuple fails,
+     * all tuples will not be saved.
+     *
+     * @param tuples new data
+     * @return a future that will contain all corresponding tuples once completed
+     * @throws TarantoolClientException in case if request failed
+     */
+    CompletableFuture<R> replaceMany(Collection<T> tuples) throws TarantoolClientException;
+
+    /**
+     * Insert or replace several tuples into the space at once. If writing of any tuple fails,
+     * all tuples will not be saved, but this behavior can be changed with the options.
+     *
+     * @param tuples new data
+     * @param options operation options
+     * @return a future that will contain all corresponding tuples once completed
+     * @throws TarantoolClientException in case if request failed
+     */
+    default CompletableFuture<R> replaceMany(Collection<T> tuples, ReplaceManyOptions options)
+            throws TarantoolClientException {
+        return replaceMany(tuples);
+    }
+
+    /**
+     * Select tuples matching the specified query with options.
      *
      * @param conditions query with options
      * @return a future that will contain all corresponding tuples once completed
@@ -101,7 +151,7 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      * Select tuples matching the specified query with specified conditions and options.
      *
      * @param conditions specified conditions
-     * @param options    specified options
+     * @param options    operation options
      * @return a future that will contain all corresponding tuples once completed
      * @throws TarantoolClientException in case if the request failed
      */
@@ -124,7 +174,7 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      *
      * @param conditions query with options
      * @param tuple      tuple with new field values
-     * @param options    specified options
+     * @param options    operation options
      * @return a future that will contain corresponding tuple once completed
      * @throws TarantoolClientException in case if the request failed
      */
@@ -147,7 +197,7 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      *
      * @param conditions query with options
      * @param operations the list update operations
-     * @param options    specified options
+     * @param options    operation options
      * @return a future that will contain corresponding tuple once completed
      * @throws TarantoolClientException in case if the request failed
      */
@@ -174,7 +224,7 @@ public interface TarantoolSpaceOperations<T extends Packable, R extends Collecti
      * @param conditions query with options
      * @param tuple      new data that will be insert if tuple will be not found
      * @param operations the list of update operations to be performed if the tuple exists
-     * @param options    specified options
+     * @param options    operation options
      * @return a future that will empty list
      * @throws TarantoolClientException in case if the request failed
      */

--- a/src/main/java/io/tarantool/driver/api/space/options/AbstractOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/AbstractOptions.java
@@ -2,12 +2,10 @@ package io.tarantool.driver.api.space.options;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
- * Public API for space operations.
- *
- * An abstract class necessary for implementing CRT (curiously recurring template)
- * pattern for the cluster proxy operation options.
+ * An abstract class-container for all operation options.
  *
  * @author Alexey Kuzin
  * @author Artyom Dubinin
@@ -18,11 +16,24 @@ public abstract class AbstractOptions<B extends AbstractOptions<B>> implements O
 
     protected abstract B self();
 
+    /**
+     * Add an option value.
+     *
+     * @param option option name
+     * @param value option value
+     */
     public void addOption(String option, Object value) {
         resultMap.put(option, value);
     }
 
-    public Map<String, Object> asMap() {
-        return resultMap;
+    /**
+     * Get an option value.
+     *
+     * @param option option name
+     * @param optionClass option value type
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> getOption(String option, Class<T> optionClass) {
+        return Optional.ofNullable((T) resultMap.get(option));
     }
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/DeleteOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/DeleteOptions.java
@@ -1,10 +1,10 @@
 package io.tarantool.driver.api.space.options;
 
 /**
- * Marker interface for space delete options
+ * Marker interface for space delete operation options
  *
  * @author Artyom Dubinin
  * @author Alexey Kuzin
  */
-public interface DeleteOptions extends Options {
+public interface DeleteOptions extends OperationWithTimeoutOptions {
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/InsertManyOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/InsertManyOptions.java
@@ -1,0 +1,26 @@
+package io.tarantool.driver.api.space.options;
+
+import java.util.Optional;
+
+/**
+ * Marker interface for space insert_many operation options
+ *
+ * @author Alexey Kuzin
+ */
+public interface InsertManyOptions extends OperationWithTimeoutOptions {
+    /**
+     * Return whether all changes should not be saved if any tuple insertion
+     * was unsuccesful.
+     *
+     * @return true, if the operation should rollback on error
+     */
+    Optional<Boolean> getRollbackOnError();
+
+    /**
+     * Return whether the operation should be interrupted if any tuple insertion
+     * was unsuccesful.
+     *
+     * @return true, if the operation should stop on error
+     */
+    Optional<Boolean> getStopOnError();
+}

--- a/src/main/java/io/tarantool/driver/api/space/options/InsertOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/InsertOptions.java
@@ -1,10 +1,10 @@
 package io.tarantool.driver.api.space.options;
 
 /**
- * Marker interface for space insert options
+ * Marker interface for space insert operation options
  *
  * @author Artyom Dubinin
  * @author Alexey Kuzin
  */
-public interface InsertOptions extends Options {
+public interface InsertOptions extends OperationWithTimeoutOptions {
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/OperationWithTimeoutOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/OperationWithTimeoutOptions.java
@@ -1,0 +1,17 @@
+package io.tarantool.driver.api.space.options;
+
+import java.util.Optional;
+
+/**
+ * Base class for all operation options that may have a configurable timeout.
+ *
+ * @author Alexey Kuzin
+ */
+public interface OperationWithTimeoutOptions extends Options {
+    /**
+     * Return operation timeout.
+     *
+     * @return timeout, in milliseconds.
+     */
+    Optional<Integer> getTimeout();
+}

--- a/src/main/java/io/tarantool/driver/api/space/options/Options.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/Options.java
@@ -1,6 +1,6 @@
 package io.tarantool.driver.api.space.options;
 
-import java.util.Map;
+import java.util.Optional;
 
 /**
  * Marker interface for space operations options
@@ -11,7 +11,7 @@ import java.util.Map;
 public interface Options {
 
     /**
-     * Add named option
+     * Add named option.
      *
      * @param option name of option
      * @param value  value of option
@@ -19,9 +19,11 @@ public interface Options {
     void addOption(String option, Object value);
 
     /**
-     * Return serializable options representation.
+     * Return option value by name.
      *
-     * @return a map
+     * @param option option name
+     * @param optionClass option value type
+     * @return option value
      */
-    Map<String, Object> asMap();
+    <T> Optional<T> getOption(String option, Class<T> optionClass);
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/ReplaceManyOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/ReplaceManyOptions.java
@@ -1,0 +1,26 @@
+package io.tarantool.driver.api.space.options;
+
+import java.util.Optional;
+
+/**
+ * Marker interface for space replace_many operation options
+ *
+ * @author Alexey Kuzin
+ */
+public interface ReplaceManyOptions extends OperationWithTimeoutOptions {
+    /**
+     * Return whether all changes should not be saved if any tuple replace
+     * was unsuccesful.
+     *
+     * @return true, if the operation should rollback on error
+     */
+    Optional<Boolean> getRollbackOnError();
+
+    /**
+     * Return whether the operation should be interrupted if any tuple replace
+     * was unsuccesful.
+     *
+     * @return true, if the operation should stop on error
+     */
+    Optional<Boolean> getStopOnError();
+}

--- a/src/main/java/io/tarantool/driver/api/space/options/ReplaceOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/ReplaceOptions.java
@@ -1,10 +1,10 @@
 package io.tarantool.driver.api.space.options;
 
 /**
- * Marker interface for space replace options
+ * Marker interface for space replace operation options
  *
  * @author Artyom Dubinin
  * @author Alexey Kuzin
  */
-public interface ReplaceOptions extends Options {
+public interface ReplaceOptions extends OperationWithTimeoutOptions {
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/SelectOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/SelectOptions.java
@@ -1,10 +1,19 @@
 package io.tarantool.driver.api.space.options;
 
+import java.util.Optional;
+
 /**
- * Marker interface for space select options
+ * Marker interface for space select operation options
  *
  * @author Artyom Dubinin
  * @author Alexey Kuzin
  */
-public interface SelectOptions extends Options {
+public interface SelectOptions extends OperationWithTimeoutOptions {
+    /**
+     * Return the internal size of batch for transferring data between
+     * storage and router nodes.
+     *
+     * @return batch size
+     */
+    Optional<Integer> getBatchSize();
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/UpdateOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/UpdateOptions.java
@@ -1,10 +1,10 @@
 package io.tarantool.driver.api.space.options;
 
 /**
- * Marker interface for space update options
+ * Marker interface for space update operation options
  *
  * @author Artyom Dubinin
  * @author Alexey Kuzin
  */
-public interface UpdateOptions extends Options {
+public interface UpdateOptions extends OperationWithTimeoutOptions {
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/UpsertOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/UpsertOptions.java
@@ -1,10 +1,10 @@
 package io.tarantool.driver.api.space.options;
 
 /**
- * Marker interface for space upsert options
+ * Marker interface for space upsert operation options
  *
  * @author Artyom Dubinin
  * @author Alexey Kuzin
  */
-public interface UpsertOptions extends Options {
+public interface UpsertOptions extends OperationWithTimeoutOptions {
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyBaseOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyBaseOptions.java
@@ -1,6 +1,9 @@
 package io.tarantool.driver.api.space.options.proxy;
 
+import java.util.Optional;
+
 import io.tarantool.driver.api.space.options.AbstractOptions;
+import io.tarantool.driver.api.space.options.OperationWithTimeoutOptions;
 
 /**
  * Represent options for all proxy functions
@@ -8,12 +11,28 @@ import io.tarantool.driver.api.space.options.AbstractOptions;
  * @author Alexey Kuzin
  * @author Artyom Dubinin
  */
-abstract class ProxyBaseOptions<B extends ProxyBaseOptions<B>> extends AbstractOptions<B> {
+abstract class ProxyBaseOptions<B extends ProxyBaseOptions<B>> extends AbstractOptions<B>
+    implements OperationWithTimeoutOptions {
 
     public static final String TIMEOUT = "timeout";
 
+    /**
+     * Specifies timeout for waiting for a server response for the operation.
+     * Configured request timeout for that client will be used by default.
+     *
+     * @param timeout request timeout, in milliseconds
+     * @return this options instance
+     */
     public B withTimeout(int timeout) {
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("Timeout should be greater than 0");
+        }
         addOption(TIMEOUT, timeout);
         return self();
+    }
+
+    @Override
+    public Optional<Integer> getTimeout() {
+        return getOption(TIMEOUT, Integer.class);
     }
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyDeleteOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyDeleteOptions.java
@@ -13,6 +13,9 @@ public final class ProxyDeleteOptions extends ProxyBaseOptions<ProxyDeleteOption
     private ProxyDeleteOptions() {
     }
 
+    /**
+     * Create new instance.
+     */
     public static ProxyDeleteOptions create() {
         return new ProxyDeleteOptions();
     }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyInsertManyOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyInsertManyOptions.java
@@ -1,0 +1,66 @@
+package io.tarantool.driver.api.space.options.proxy;
+
+import java.util.Optional;
+
+import io.tarantool.driver.api.space.options.InsertManyOptions;
+
+/**
+ * Represent options for insert_many cluster proxy operation
+ *
+ * @author Alexey Kuzin
+ */
+public final class ProxyInsertManyOptions extends ProxyBaseOptions<ProxyInsertManyOptions>
+    implements InsertManyOptions {
+
+    public static final String ROLLBACK_ON_ERROR = "rollback_on_error";
+    public static final String STOP_ON_ERROR = "stop_on_error";
+
+    private ProxyInsertManyOptions() {
+    }
+
+    /**
+     * Create new instance.
+     */
+    public static ProxyInsertManyOptions create() {
+        return new ProxyInsertManyOptions();
+    }
+
+    /**
+     * Specifies whether to not save any changes in the space if any tuple insert operation
+     * is unsuccesful. Default value is <code>true</code>.
+     *
+     * @param rollbackOnError should rollback batch on error
+     * @return this options instance
+     */
+    public ProxyInsertManyOptions withRollbackOnError(boolean rollbackOnError) {
+        addOption(ROLLBACK_ON_ERROR, rollbackOnError);
+        return self();
+    }
+
+    /**
+     * Specifies whether to not try to insert more tuples into the space if any tuple insert
+     * operation is unsuccesful. Default value is <code>true</code>.
+     *
+     * @param stopOnError should stop batch on error
+     * @return this options instance
+     */
+    public ProxyInsertManyOptions withStopOnError(boolean stopOnError) {
+        addOption(STOP_ON_ERROR, stopOnError);
+        return self();
+    }
+
+    @Override
+    protected ProxyInsertManyOptions self() {
+        return this;
+    }
+
+    @Override
+    public Optional<Boolean> getRollbackOnError() {
+        return getOption(ROLLBACK_ON_ERROR, Boolean.class);
+    }
+
+    @Override
+    public Optional<Boolean> getStopOnError() {
+        return getOption(STOP_ON_ERROR, Boolean.class);
+    }
+}

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyInsertOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyInsertOptions.java
@@ -13,6 +13,9 @@ public final class ProxyInsertOptions extends ProxyBaseOptions<ProxyInsertOption
     private ProxyInsertOptions() {
     }
 
+    /**
+     * Create new instance.
+     */
     public static ProxyInsertOptions create() {
         return new ProxyInsertOptions();
     }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyReplaceManyOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyReplaceManyOptions.java
@@ -1,0 +1,66 @@
+package io.tarantool.driver.api.space.options.proxy;
+
+import java.util.Optional;
+
+import io.tarantool.driver.api.space.options.ReplaceManyOptions;
+
+/**
+ * Represent options for replace_many cluster proxy operation
+ *
+ * @author Alexey Kuzin
+ */
+public final class ProxyReplaceManyOptions extends ProxyBaseOptions<ProxyReplaceManyOptions>
+    implements ReplaceManyOptions {
+
+    public static final String ROLLBACK_ON_ERROR = "rollback_on_error";
+    public static final String STOP_ON_ERROR = "stop_on_error";
+
+    private ProxyReplaceManyOptions() {
+    }
+
+    /**
+     * Create new instance.
+     */
+    public static ProxyReplaceManyOptions create() {
+        return new ProxyReplaceManyOptions();
+    }
+
+    /**
+     * Specifies whether to not save any changes in the space if any tuple replace operation
+     * is unsuccesful. Default value is <code>true</code>.
+     *
+     * @param rollbackOnError should rollback batch on error
+     * @return this options instance
+     */
+    public ProxyReplaceManyOptions withRollbackOnError(boolean rollbackOnError) {
+        addOption(ROLLBACK_ON_ERROR, rollbackOnError);
+        return self();
+    }
+
+    /**
+     * Specifies whether to not try to replace more tuples into the space if any tuple replace
+     * operation is unsuccesful. Default value is <code>true</code>.
+     *
+     * @param stopOnError should stop batch on error
+     * @return this options instance
+     */
+    public ProxyReplaceManyOptions withStopOnError(boolean stopOnError) {
+        addOption(STOP_ON_ERROR, stopOnError);
+        return self();
+    }
+
+    @Override
+    protected ProxyReplaceManyOptions self() {
+        return this;
+    }
+
+    @Override
+    public Optional<Boolean> getRollbackOnError() {
+        return getOption(ROLLBACK_ON_ERROR, Boolean.class);
+    }
+
+    @Override
+    public Optional<Boolean> getStopOnError() {
+        return getOption(STOP_ON_ERROR, Boolean.class);
+    }
+}

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyReplaceOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyReplaceOptions.java
@@ -13,6 +13,9 @@ public final class ProxyReplaceOptions extends ProxyBaseOptions<ProxyReplaceOpti
     private ProxyReplaceOptions() {
     }
 
+    /**
+     * Create new instance.
+     */
     public static ProxyReplaceOptions create() {
         return new ProxyReplaceOptions();
     }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxySelectOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxySelectOptions.java
@@ -1,5 +1,7 @@
 package io.tarantool.driver.api.space.options.proxy;
 
+import java.util.Optional;
+
 import io.tarantool.driver.api.space.options.SelectOptions;
 
 /**
@@ -19,7 +21,16 @@ public final class ProxySelectOptions extends ProxyBaseOptions<ProxySelectOption
         return new ProxySelectOptions();
     }
 
-    public ProxySelectOptions withBatchSize(long batchSize) {
+    /**
+     * Specifies internal batch size for transferring data from storage nodes to router nodes.
+     *
+     * @param batchSize batch size, should be greater than 0
+     * @return this options instance
+     */
+    public ProxySelectOptions withBatchSize(int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("Batch size should be greater than 0");
+        }
         addOption(BATCH_SIZE, batchSize);
         return self();
     }
@@ -27,5 +38,10 @@ public final class ProxySelectOptions extends ProxyBaseOptions<ProxySelectOption
     @Override
     protected ProxySelectOptions self() {
         return this;
+    }
+
+    @Override
+    public Optional<Integer> getBatchSize() {
+        return getOption(BATCH_SIZE, Integer.class);
     }
 }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyTruncateOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyTruncateOptions.java
@@ -1,0 +1,24 @@
+package io.tarantool.driver.api.space.options.proxy;
+
+/**
+ * Represent options for truncate cluster proxy operation
+ *
+ * @author Alexey Kuzin
+ */
+public final class ProxyTruncateOptions extends ProxyBaseOptions<ProxyTruncateOptions> {
+
+    private ProxyTruncateOptions() {
+    }
+
+    /**
+     * Create new instance.
+     */
+    public static ProxyTruncateOptions create() {
+        return new ProxyTruncateOptions();
+    }
+
+    @Override
+    protected ProxyTruncateOptions self() {
+        return this;
+    }
+}

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyUpdateOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyUpdateOptions.java
@@ -13,6 +13,9 @@ public final class ProxyUpdateOptions extends ProxyBaseOptions<ProxyUpdateOption
     private ProxyUpdateOptions() {
     }
 
+    /**
+     * Create new instance.
+     */
     public static ProxyUpdateOptions create() {
         return new ProxyUpdateOptions();
     }

--- a/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyUpsertOptions.java
+++ b/src/main/java/io/tarantool/driver/api/space/options/proxy/ProxyUpsertOptions.java
@@ -13,6 +13,9 @@ public final class ProxyUpsertOptions extends ProxyBaseOptions<ProxyUpsertOption
     private ProxyUpsertOptions() {
     }
 
+    /**
+     * Create new instance.
+     */
     public static ProxyUpsertOptions create() {
         return new ProxyUpsertOptions();
     }

--- a/src/main/java/io/tarantool/driver/core/proxy/AbstractProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/AbstractProxyOperation.java
@@ -58,14 +58,14 @@ abstract class AbstractProxyOperation<T> implements ProxyOperation<T> {
         return client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapper);
     }
 
-    abstract static class GenericOperationsBuilder<T, B extends GenericOperationsBuilder<T, B>> {
+    abstract static
+    class GenericOperationsBuilder<T, O extends Options, B extends GenericOperationsBuilder<T, O, B>> {
         protected TarantoolCallOperations client;
         protected String spaceName;
         protected String functionName;
         protected MessagePackObjectMapper argumentsMapper;
         protected CallResultMapper<T, SingleValueCallResult<T>> resultMapper;
-        protected int requestTimeout;
-        protected Options options;
+        protected O options;
 
         GenericOperationsBuilder() {
         }
@@ -128,23 +128,12 @@ abstract class AbstractProxyOperation<T> implements ProxyOperation<T> {
         }
 
         /**
-         * Specify response reading timeout
-         *
-         * @param requestTimeout the timeout for reading the responses from Tarantool server, in milliseconds
-         * @return builder
-         */
-        public B withRequestTimeout(int requestTimeout) {
-            this.requestTimeout = requestTimeout;
-            return self();
-        }
-
-        /**
          * Specify custom options
          *
          * @param options cluster proxy operation options
          * @return builder
          */
-        public B withOptions(Options options) {
+        public B withOptions(O options) {
             this.options = options;
             return self();
         }

--- a/src/main/java/io/tarantool/driver/core/proxy/CRUDAbstractOperationOptions.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/CRUDAbstractOperationOptions.java
@@ -16,7 +16,7 @@ abstract class CRUDAbstractOperationOptions {
     private final Map<String, Object> resultMap = new HashMap<>();
 
     /**
-     * Inheritable Builder for select cluster proxy operation options.
+     * Inheritable Builder for cluster proxy operation options.
      * <p>
      * This abstract class is necessary for implementing fluent builder inheritance.
      * The solution with {@code self()} method allows to avoid weird java

--- a/src/main/java/io/tarantool/driver/core/proxy/CRUDAbstractOperationOptions.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/CRUDAbstractOperationOptions.java
@@ -2,6 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This class is not part of the public API.
@@ -38,8 +39,10 @@ abstract class CRUDAbstractOperationOptions {
         public abstract O build();
     }
 
-    protected void addOption(String option, Object value) {
-        resultMap.put(option, value);
+    protected void addOption(String option, Optional<?> value) {
+        if (value.isPresent()) {
+            resultMap.put(option, value.get());
+        }
     }
 
     /**

--- a/src/main/java/io/tarantool/driver/core/proxy/CRUDBaseOptions.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/CRUDBaseOptions.java
@@ -1,6 +1,6 @@
 package io.tarantool.driver.core.proxy;
 
-import io.tarantool.driver.api.space.options.Options;
+import java.util.Optional;
 
 /**
  * This class is not part of the public API.
@@ -17,16 +17,7 @@ class CRUDBaseOptions extends CRUDAbstractOperationOptions {
     protected
     <O extends CRUDBaseOptions, T extends AbstractBuilder<O, T>>
     CRUDBaseOptions(AbstractBuilder<O, T> builder) {
-        if (builder.timeout != null) {
-            addOption(TIMEOUT, builder.timeout);
-        }
-
-        if (builder.options != null) {
-            Object batchSize = builder.options.asMap().get(TIMEOUT);
-            if (batchSize != null) {
-                addOption(TIMEOUT, batchSize);
-            }
-        }
+        addOption(TIMEOUT, builder.timeout);
     }
 
     /**
@@ -37,16 +28,10 @@ class CRUDBaseOptions extends CRUDAbstractOperationOptions {
     protected abstract static
     class AbstractBuilder<O extends CRUDBaseOptions, T extends AbstractBuilder<O, T>>
         extends CRUDAbstractOperationOptions.AbstractBuilder<O, T> {
-        protected Integer timeout;
-        protected Options options;
+        protected Optional<Integer> timeout = Optional.empty();
 
-        public T withTimeout(int timeout) {
+        public T withTimeout(Optional<Integer> timeout) {
             this.timeout = timeout;
-            return self();
-        }
-
-        public T withOptions(Options options) {
-            this.options = options;
             return self();
         }
     }

--- a/src/main/java/io/tarantool/driver/core/proxy/CRUDBatchOptions.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/CRUDBatchOptions.java
@@ -1,6 +1,6 @@
 package io.tarantool.driver.core.proxy;
 
-import java.util.Map;
+import java.util.Optional;
 
 /**
  * This class is not part of the public API.
@@ -15,38 +15,32 @@ public final class CRUDBatchOptions extends CRUDBaseOptions {
     public static final String BATCH_ROLLBACK_ON_ERROR = "rollback_on_error";
 
     protected
-    <O extends CRUDBatchOptions, T extends AbstractBuilder<O, T>>
-    CRUDBatchOptions(AbstractBuilder<O, T> builder) {
+    <T extends AbstractBuilder<T>>
+    CRUDBatchOptions(AbstractBuilder<T> builder) {
         super(builder);
 
-        if (builder.stopOnError != null) {
-            addOption(BATCH_STOP_ON_ERROR, builder.stopOnError);
-        }
-
-        if (builder.rollbackOnError != null) {
-            addOption(BATCH_ROLLBACK_ON_ERROR, builder.rollbackOnError);
-        }
+        addOption(BATCH_STOP_ON_ERROR, builder.stopOnError);
+        addOption(BATCH_ROLLBACK_ON_ERROR, builder.rollbackOnError);
     }
 
     protected abstract static
-    class AbstractBuilder<O extends CRUDBaseOptions, T extends AbstractBuilder<O, T>>
-        extends CRUDBaseOptions.AbstractBuilder<O, T> {
-        private Boolean stopOnError;
-        private Boolean rollbackOnError;
+    class AbstractBuilder<T extends AbstractBuilder<T>>
+        extends CRUDBaseOptions.AbstractBuilder<CRUDBatchOptions, T> {
+        private Optional<Boolean> stopOnError = Optional.empty();
+        private Optional<Boolean> rollbackOnError = Optional.empty();
 
-        public T withStopOnError(Boolean stopOnError) {
+        public T withStopOnError(Optional<Boolean> stopOnError) {
             this.stopOnError = stopOnError;
             return self();
         }
 
-        public T withRollbackOnError(Boolean rollbackOnError) {
+        public T withRollbackOnError(Optional<Boolean> rollbackOnError) {
             this.rollbackOnError = rollbackOnError;
             return self();
         }
     }
 
-    protected static final class Builder
-        extends AbstractBuilder<CRUDBatchOptions, Builder> {
+    protected static final class Builder extends AbstractBuilder<Builder> {
 
         @Override
         Builder self() {

--- a/src/main/java/io/tarantool/driver/core/proxy/CRUDBatchOptions.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/CRUDBatchOptions.java
@@ -1,0 +1,61 @@
+package io.tarantool.driver.core.proxy;
+
+import java.util.Map;
+
+/**
+ * This class is not part of the public API.
+ *
+ * Represent options for proxy cluster batch operations
+ *
+ * @author Alexey Kuzin
+ */
+public final class CRUDBatchOptions extends CRUDBaseOptions {
+
+    public static final String BATCH_STOP_ON_ERROR = "stop_on_error";
+    public static final String BATCH_ROLLBACK_ON_ERROR = "rollback_on_error";
+
+    protected
+    <O extends CRUDBatchOptions, T extends AbstractBuilder<O, T>>
+    CRUDBatchOptions(AbstractBuilder<O, T> builder) {
+        super(builder);
+
+        if (builder.stopOnError != null) {
+            addOption(BATCH_STOP_ON_ERROR, builder.stopOnError);
+        }
+
+        if (builder.rollbackOnError != null) {
+            addOption(BATCH_ROLLBACK_ON_ERROR, builder.rollbackOnError);
+        }
+    }
+
+    protected abstract static
+    class AbstractBuilder<O extends CRUDBaseOptions, T extends AbstractBuilder<O, T>>
+        extends CRUDBaseOptions.AbstractBuilder<O, T> {
+        private Boolean stopOnError;
+        private Boolean rollbackOnError;
+
+        public T withStopOnError(Boolean stopOnError) {
+            this.stopOnError = stopOnError;
+            return self();
+        }
+
+        public T withRollbackOnError(Boolean rollbackOnError) {
+            this.rollbackOnError = rollbackOnError;
+            return self();
+        }
+    }
+
+    protected static final class Builder
+        extends AbstractBuilder<CRUDBatchOptions, Builder> {
+
+        @Override
+        Builder self() {
+            return this;
+        }
+
+        @Override
+        public CRUDBatchOptions build() {
+            return new CRUDBatchOptions(this);
+        }
+    }
+}

--- a/src/main/java/io/tarantool/driver/core/proxy/CRUDSelectOptions.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/CRUDSelectOptions.java
@@ -1,5 +1,7 @@
 package io.tarantool.driver.core.proxy;
 
+import java.util.Optional;
+
 import io.tarantool.driver.protocol.Packable;
 
 /**
@@ -17,28 +19,13 @@ final class CRUDSelectOptions extends CRUDBaseOptions {
     public static final String SELECT_AFTER = "after";
     public static final String SELECT_BATCH_SIZE = "batch_size";
 
-    private <O extends CRUDSelectOptions, T extends AbstractBuilder<O, T>>
-    CRUDSelectOptions(AbstractBuilder<O, T> builder) {
+    private <T extends AbstractBuilder<T>>
+    CRUDSelectOptions(AbstractBuilder<T> builder) {
         super(builder);
 
-        if (builder.selectLimit != null) {
-            addOption(SELECT_LIMIT, builder.selectLimit);
-        }
-
-        if (builder.after != null) {
-            addOption(SELECT_AFTER, builder.after);
-        }
-
-        if (builder.selectBatchSize != null) {
-            addOption(SELECT_BATCH_SIZE, builder.selectBatchSize);
-        }
-
-        if (builder.options != null) {
-            Object batchSize = builder.options.asMap().get(SELECT_BATCH_SIZE);
-            if (batchSize != null) {
-                addOption(SELECT_BATCH_SIZE, batchSize);
-            }
-        }
+        addOption(SELECT_LIMIT, builder.selectLimit);
+        addOption(SELECT_AFTER, builder.after);
+        addOption(SELECT_BATCH_SIZE, builder.selectBatchSize);
     }
 
     /**
@@ -47,23 +34,23 @@ final class CRUDSelectOptions extends CRUDBaseOptions {
      * @see CRUDAbstractOperationOptions.AbstractBuilder
      */
     protected abstract static
-    class AbstractBuilder<O extends CRUDSelectOptions, T extends AbstractBuilder<O, T>>
-        extends CRUDBaseOptions.AbstractBuilder<O, T> {
-        private Long selectLimit;
-        private Packable after;
-        private Long selectBatchSize;
+    class AbstractBuilder<T extends AbstractBuilder<T>>
+        extends CRUDBaseOptions.AbstractBuilder<CRUDSelectOptions, T> {
+        private Optional<Long> selectLimit = Optional.empty();
+        private Optional<Packable> after = Optional.empty();
+        private Optional<Integer> selectBatchSize = Optional.empty();
 
-        public T withSelectLimit(long selectLimit) {
+        public T withSelectLimit(Optional<Long> selectLimit) {
             this.selectLimit = selectLimit;
             return self();
         }
 
-        public T withSelectBatchSize(long selectBatchSize) {
+        public T withSelectBatchSize(Optional<Integer> selectBatchSize) {
             this.selectBatchSize = selectBatchSize;
             return self();
         }
 
-        public T withSelectAfter(Packable startTuple) {
+        public T withSelectAfter(Optional<Packable> startTuple) {
             this.after = startTuple;
             return self();
         }
@@ -72,8 +59,7 @@ final class CRUDSelectOptions extends CRUDBaseOptions {
     /**
      * Concrete Builder implementation for select cluster proxy operation options.
      */
-    protected static final class Builder
-        extends AbstractBuilder<CRUDSelectOptions, Builder> {
+    protected static final class Builder extends AbstractBuilder<Builder> {
 
         @Override
         Builder self() {

--- a/src/main/java/io/tarantool/driver/core/proxy/DeleteProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/DeleteProxyOperation.java
@@ -2,6 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolCallOperations;
+import io.tarantool.driver.api.space.options.DeleteOptions;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.TarantoolIndexQuery;
@@ -29,7 +30,8 @@ public final class DeleteProxyOperation<T> extends AbstractProxyOperation<T> {
     /**
      * The builder for this class.
      */
-    public static final class Builder<T> extends GenericOperationsBuilder<T, Builder<T>> {
+    public static final class Builder<T>
+        extends GenericOperationsBuilder<T, DeleteOptions, Builder<T>> {
         private TarantoolIndexQuery indexQuery;
 
         public Builder() {
@@ -47,8 +49,7 @@ public final class DeleteProxyOperation<T> extends AbstractProxyOperation<T> {
 
         public DeleteProxyOperation<T> build() {
             CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
-                    .withTimeout(requestTimeout)
-                    .withOptions(options)
+                    .withTimeout(options.getTimeout())
                     .build();
 
             List<?> arguments = Arrays.asList(spaceName, indexQuery.getKeyValues(), requestOptions.asMap());

--- a/src/main/java/io/tarantool/driver/core/proxy/InsertManyProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/InsertManyProxyOperation.java
@@ -2,7 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolCallOperations;
-import io.tarantool.driver.api.space.options.ReplaceOptions;
+import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
@@ -12,17 +12,16 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Proxy operation for replace
+ * Proxy operation for inserting many records at once
  *
  * @param <T> result type
  * @param <R> result collection type
- * @author Sergey Volgin
- * @author Artyom Dubinin
+ * @author Alexey Kuzin
  */
-public final class ReplaceProxyOperation<T extends Packable, R extends Collection<T>>
+public final class InsertManyProxyOperation<T extends Packable, R extends Collection<T>>
         extends AbstractProxyOperation<R> {
 
-    ReplaceProxyOperation(TarantoolCallOperations client,
+    InsertManyProxyOperation(TarantoolCallOperations client,
                           String functionName,
                           List<?> arguments,
                           MessagePackObjectMapper argumentsMapper,
@@ -34,8 +33,8 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
      * The builder for this class.
      */
     public static final class Builder<T extends Packable, R extends Collection<T>>
-            extends GenericOperationsBuilder<R, ReplaceOptions, Builder<T, R>> {
-        private T tuple;
+        extends GenericOperationsBuilder<R, InsertManyOptions, Builder<T, R>> {
+        private Collection<T> tuples;
 
         public Builder() {
         }
@@ -45,19 +44,25 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
             return this;
         }
 
-        public Builder<T, R> withTuple(T tuple) {
-            this.tuple = tuple;
+        public Builder<T, R> withTuples(Collection<T> tuples) {
+            this.tuples = tuples;
             return this;
         }
 
-        public ReplaceProxyOperation<T, R> build() {
-            CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
+        public InsertManyProxyOperation<T, R> build() {
+            if (tuples == null) {
+                throw new IllegalArgumentException("Tuples must be specified for batch insert operation");
+            }
+
+            CRUDBatchOptions requestOptions = new CRUDBatchOptions.Builder()
                     .withTimeout(options.getTimeout())
+                    .withStopOnError(options.getStopOnError())
+                    .withRollbackOnError(options.getRollbackOnError())
                     .build();
 
-            List<?> arguments = Arrays.asList(spaceName, tuple, requestOptions.asMap());
+            List<?> arguments = Arrays.asList(spaceName, tuples, requestOptions.asMap());
 
-            return new ReplaceProxyOperation<>(
+            return new InsertManyProxyOperation<>(
                     this.client, this.functionName, arguments, this.argumentsMapper, this.resultMapper);
         }
     }

--- a/src/main/java/io/tarantool/driver/core/proxy/InsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/InsertProxyOperation.java
@@ -2,6 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolCallOperations;
+import io.tarantool.driver.api.space.options.InsertOptions;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
@@ -32,7 +33,7 @@ public final class InsertProxyOperation<T extends Packable, R extends Collection
      * The builder for this class.
      */
     public static final class Builder<T extends Packable, R extends Collection<T>>
-            extends GenericOperationsBuilder<R, Builder<T, R>> {
+            extends GenericOperationsBuilder<R, InsertOptions, Builder<T, R>> {
         private T tuple;
 
         public Builder() {
@@ -50,8 +51,7 @@ public final class InsertProxyOperation<T extends Packable, R extends Collection
 
         public InsertProxyOperation<T, R> build() {
             CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
-                    .withTimeout(requestTimeout)
-                    .withOptions(options)
+                    .withTimeout(options.getTimeout())
                     .build();
 
             List<?> arguments = Arrays.asList(spaceName, tuple, requestOptions.asMap());

--- a/src/main/java/io/tarantool/driver/core/proxy/ProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/ProxyOperation.java
@@ -9,6 +9,10 @@ import java.util.concurrent.CompletableFuture;
  * @author Sergey Volgin
  */
 public interface ProxyOperation<T> {
-
+    /**
+     * Perform operation.
+     *
+     * @return a future with operation result
+     */
     CompletableFuture<T> execute();
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/ReplaceManyProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/ReplaceManyProxyOperation.java
@@ -2,7 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolCallOperations;
-import io.tarantool.driver.api.space.options.ReplaceOptions;
+import io.tarantool.driver.api.space.options.ReplaceManyOptions;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
@@ -12,17 +12,16 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Proxy operation for replace
+ * Proxy operation for replacing many records at once
  *
  * @param <T> result type
  * @param <R> result collection type
- * @author Sergey Volgin
- * @author Artyom Dubinin
+ * @author Alexey Kuzin
  */
-public final class ReplaceProxyOperation<T extends Packable, R extends Collection<T>>
+public final class ReplaceManyProxyOperation<T extends Packable, R extends Collection<T>>
         extends AbstractProxyOperation<R> {
 
-    ReplaceProxyOperation(TarantoolCallOperations client,
+    ReplaceManyProxyOperation(TarantoolCallOperations client,
                           String functionName,
                           List<?> arguments,
                           MessagePackObjectMapper argumentsMapper,
@@ -34,8 +33,8 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
      * The builder for this class.
      */
     public static final class Builder<T extends Packable, R extends Collection<T>>
-            extends GenericOperationsBuilder<R, ReplaceOptions, Builder<T, R>> {
-        private T tuple;
+        extends GenericOperationsBuilder<R, ReplaceManyOptions, Builder<T, R>> {
+        private Collection<T> tuples;
 
         public Builder() {
         }
@@ -45,19 +44,25 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
             return this;
         }
 
-        public Builder<T, R> withTuple(T tuple) {
-            this.tuple = tuple;
+        public Builder<T, R> withTuples(Collection<T> tuples) {
+            this.tuples = tuples;
             return this;
         }
 
-        public ReplaceProxyOperation<T, R> build() {
-            CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
+        public ReplaceManyProxyOperation<T, R> build() {
+            if (tuples == null) {
+                throw new IllegalArgumentException("Tuples must be specified for batch replace operation");
+            }
+
+            CRUDBatchOptions requestOptions = new CRUDBatchOptions.Builder()
                     .withTimeout(options.getTimeout())
+                    .withStopOnError(options.getStopOnError())
+                    .withRollbackOnError(options.getRollbackOnError())
                     .build();
 
-            List<?> arguments = Arrays.asList(spaceName, tuple, requestOptions.asMap());
+            List<?> arguments = Arrays.asList(spaceName, tuples, requestOptions.asMap());
 
-            return new ReplaceProxyOperation<>(
+            return new ReplaceManyProxyOperation<>(
                     this.client, this.functionName, arguments, this.argumentsMapper, this.resultMapper);
         }
     }

--- a/src/main/java/io/tarantool/driver/core/proxy/SelectProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/SelectProxyOperation.java
@@ -5,11 +5,13 @@ import io.tarantool.driver.api.TarantoolCallOperations;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
+import io.tarantool.driver.api.space.options.SelectOptions;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Proxy operation for select
@@ -31,7 +33,8 @@ public final class SelectProxyOperation<T> extends AbstractProxyOperation<T> {
     /**
      * The builder for this class.
      */
-    public static final class Builder<T> extends GenericOperationsBuilder<T, Builder<T>> {
+    public static final class Builder<T>
+        extends GenericOperationsBuilder<T, SelectOptions, Builder<T>> {
         private final TarantoolMetadataOperations operations;
         private final TarantoolSpaceMetadata metadata;
         private Conditions conditions;
@@ -53,11 +56,10 @@ public final class SelectProxyOperation<T> extends AbstractProxyOperation<T> {
 
         public SelectProxyOperation<T> build() {
             CRUDSelectOptions.Builder requestOptions = new CRUDSelectOptions.Builder()
-                    .withTimeout(requestTimeout)
-                    .withSelectBatchSize(conditions.getLimit())
-                    .withSelectLimit(conditions.getLimit())
-                    .withSelectAfter(conditions.getStartTuple())
-                    .withOptions(options);
+                    .withTimeout(options.getTimeout())
+                    .withSelectBatchSize(options.getBatchSize())
+                    .withSelectLimit(Optional.of(conditions.getLimit()))
+                    .withSelectAfter(Optional.ofNullable(conditions.getStartTuple()));
 
             List<?> arguments = Arrays.asList(
                     spaceName,

--- a/src/main/java/io/tarantool/driver/core/proxy/TruncateProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/TruncateProxyOperation.java
@@ -2,6 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.TarantoolCallOperations;
 import io.tarantool.driver.api.TarantoolVoidResult;
+import io.tarantool.driver.api.space.options.OperationWithTimeoutOptions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -54,7 +55,9 @@ public final class TruncateProxyOperation implements ProxyOperation<Void> {
         return new Builder();
     }
 
-    public static final class Builder extends AbstractProxyOperation.GenericOperationsBuilder<Void, Builder> {
+    public static final class Builder
+        extends AbstractProxyOperation.GenericOperationsBuilder<Void, OperationWithTimeoutOptions, Builder> {
+
         public Builder() {
         }
 
@@ -68,11 +71,11 @@ public final class TruncateProxyOperation implements ProxyOperation<Void> {
          * @return TruncateProxyOperation instance
          */
         public TruncateProxyOperation build() {
-            CRUDBaseOptions options = new CRUDBaseOptions.Builder()
-                    .withTimeout(requestTimeout)
+            CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
+                    .withTimeout(options.getTimeout())
                     .build();
 
-            List<?> arguments = Arrays.asList(spaceName, options.asMap());
+            List<?> arguments = Arrays.asList(spaceName, requestOptions.asMap());
 
             return new TruncateProxyOperation(this.client, this.functionName, arguments);
         }

--- a/src/main/java/io/tarantool/driver/core/proxy/UpdateProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/UpdateProxyOperation.java
@@ -2,6 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolCallOperations;
+import io.tarantool.driver.api.space.options.UpdateOptions;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
@@ -30,7 +31,8 @@ public final class UpdateProxyOperation<T> extends AbstractProxyOperation<T> {
     /**
      * The builder for this class.
      */
-    public static final class Builder<T> extends GenericOperationsBuilder<T, Builder<T>> {
+    public static final class Builder<T>
+        extends GenericOperationsBuilder<T, UpdateOptions, Builder<T>> {
         private TarantoolIndexQuery indexQuery;
         private TupleOperations operations;
 
@@ -54,8 +56,7 @@ public final class UpdateProxyOperation<T> extends AbstractProxyOperation<T> {
 
         public UpdateProxyOperation<T> build() {
             CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
-                    .withTimeout(requestTimeout)
-                    .withOptions(options)
+                    .withTimeout(options.getTimeout())
                     .build();
 
             List<?> arguments = Arrays.asList(spaceName,

--- a/src/main/java/io/tarantool/driver/core/proxy/UpsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/UpsertProxyOperation.java
@@ -2,6 +2,7 @@ package io.tarantool.driver.core.proxy;
 
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolCallOperations;
+import io.tarantool.driver.api.space.options.UpsertOptions;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
@@ -33,7 +34,7 @@ public final class UpsertProxyOperation<T extends Packable, R extends Collection
      * The builder for this class.
      */
     public static final class Builder<T extends Packable, R extends Collection<T>>
-            extends GenericOperationsBuilder<R, Builder<T, R>> {
+            extends GenericOperationsBuilder<R, UpsertOptions, Builder<T, R>> {
         private T tuple;
         private TupleOperations operations;
 
@@ -57,8 +58,7 @@ public final class UpsertProxyOperation<T extends Packable, R extends Collection
 
         public UpsertProxyOperation<T, R> build() {
             CRUDBaseOptions requestOptions = new CRUDBaseOptions.Builder()
-                    .withTimeout(requestTimeout)
-                    .withOptions(options)
+                    .withTimeout(options.getTimeout())
                     .build();
 
             List<?> arguments = Arrays.asList(

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
@@ -9,16 +9,29 @@ import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.proxy.ProxyOperationsMappingConfig;
 import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.DeleteOptions;
+import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.InsertOptions;
+import io.tarantool.driver.api.space.options.ReplaceManyOptions;
 import io.tarantool.driver.api.space.options.ReplaceOptions;
 import io.tarantool.driver.api.space.options.SelectOptions;
 import io.tarantool.driver.api.space.options.UpdateOptions;
 import io.tarantool.driver.api.space.options.UpsertOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyDeleteOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyInsertManyOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyInsertOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyReplaceManyOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyReplaceOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxySelectOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyTruncateOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyUpdateOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyUpsertOptions;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.core.proxy.DeleteProxyOperation;
 import io.tarantool.driver.core.proxy.InsertProxyOperation;
+import io.tarantool.driver.core.proxy.InsertManyProxyOperation;
 import io.tarantool.driver.core.proxy.ProxyOperation;
 import io.tarantool.driver.core.proxy.ReplaceProxyOperation;
+import io.tarantool.driver.core.proxy.ReplaceManyProxyOperation;
 import io.tarantool.driver.core.proxy.SelectProxyOperation;
 import io.tarantool.driver.core.proxy.TruncateProxyOperation;
 import io.tarantool.driver.core.proxy.UpdateProxyOperation;
@@ -64,11 +77,16 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> delete(Conditions conditions) throws TarantoolClientException {
-        return delete(conditions, tupleResultMapper(), null);
+        return delete(conditions, tupleResultMapper(), ProxyDeleteOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> delete(Conditions conditions, DeleteOptions options) throws TarantoolClientException {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return delete(conditions, tupleResultMapper(), options);
     }
 
@@ -85,7 +103,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withIndexQuery(indexQuery)
                 .withArgumentsMapper(config.getMessagePackMapper())
                 .withResultMapper(resultMapper)
-                .withRequestTimeout(config.getRequestTimeout())
                 .withOptions(options)
                 .build();
 
@@ -94,11 +111,16 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> insert(T tuple) throws TarantoolClientException {
-        return insert(tuple, tupleResultMapper(), null);
+        return insert(tuple, tupleResultMapper(), ProxyInsertOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> insert(T tuple, InsertOptions options) throws TarantoolClientException {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return insert(tuple, tupleResultMapper(), options);
     }
 
@@ -113,7 +135,41 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withTuple(tuple)
                 .withArgumentsMapper(config.getMessagePackMapper())
                 .withResultMapper(resultMapper)
-                .withRequestTimeout(config.getRequestTimeout())
+                .withOptions(options)
+                .build();
+
+        return executeOperation(operation);
+    }
+
+    @Override
+    public CompletableFuture<R> insertMany(Collection<T> tuples) {
+        return insertMany(tuples, tupleResultMapper(), ProxyInsertManyOptions.create()
+            .withTimeout(config.getRequestTimeout())
+            .withStopOnError(true)
+            .withRollbackOnError(true)
+        );
+    }
+
+    @Override
+    public CompletableFuture<R> insertMany(Collection<T> tuples, InsertManyOptions options)
+            throws TarantoolClientException {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
+        return insertMany(tuples, tupleResultMapper(), options);
+    }
+
+    private CompletableFuture<R> insertMany(Collection<T> tuples,
+                                            CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+                                            InsertManyOptions options)
+            throws TarantoolClientException {
+        InsertManyProxyOperation<T, R> operation = new InsertManyProxyOperation.Builder<T, R>()
+                .withClient(client)
+                .withSpaceName(spaceName)
+                .withFunctionName(operationsMapping.getInsertManyFunctionName())
+                .withTuples(tuples)
+                .withArgumentsMapper(config.getMessagePackMapper())
+                .withResultMapper(resultMapper)
                 .withOptions(options)
                 .build();
 
@@ -122,11 +178,16 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> replace(T tuple) throws TarantoolClientException {
-        return replace(tuple, tupleResultMapper(), null);
+        return replace(tuple, tupleResultMapper(), ProxyReplaceOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> replace(T tuple, ReplaceOptions options) throws TarantoolClientException {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return replace(tuple, tupleResultMapper(), options);
     }
 
@@ -141,7 +202,40 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withTuple(tuple)
                 .withArgumentsMapper(config.getMessagePackMapper())
                 .withResultMapper(resultMapper)
-                .withRequestTimeout(config.getRequestTimeout())
+                .withOptions(options)
+                .build();
+
+        return executeOperation(operation);
+    }
+
+    @Override
+    public CompletableFuture<R> replaceMany(Collection<T> tuples) throws TarantoolClientException {
+        return replaceMany(tuples, tupleResultMapper(), ProxyReplaceManyOptions.create()
+            .withTimeout(config.getRequestTimeout())
+            .withStopOnError(true)
+            .withRollbackOnError(true)
+        );
+    }
+
+    @Override
+    public CompletableFuture<R> replaceMany(Collection<T> tuples, ReplaceManyOptions options) {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
+        return replaceMany(tuples, tupleResultMapper(), options);
+    }
+
+    private CompletableFuture<R> replaceMany(Collection<T> tuples,
+                                             CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+                                             ReplaceManyOptions options)
+            throws TarantoolClientException {
+        ReplaceManyProxyOperation<T, R> operation = new ReplaceManyProxyOperation.Builder<T, R>()
+                .withClient(client)
+                .withSpaceName(spaceName)
+                .withFunctionName(operationsMapping.getReplaceManyFunctionName())
+                .withTuples(tuples)
+                .withArgumentsMapper(config.getMessagePackMapper())
+                .withResultMapper(resultMapper)
                 .withOptions(options)
                 .build();
 
@@ -150,12 +244,17 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> select(Conditions conditions) throws TarantoolClientException {
-        return select(conditions, tupleResultMapper(), null);
+        return select(conditions, tupleResultMapper(), ProxySelectOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> select(Conditions conditions,
                                        SelectOptions options) throws TarantoolClientException {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return select(conditions, tupleResultMapper(), options);
     }
 
@@ -163,7 +262,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                                         CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
                                         SelectOptions options)
             throws TarantoolClientException {
-
         SelectProxyOperation<R> operation = new SelectProxyOperation.Builder<R>(metadataOperations, spaceMetadata)
                 .withClient(client)
                 .withSpaceName(spaceName)
@@ -172,7 +270,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withOptions(options)
                 .withArgumentsMapper(config.getMessagePackMapper())
                 .withResultMapper(resultMapper)
-                .withRequestTimeout(config.getRequestTimeout())
+                .withOptions(options)
                 .build();
 
         return executeOperation(operation);
@@ -180,11 +278,16 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, T tuple) {
-        return update(conditions, makeOperationsFromTuple(tuple), tupleResultMapper(), null);
+        return update(conditions, makeOperationsFromTuple(tuple), tupleResultMapper(), ProxyUpdateOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, T tuple, UpdateOptions options) {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return update(conditions, makeOperationsFromTuple(tuple), tupleResultMapper(), options);
     }
 
@@ -198,11 +301,16 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, TupleOperations operations) {
-        return update(conditions, operations, tupleResultMapper(), null);
+        return update(conditions, operations, tupleResultMapper(), ProxyUpdateOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, TupleOperations operations, UpdateOptions options) {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return update(conditions, operations, tupleResultMapper(), options);
     }
 
@@ -220,7 +328,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withTupleOperation(operations)
                 .withArgumentsMapper(config.getMessagePackMapper())
                 .withResultMapper(resultMapper)
-                .withRequestTimeout(config.getRequestTimeout())
                 .withOptions(options)
                 .build();
 
@@ -229,12 +336,17 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> upsert(Conditions conditions, T tuple, TupleOperations operations) {
-        return upsert(conditions, tuple, operations, tupleResultMapper(), null);
+        return upsert(conditions, tuple, operations, tupleResultMapper(), ProxyUpsertOptions.create()
+            .withTimeout(config.getRequestTimeout())
+        );
     }
 
     @Override
     public CompletableFuture<R> upsert(Conditions conditions, T tuple, TupleOperations operations,
                                        UpsertOptions options) {
+        if (options == null) {
+            throw new IllegalArgumentException("Options should not be null");
+        }
         return upsert(conditions, tuple, operations, tupleResultMapper(), options);
     }
 
@@ -252,7 +364,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withTupleOperation(operations)
                 .withArgumentsMapper(config.getMessagePackMapper())
                 .withResultMapper(resultMapper)
-                .withRequestTimeout(config.getRequestTimeout())
                 .withOptions(options)
                 .build();
 
@@ -266,7 +377,9 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                     .withClient(client)
                     .withSpaceName(spaceName)
                     .withFunctionName(operationsMapping.getTruncateFunctionName())
-                    .withRequestTimeout(config.getRequestTimeout())
+                    .withOptions(ProxyTruncateOptions.create()
+                        .withTimeout(config.getRequestTimeout())
+                    )
                     .build()
             );
         } catch (TarantoolClientException e) {

--- a/src/main/java/io/tarantool/driver/core/space/RetryingTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/RetryingTarantoolSpace.java
@@ -7,7 +7,9 @@ import io.tarantool.driver.api.retry.RequestRetryPolicy;
 import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
 import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.DeleteOptions;
+import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.InsertOptions;
+import io.tarantool.driver.api.space.options.ReplaceManyOptions;
 import io.tarantool.driver.api.space.options.ReplaceOptions;
 import io.tarantool.driver.api.space.options.SelectOptions;
 import io.tarantool.driver.api.space.options.UpdateOptions;
@@ -73,6 +75,17 @@ public class RetryingTarantoolSpace<T extends Packable, R extends Collection<T>>
     }
 
     @Override
+    public CompletableFuture<R> insertMany(Collection<T> tuples) throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.insertMany(tuples));
+    }
+
+    @Override
+    public CompletableFuture<R> insertMany(Collection<T> tuples, InsertManyOptions options)
+            throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.insertMany(tuples, options));
+    }
+
+    @Override
     public CompletableFuture<R> replace(T tuple)
             throws TarantoolClientException {
         return wrapOperation(() -> spaceOperations.replace(tuple));
@@ -82,6 +95,18 @@ public class RetryingTarantoolSpace<T extends Packable, R extends Collection<T>>
     public CompletableFuture<R> replace(T tuple, ReplaceOptions options)
             throws TarantoolClientException {
         return wrapOperation(() -> spaceOperations.replace(tuple, options));
+    }
+
+    @Override
+    public CompletableFuture<R> replaceMany(Collection<T> tuples)
+            throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.replaceMany(tuples));
+    }
+
+    @Override
+    public CompletableFuture<R> replaceMany(Collection<T> tuples, ReplaceManyOptions options)
+            throws TarantoolClientException {
+        return wrapOperation(() -> spaceOperations.replaceMany(tuples, options));
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
@@ -85,6 +85,14 @@ public abstract class TarantoolSpace<T extends Packable, R extends Collection<T>
         return insert(tuple, tupleResultMapper());
     }
 
+    @Override
+    public CompletableFuture<R> insertMany(Collection<T> tuples) throws TarantoolClientException {
+        // TODO: add support with interactive transactions if the node has the MVCC mode enabled
+        // TODO: add support in all other cases if https://github.com/tarantool/tarantool/issues/7691 is implemented
+        throw new UnsupportedOperationException(
+            "Standalone node API does not support inserting several tuples at once yet");
+    }
+
     private CompletableFuture<R> insert(T tuple, MessagePackValueMapper resultMapper)
             throws TarantoolClientException {
         try {
@@ -102,6 +110,14 @@ public abstract class TarantoolSpace<T extends Packable, R extends Collection<T>
     @Override
     public CompletableFuture<R> replace(T tuple) throws TarantoolClientException {
         return replace(tuple, tupleResultMapper());
+    }
+
+    @Override
+    public CompletableFuture<R> replaceMany(Collection<T> tuples) throws TarantoolClientException {
+        // TODO: add support with interactive transactions if the node has the MVCC mode enabled
+        // TODO: add support in all other cases if https://github.com/tarantool/tarantool/issues/7691 is implemented
+        throw new UnsupportedOperationException(
+            "Standalone node API does not support replacing several tuples at once yet");
     }
 
     private CompletableFuture<R> replace(T tuple, MessagePackValueMapper resultMapper)

--- a/src/test/java/io/tarantool/driver/core/proxy/CRUDOperationOptionsTest.java
+++ b/src/test/java/io/tarantool/driver/core/proxy/CRUDOperationOptionsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -30,24 +31,24 @@ public class CRUDOperationOptionsTest {
         TarantoolTuple tuple = new TarantoolTupleImpl(values, defaultMapper);
 
         CRUDSelectOptions options = new CRUDSelectOptions.Builder()
-                .withTimeout(1000)
-                .withSelectLimit(50)
-                .withSelectBatchSize(10)
-                .withSelectAfter(tuple)
+                .withTimeout(Optional.of(1000))
+                .withSelectLimit(Optional.of(50L))
+                .withSelectBatchSize(Optional.of(10))
+                .withSelectAfter(Optional.of(tuple))
                 .build();
 
         assertEquals(4, options.asMap().size());
 
         assertEquals(1000, options.asMap().get(CRUDBaseOptions.TIMEOUT));
         assertEquals(50L, options.asMap().get(CRUDSelectOptions.SELECT_LIMIT));
-        assertEquals(10L, options.asMap().get(CRUDSelectOptions.SELECT_BATCH_SIZE));
+        assertEquals(10, options.asMap().get(CRUDSelectOptions.SELECT_BATCH_SIZE));
         assertEquals(tuple, options.asMap().get(CRUDSelectOptions.SELECT_AFTER));
     }
 
     @Test
     public void baseOperationOptions_createNotEmptyTest() {
         CRUDBaseOptions options = new CRUDBaseOptions.Builder()
-                .withTimeout(1000)
+                .withTimeout(Optional.of(1000))
                 .build();
 
         assertEquals(1, options.asMap().size());
@@ -57,8 +58,8 @@ public class CRUDOperationOptionsTest {
     @Test
     public void batchOperationOptions_createNotEmptyTest() {
         CRUDBatchOptions options = new CRUDBatchOptions.Builder()
-                .withStopOnError(false)
-                .withRollbackOnError(true)
+                .withStopOnError(Optional.of(false))
+                .withRollbackOnError(Optional.of(true))
                 .build();
 
         assertEquals(2, options.asMap().size());

--- a/src/test/java/io/tarantool/driver/core/proxy/CRUDOperationOptionsTest.java
+++ b/src/test/java/io/tarantool/driver/core/proxy/CRUDOperationOptionsTest.java
@@ -53,4 +53,16 @@ public class CRUDOperationOptionsTest {
         assertEquals(1, options.asMap().size());
         assertEquals(1000, options.asMap().get(CRUDBaseOptions.TIMEOUT));
     }
+
+    @Test
+    public void batchOperationOptions_createNotEmptyTest() {
+        CRUDBatchOptions options = new CRUDBatchOptions.Builder()
+                .withStopOnError(false)
+                .withRollbackOnError(true)
+                .build();
+
+        assertEquals(2, options.asMap().size());
+        assertEquals(false, options.asMap().get(CRUDBatchOptions.BATCH_STOP_ON_ERROR));
+        assertEquals(true, options.asMap().get(CRUDBatchOptions.BATCH_ROLLBACK_ON_ERROR));
+    }
 }

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -179,6 +179,24 @@ public class ClusterTarantoolTupleClientIT {
     }
 
     @Test
+    public void test_insertMany_shouldThrowException() throws Exception {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(TEST_SPACE_NAME);
+
+        assertThrows(UnsupportedOperationException.class,
+                     () -> testSpace.insertMany(Collections.emptyList()));
+    }
+
+    @Test
+    public void test_replaceMany_shouldThrowException() throws Exception {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+                client.space(TEST_SPACE_NAME);
+
+        assertThrows(UnsupportedOperationException.class,
+                     () -> testSpace.replaceMany(Collections.emptyList()));
+    }
+
+    @Test
     public void deleteRequest() throws Exception {
         TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
                 client.space(TEST_SPACE_NAME);

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceDeleteOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceDeleteOptionsIT.java
@@ -5,15 +5,12 @@ import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.space.TarantoolSpaceOperations;
-import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
-import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.core.ClusterTarantoolTupleClient;
 import io.tarantool.driver.core.ProxyTarantoolTupleClient;
 import io.tarantool.driver.api.space.options.proxy.ProxyDeleteOptions;
 import io.tarantool.driver.integration.SharedCartridgeContainer;
-import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,9 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ProxySpaceDeleteOptionsIT extends SharedCartridgeContainer {
 
     private static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
-    private static final DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
-    private static final TarantoolTupleFactory tupleFactory =
-            new DefaultTarantoolTupleFactory(mapperFactory.defaultComplexTypesMapper());
 
     public static String USER_NAME;
     public static String PASSWORD;
@@ -85,8 +79,8 @@ public class ProxySpaceDeleteOptionsIT extends SharedCartridgeContainer {
 
         // with option timeout
         profileSpace.delete(
-                conditions,
-                ProxyDeleteOptions.create().withTimeout(customRequestTimeout)
+            conditions,
+            ProxyDeleteOptions.create().withTimeout(customRequestTimeout)
         ).get();
         crudDeleteOpts = client.eval("return crud_delete_opts").get();
         assertEquals(customRequestTimeout, ((HashMap) crudDeleteOpts.get(0)).get("timeout"));

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertManyOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertManyOptionsIT.java
@@ -10,13 +10,15 @@ import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.core.ClusterTarantoolTupleClient;
 import io.tarantool.driver.core.ProxyTarantoolTupleClient;
-import io.tarantool.driver.api.space.options.proxy.ProxyReplaceOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyInsertManyOptions;
 import io.tarantool.driver.integration.SharedCartridgeContainer;
 import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -24,9 +26,9 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Artyom Dubinin
+ * @author Alexey Kuzin
  */
-public class ProxySpaceReplaceOptionsIT extends SharedCartridgeContainer {
+public class ProxySpaceInsertManyOptionsIT extends SharedCartridgeContainer {
 
     private static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
     private static final DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
@@ -68,6 +70,39 @@ public class ProxySpaceReplaceOptionsIT extends SharedCartridgeContainer {
     }
 
     @Test
+    public void withStopOnError_withRollbackOnError() throws ExecutionException, InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+                client.space(TEST_SPACE_NAME);
+
+        List<TarantoolTuple> tarantoolTuples = Arrays.asList(
+            tupleFactory.create(1, null, "FIO", 50, 100),
+            tupleFactory.create(2, null, "KEK", 75, 125)
+        );
+
+        // with default values
+        profileSpace.insertMany(tarantoolTuples).get();
+        List<?> crudInsertManyOpts = client.eval("return crud_insert_many_opts").get();
+        assertEquals(true, ((HashMap) crudInsertManyOpts.get(0)).get("rollback_on_error"));
+        assertEquals(true, ((HashMap) crudInsertManyOpts.get(0)).get("stop_on_error"));
+
+        // with custom values
+        tarantoolTuples = Arrays.asList(
+            tupleFactory.create(3, null, "FIO", 50, 100),
+            tupleFactory.create(4, null, "KEK", 75, 125)
+        );
+
+        profileSpace.insertMany(
+            tarantoolTuples,
+            ProxyInsertManyOptions.create()
+                .withRollbackOnError(false)
+                .withStopOnError(false)
+        ).get();
+        crudInsertManyOpts = client.eval("return crud_insert_many_opts").get();
+        assertEquals(false, ((HashMap) crudInsertManyOpts.get(0)).get("rollback_on_error"));
+        assertEquals(false, ((HashMap) crudInsertManyOpts.get(0)).get("stop_on_error"));
+    }
+
+    @Test
     public void withTimeout() throws ExecutionException, InterruptedException {
         TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
                 client.space(TEST_SPACE_NAME);
@@ -75,19 +110,27 @@ public class ProxySpaceReplaceOptionsIT extends SharedCartridgeContainer {
         int requestConfigTimeout = client.getConfig().getRequestTimeout();
         int customRequestTimeout = requestConfigTimeout * 2;
 
-        TarantoolTuple tarantoolTuple = tupleFactory.create(1, null, "FIO", 50, 100);
+        List<TarantoolTuple> tarantoolTuples = Arrays.asList(
+            tupleFactory.create(1, null, "FIO", 50, 100),
+            tupleFactory.create(2, null, "KEK", 75, 125)
+        );
 
         // with config timeout
-        profileSpace.replace(tarantoolTuple).get();
-        List<?> crudReplaceOpts = client.eval("return crud_replace_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudReplaceOpts.get(0)).get("timeout"));
+        profileSpace.insertMany(tarantoolTuples).get();
+        List<?> crudInsertManyOpts = client.eval("return crud_insert_many_opts").get();
+        assertEquals(requestConfigTimeout, ((HashMap) crudInsertManyOpts.get(0)).get("timeout"));
 
         // with option timeout
-        profileSpace.replace(
-                tarantoolTuple,
-                ProxyReplaceOptions.create().withTimeout(customRequestTimeout)
+        tarantoolTuples = Arrays.asList(
+            tupleFactory.create(3, null, "FIO", 50, 100),
+            tupleFactory.create(4, null, "KEK", 75, 125)
+        );
+
+        profileSpace.insertMany(
+            tarantoolTuples,
+            ProxyInsertManyOptions.create().withTimeout(customRequestTimeout)
         ).get();
-        crudReplaceOpts = client.eval("return crud_replace_opts").get();
-        assertEquals(customRequestTimeout, ((HashMap) crudReplaceOpts.get(0)).get("timeout"));
+        crudInsertManyOpts = client.eval("return crud_insert_many_opts").get();
+        assertEquals(customRequestTimeout, ((HashMap) crudInsertManyOpts.get(0)).get("timeout"));
     }
 }

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceSelectOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceSelectOptionsIT.java
@@ -87,10 +87,13 @@ public class ProxySpaceSelectOptionsIT extends SharedCartridgeContainer {
         TarantoolResult<TarantoolTuple> selectResult = profileSpace.select(conditions).get();
         assertEquals(10, selectResult.size());
         List<?> crudSelectOpts = client.eval("return crud_select_opts").get();
-        assertEquals(10, ((HashMap) crudSelectOpts.get(0)).get("batch_size"));
+        assertEquals(null, ((HashMap) crudSelectOpts.get(0)).get("batch_size"));
 
         // with batchSize
-        selectResult = profileSpace.select(conditions, ProxySelectOptions.create().withBatchSize(5)).get();
+        selectResult = profileSpace.select(
+            conditions,
+            ProxySelectOptions.create().withBatchSize(5)
+        ).get();
         assertEquals(10, selectResult.size());
         crudSelectOpts = client.eval("return crud_select_opts").get();
         assertEquals(5, ((HashMap) crudSelectOpts.get(0)).get("batch_size"));

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpsertOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpsertOptionsIT.java
@@ -88,11 +88,11 @@ public class ProxySpaceUpsertOptionsIT extends SharedCartridgeContainer {
 
         // with option timeout
         profileSpace.upsert(
-                conditions,
-                tarantoolTuple,
-                TupleOperations.set("age", 50),
-                ProxyUpsertOptions.create().withTimeout(customRequestTimeout)
-                           ).get();
+            conditions,
+            tarantoolTuple,
+            TupleOperations.set("age", 50),
+            ProxyUpsertOptions.create().withTimeout(customRequestTimeout)
+        ).get();
         crudUpsertOpts = client.eval("return crud_upsert_opts").get();
         assertEquals(customRequestTimeout, ((HashMap) crudUpsertOpts.get(0)).get("timeout"));
     }

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -19,7 +19,9 @@ local crud_methods_to_patch = {
     'select',
     'delete',
     'insert',
+    'insert_many',
     'replace',
+    'replace_many',
     'update',
     'upsert',
 }

--- a/src/test/resources/cartridge/testapp-scm-1.rockspec
+++ b/src/test/resources/cartridge/testapp-scm-1.rockspec
@@ -8,7 +8,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'cartridge == 2.7.3-1',
-    'crud == 0.10.0-1',
+    'crud == 0.14.0-1',
 }
 build = {
     type = 'none';


### PR DESCRIPTION
This patch adds support for [insert_many](https://github.com/tarantool/crud#insert-many) and [replace_many](https://github.com/tarantool/crud#replace-many) CRUD operations.
Limitations: the `rollbackOnError` and `stopOnError` options are set to `true` and are not user-configurable now. But it corresponds to the main user scenario. Configuring these parameters will be possible after #254 is fully implemented.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Depends on #258 

Closes #259 
