### PR TITLE
Fix scm tag in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <connection>scm:git:git@github.com/tarantool/cartridge-java.git</connection>
         <developerConnection>scm:git:git@github.com:tarantool/cartridge-java.git</developerConnection>
         <url>http://github.com/tarantool/cartridge-java/tree/master</url>
-      <tag>v0.8.1</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
I don't know why, but maven doesn't return head tag in these commits
https://github.com/tarantool/cartridge-java/commit/ce35c46086a7940ce3bad195165d4d872d385b74
https://github.com/tarantool/cartridge-java/commit/43c5c2c4aaf324e7a92d971269802f26e1fbe9c8