### PR TITLE
Changes for TarantoolNullField class to singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-
+- Changed TarantoolNullField class to singleton ([#195](https://github.com/tarantool/cartridge-java/pull/275))
 ## [0.9.0] - 2022-10-03
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Changed TarantoolNullField class to singleton ([#195](https://github.com/tarantool/cartridge-java/pull/275))
+
 ## [0.9.0] - 2022-10-03
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-
+- Changed TarantoolNullField class to singleton
 ### Features
 - Added options parameter to Tarantool Space API ([#266](https://github.com/tarantool/cartridge-java/pull/266))
 - Added bucket id parameter to Tarantool Space API ([#270](https://github.com/tarantool/cartridge-java/pull/270))

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
@@ -12,7 +12,7 @@ import org.msgpack.value.ValueFactory;
  */
 public final class TarantoolNullField implements TarantoolField {
 
-    public static final TarantoolNullField EMPTY = new TarantoolNullField();
+    public static final TarantoolNullField INSTANCE = new TarantoolNullField();
 
     private TarantoolNullField() {
     }

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
@@ -12,15 +12,9 @@ import org.msgpack.value.ValueFactory;
  */
 public final class TarantoolNullField implements TarantoolField {
 
-    private static final TarantoolNullField EMPTY = new TarantoolNullField(null);
-    private final TarantoolNullField value;
+    public static final TarantoolNullField EMPTY = new TarantoolNullField();
 
-    private TarantoolNullField(TarantoolNullField value) {
-        this.value = value;
-    }
-
-    public static TarantoolNullField create() {
-        return EMPTY;
+    private TarantoolNullField() {
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
@@ -11,6 +11,17 @@ import org.msgpack.value.ValueFactory;
  * @author Alexey Kuzin
  */
 public final class TarantoolNullField implements TarantoolField {
+    private static final TarantoolNullField EMPTY = new TarantoolNullField(null);
+
+	private final TarantoolNullField value;
+
+	private TarantoolNullField(TarantoolNullField value) {
+		this.value = value;
+	}
+
+	public static TarantoolNullField empty() {
+		return EMPTY;
+	}
 
     @Override
     public Value toMessagePackValue(MessagePackObjectMapper mapper) {

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
@@ -19,7 +19,7 @@ public final class TarantoolNullField implements TarantoolField {
         this.value = value;
     }
 
-    public static TarantoolNullField empty() {
+    public static TarantoolNullField create() {
         return EMPTY;
     }
 

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolNullField.java
@@ -11,17 +11,17 @@ import org.msgpack.value.ValueFactory;
  * @author Alexey Kuzin
  */
 public final class TarantoolNullField implements TarantoolField {
+
     private static final TarantoolNullField EMPTY = new TarantoolNullField(null);
+    private final TarantoolNullField value;
 
-	private final TarantoolNullField value;
+    private TarantoolNullField(TarantoolNullField value) {
+        this.value = value;
+    }
 
-	private TarantoolNullField(TarantoolNullField value) {
-		this.value = value;
-	}
-
-	public static TarantoolNullField empty() {
-		return EMPTY;
-	}
+    public static TarantoolNullField empty() {
+        return EMPTY;
+    }
 
     @Override
     public Value toMessagePackValue(MessagePackObjectMapper mapper) {

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -93,7 +93,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(values.size());
             for (Object value : values) {
                 if (value == null) {
-                    this.fields.add(TarantoolNullField.empty());
+                    this.fields.add(TarantoolNullField.create());
                 } else {
                     this.fields.add(new TarantoolFieldImpl(value));
                 }
@@ -127,7 +127,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(value.size());
             for (Value fieldValue : value) {
                 if (fieldValue.isNilValue()) {
-                    fields.add(TarantoolNullField.empty());
+                    fields.add(TarantoolNullField.create());
                 } else {
                     fields.add(new TarantoolFieldImpl(fieldValue));
                 }
@@ -229,12 +229,12 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         }
 
         if (field == null) {
-            field = TarantoolNullField.empty();
+            field = TarantoolNullField.create();
         }
 
         if (fields.size() < fieldPosition) {
             for (int i = fields.size(); i < fieldPosition; i++) {
-                fields.add(TarantoolNullField.empty());
+                fields.add(TarantoolNullField.create());
             }
         }
 
@@ -258,7 +258,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(int fieldPosition, Object value) {
         TarantoolField tarantoolField = value == null ?
-                TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
+                TarantoolNullField.create() : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldPosition, tarantoolField);
     }
@@ -266,7 +266,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(String fieldName, Object value) {
         TarantoolField tarantoolField = value == null ?
-               TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
+               TarantoolNullField.create() : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldName, tarantoolField);
     }
@@ -443,7 +443,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         this.fields = new ArrayList<>(value.size());
         for (Value fieldValue : value) {
             if (fieldValue.isNilValue()) {
-                fields.add(TarantoolNullField.empty());
+                fields.add(TarantoolNullField.create());
             } else {
                 fields.add(new TarantoolFieldImpl(fieldValue));
             }

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -93,7 +93,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(values.size());
             for (Object value : values) {
                 if (value == null) {
-                    this.fields.add(TarantoolNullField.EMPTY);
+                    this.fields.add(TarantoolNullField.INSTANCE);
                 } else {
                     this.fields.add(new TarantoolFieldImpl(value));
                 }
@@ -127,7 +127,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(value.size());
             for (Value fieldValue : value) {
                 if (fieldValue.isNilValue()) {
-                    fields.add(TarantoolNullField.EMPTY);
+                    fields.add(TarantoolNullField.INSTANCE);
                 } else {
                     fields.add(new TarantoolFieldImpl(fieldValue));
                 }
@@ -229,12 +229,12 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         }
 
         if (field == null) {
-            field = TarantoolNullField.EMPTY;
+            field = TarantoolNullField.INSTANCE;
         }
 
         if (fields.size() < fieldPosition) {
             for (int i = fields.size(); i < fieldPosition; i++) {
-                fields.add(TarantoolNullField.EMPTY);
+                fields.add(TarantoolNullField.INSTANCE);
             }
         }
 
@@ -258,7 +258,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(int fieldPosition, Object value) {
         TarantoolField tarantoolField = value == null ?
-                TarantoolNullField.EMPTY : new TarantoolFieldImpl(mapper.toValue(value));
+                TarantoolNullField.INSTANCE : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldPosition, tarantoolField);
     }
@@ -266,7 +266,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(String fieldName, Object value) {
         TarantoolField tarantoolField = value == null ?
-               TarantoolNullField.EMPTY : new TarantoolFieldImpl(mapper.toValue(value));
+               TarantoolNullField.INSTANCE : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldName, tarantoolField);
     }
@@ -443,7 +443,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         this.fields = new ArrayList<>(value.size());
         for (Value fieldValue : value) {
             if (fieldValue.isNilValue()) {
-                fields.add(TarantoolNullField.EMPTY);
+                fields.add(TarantoolNullField.INSTANCE);
             } else {
                 fields.add(new TarantoolFieldImpl(fieldValue));
             }

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -258,7 +258,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(int fieldPosition, Object value) {
         TarantoolField tarantoolField = value == null ?
-				TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
+                TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldPosition, tarantoolField);
     }
@@ -266,7 +266,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(String fieldName, Object value) {
         TarantoolField tarantoolField = value == null ?
-				TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
+               TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldName, tarantoolField);
     }

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -93,7 +93,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(values.size());
             for (Object value : values) {
                 if (value == null) {
-                    this.fields.add(new TarantoolNullField());
+                    this.fields.add(TarantoolNullField.empty());
                 } else {
                     this.fields.add(new TarantoolFieldImpl(value));
                 }
@@ -127,7 +127,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(value.size());
             for (Value fieldValue : value) {
                 if (fieldValue.isNilValue()) {
-                    fields.add(new TarantoolNullField());
+                    fields.add(TarantoolNullField.empty());
                 } else {
                     fields.add(new TarantoolFieldImpl(fieldValue));
                 }
@@ -229,12 +229,12 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         }
 
         if (field == null) {
-            field = new TarantoolNullField();
+            field = TarantoolNullField.empty();
         }
 
         if (fields.size() < fieldPosition) {
             for (int i = fields.size(); i < fieldPosition; i++) {
-                fields.add(new TarantoolNullField());
+                fields.add(TarantoolNullField.empty());
             }
         }
 
@@ -258,7 +258,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(int fieldPosition, Object value) {
         TarantoolField tarantoolField = value == null ?
-                new TarantoolNullField() : new TarantoolFieldImpl(mapper.toValue(value));
+				TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldPosition, tarantoolField);
     }
@@ -266,7 +266,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(String fieldName, Object value) {
         TarantoolField tarantoolField = value == null ?
-                new TarantoolNullField() : new TarantoolFieldImpl(mapper.toValue(value));
+				TarantoolNullField.empty() : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldName, tarantoolField);
     }
@@ -443,7 +443,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         this.fields = new ArrayList<>(value.size());
         for (Value fieldValue : value) {
             if (fieldValue.isNilValue()) {
-                fields.add(new TarantoolNullField());
+                fields.add(TarantoolNullField.empty());
             } else {
                 fields.add(new TarantoolFieldImpl(fieldValue));
             }

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -93,7 +93,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(values.size());
             for (Object value : values) {
                 if (value == null) {
-                    this.fields.add(TarantoolNullField.create());
+                    this.fields.add(TarantoolNullField.EMPTY);
                 } else {
                     this.fields.add(new TarantoolFieldImpl(value));
                 }
@@ -127,7 +127,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
             this.fields.ensureCapacity(value.size());
             for (Value fieldValue : value) {
                 if (fieldValue.isNilValue()) {
-                    fields.add(TarantoolNullField.create());
+                    fields.add(TarantoolNullField.EMPTY);
                 } else {
                     fields.add(new TarantoolFieldImpl(fieldValue));
                 }
@@ -229,12 +229,12 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         }
 
         if (field == null) {
-            field = TarantoolNullField.create();
+            field = TarantoolNullField.EMPTY;
         }
 
         if (fields.size() < fieldPosition) {
             for (int i = fields.size(); i < fieldPosition; i++) {
-                fields.add(TarantoolNullField.create());
+                fields.add(TarantoolNullField.EMPTY);
             }
         }
 
@@ -258,7 +258,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(int fieldPosition, Object value) {
         TarantoolField tarantoolField = value == null ?
-                TarantoolNullField.create() : new TarantoolFieldImpl(mapper.toValue(value));
+                TarantoolNullField.EMPTY : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldPosition, tarantoolField);
     }
@@ -266,7 +266,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public void putObject(String fieldName, Object value) {
         TarantoolField tarantoolField = value == null ?
-               TarantoolNullField.create() : new TarantoolFieldImpl(mapper.toValue(value));
+               TarantoolNullField.EMPTY : new TarantoolFieldImpl(mapper.toValue(value));
 
         setField(fieldName, tarantoolField);
     }
@@ -443,7 +443,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
         this.fields = new ArrayList<>(value.size());
         for (Value fieldValue : value) {
             if (fieldValue.isNilValue()) {
-                fields.add(TarantoolNullField.create());
+                fields.add(TarantoolNullField.EMPTY);
             } else {
                 fields.add(new TarantoolFieldImpl(fieldValue));
             }

--- a/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
@@ -13,7 +13,7 @@ public class TarantoolNullFieldTest {
 
     @Test
     public void test_hashCode_shouldReturnHashCode() {
-        TarantoolNullField nullField = new TarantoolNullField();
+        TarantoolNullField nullField = TarantoolNullField.empty();
 
         assertNotEquals(0, nullField.hashCode());
         assertEquals(nullField.hashCode(), nullField.hashCode());
@@ -22,7 +22,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_toString_shouldReturnString() {
         // given
-        TarantoolNullField nullField = new TarantoolNullField();
+        TarantoolNullField nullField = TarantoolNullField.empty();
 
         // when
         String str = nullField.toString();
@@ -36,8 +36,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnTrue() {
         // given
-        TarantoolNullField nullField1 = new TarantoolNullField();
-        TarantoolNullField nullField2 = new TarantoolNullField();
+        TarantoolNullField nullField1 = TarantoolNullField.empty();
+        TarantoolNullField nullField2 = TarantoolNullField.empty();
 
         // then
         assertEquals(nullField1, nullField1);
@@ -47,7 +47,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnFalse() {
         // given
-        TarantoolNullField nullField = new TarantoolNullField();
+        TarantoolNullField nullField = TarantoolNullField.empty();
         Object dummyObject = new Object() { };
 
         // then
@@ -58,8 +58,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_AddNullFieldsToHashSet_shouldCreateHashSetWithOneElements() {
         // given
-        TarantoolNullField nullField1 = new TarantoolNullField();
-        TarantoolNullField nullField2 = new TarantoolNullField();
+        TarantoolNullField nullField1 = TarantoolNullField.empty();
+        TarantoolNullField nullField2 = TarantoolNullField.empty();
 
         // when
         HashSet<TarantoolNullField> fieldsSet = new HashSet<>();

--- a/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
@@ -13,7 +13,7 @@ public class TarantoolNullFieldTest {
 
     @Test
     public void test_hashCode_shouldReturnHashCode() {
-        TarantoolNullField nullField = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField = TarantoolNullField.INSTANCE;
 
         assertNotEquals(0, nullField.hashCode());
         assertEquals(nullField.hashCode(), nullField.hashCode());
@@ -22,7 +22,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_toString_shouldReturnString() {
         // given
-        TarantoolNullField nullField = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField = TarantoolNullField.INSTANCE;
 
         // when
         String str = nullField.toString();
@@ -36,8 +36,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnTrue() {
         // given
-        TarantoolNullField nullField1 = TarantoolNullField.EMPTY;
-        TarantoolNullField nullField2 = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField1 = TarantoolNullField.INSTANCE;
+        TarantoolNullField nullField2 = TarantoolNullField.INSTANCE;
 
         // then
         assertEquals(nullField1, nullField1);
@@ -47,7 +47,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnFalse() {
         // given
-        TarantoolNullField nullField = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField = TarantoolNullField.INSTANCE;
         Object dummyObject = new Object() { };
 
         // then
@@ -58,8 +58,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_AddNullFieldsToHashSet_shouldCreateHashSetWithOneElements() {
         // given
-        TarantoolNullField nullField1 = TarantoolNullField.EMPTY;
-        TarantoolNullField nullField2 = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField1 = TarantoolNullField.INSTANCE;
+        TarantoolNullField nullField2 = TarantoolNullField.INSTANCE;
 
         // when
         HashSet<TarantoolNullField> fieldsSet = new HashSet<>();

--- a/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
@@ -13,7 +13,7 @@ public class TarantoolNullFieldTest {
 
     @Test
     public void test_hashCode_shouldReturnHashCode() {
-        TarantoolNullField nullField = TarantoolNullField.create();
+        TarantoolNullField nullField = TarantoolNullField.EMPTY;
 
         assertNotEquals(0, nullField.hashCode());
         assertEquals(nullField.hashCode(), nullField.hashCode());
@@ -22,7 +22,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_toString_shouldReturnString() {
         // given
-        TarantoolNullField nullField = TarantoolNullField.create();
+        TarantoolNullField nullField = TarantoolNullField.EMPTY;
 
         // when
         String str = nullField.toString();
@@ -36,8 +36,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnTrue() {
         // given
-        TarantoolNullField nullField1 = TarantoolNullField.create();
-        TarantoolNullField nullField2 = TarantoolNullField.create();
+        TarantoolNullField nullField1 = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField2 = TarantoolNullField.EMPTY;
 
         // then
         assertEquals(nullField1, nullField1);
@@ -47,7 +47,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnFalse() {
         // given
-        TarantoolNullField nullField = TarantoolNullField.create();
+        TarantoolNullField nullField = TarantoolNullField.EMPTY;
         Object dummyObject = new Object() { };
 
         // then
@@ -58,8 +58,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_AddNullFieldsToHashSet_shouldCreateHashSetWithOneElements() {
         // given
-        TarantoolNullField nullField1 = TarantoolNullField.create();
-        TarantoolNullField nullField2 = TarantoolNullField.create();
+        TarantoolNullField nullField1 = TarantoolNullField.EMPTY;
+        TarantoolNullField nullField2 = TarantoolNullField.EMPTY;
 
         // when
         HashSet<TarantoolNullField> fieldsSet = new HashSet<>();

--- a/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/TarantoolNullFieldTest.java
@@ -13,7 +13,7 @@ public class TarantoolNullFieldTest {
 
     @Test
     public void test_hashCode_shouldReturnHashCode() {
-        TarantoolNullField nullField = TarantoolNullField.empty();
+        TarantoolNullField nullField = TarantoolNullField.create();
 
         assertNotEquals(0, nullField.hashCode());
         assertEquals(nullField.hashCode(), nullField.hashCode());
@@ -22,7 +22,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_toString_shouldReturnString() {
         // given
-        TarantoolNullField nullField = TarantoolNullField.empty();
+        TarantoolNullField nullField = TarantoolNullField.create();
 
         // when
         String str = nullField.toString();
@@ -36,8 +36,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnTrue() {
         // given
-        TarantoolNullField nullField1 = TarantoolNullField.empty();
-        TarantoolNullField nullField2 = TarantoolNullField.empty();
+        TarantoolNullField nullField1 = TarantoolNullField.create();
+        TarantoolNullField nullField2 = TarantoolNullField.create();
 
         // then
         assertEquals(nullField1, nullField1);
@@ -47,7 +47,7 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_equals_shouldReturnFalse() {
         // given
-        TarantoolNullField nullField = TarantoolNullField.empty();
+        TarantoolNullField nullField = TarantoolNullField.create();
         Object dummyObject = new Object() { };
 
         // then
@@ -58,8 +58,8 @@ public class TarantoolNullFieldTest {
     @Test
     public void test_AddNullFieldsToHashSet_shouldCreateHashSetWithOneElements() {
         // given
-        TarantoolNullField nullField1 = TarantoolNullField.empty();
-        TarantoolNullField nullField2 = TarantoolNullField.empty();
+        TarantoolNullField nullField1 = TarantoolNullField.create();
+        TarantoolNullField nullField2 = TarantoolNullField.create();
 
         // when
         HashSet<TarantoolNullField> fieldsSet = new HashSet<>();

--- a/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
@@ -118,13 +118,13 @@ public class TupleOperationsTest {
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(TarantoolNullField.empty(), operations.asList().get(1).getValue());
+        assertEquals(TarantoolNullField.create(), operations.asList().get(1).getValue());
 
         operations = TupleOperations.fromTarantoolTuple(tupleFactory.create("abc", null, null));
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(TarantoolNullField.empty(), operations.asList().get(2).getValue());
+        assertEquals(TarantoolNullField.create(), operations.asList().get(2).getValue());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
@@ -118,13 +118,13 @@ public class TupleOperationsTest {
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(TarantoolNullField.create(), operations.asList().get(1).getValue());
+        assertEquals(TarantoolNullField.EMPTY, operations.asList().get(1).getValue());
 
         operations = TupleOperations.fromTarantoolTuple(tupleFactory.create("abc", null, null));
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(TarantoolNullField.create(), operations.asList().get(2).getValue());
+        assertEquals(TarantoolNullField.EMPTY, operations.asList().get(2).getValue());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
@@ -118,13 +118,13 @@ public class TupleOperationsTest {
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(TarantoolNullField.EMPTY, operations.asList().get(1).getValue());
+        assertEquals(TarantoolNullField.INSTANCE, operations.asList().get(1).getValue());
 
         operations = TupleOperations.fromTarantoolTuple(tupleFactory.create("abc", null, null));
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(TarantoolNullField.EMPTY, operations.asList().get(2).getValue());
+        assertEquals(TarantoolNullField.INSTANCE, operations.asList().get(2).getValue());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
+++ b/src/test/java/io/tarantool/driver/api/tuple/operations/TupleOperationsTest.java
@@ -118,13 +118,13 @@ public class TupleOperationsTest {
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(new TarantoolNullField(), operations.asList().get(1).getValue());
+        assertEquals(TarantoolNullField.empty(), operations.asList().get(1).getValue());
 
         operations = TupleOperations.fromTarantoolTuple(tupleFactory.create("abc", null, null));
         fieldNumbers = operations.asList().stream().map(TupleOperation::getFieldIndex)
                 .collect(Collectors.toList());
         assertEquals(Arrays.asList(0, 1, 2), fieldNumbers);
-        assertEquals(new TarantoolNullField(), operations.asList().get(2).getValue());
+        assertEquals(TarantoolNullField.empty(), operations.asList().get(2).getValue());
     }
 
     @Test


### PR DESCRIPTION
What has been done? Why? What problem is being solved?
The `TarantoolNullField `class was not singleton and its only task it to provide functionality similar to `Optional.Empty()`.
Changes done to make `TarantoolNullField `behaves same as `Optional.Empty()`.

I didn't forget about

- [X] Tests
- [X] Changelog
- [X] Documentation
- [X] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Closes #195 