### PR TITLE
Fixes links in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ If you want to start tarantool application manually all you need is to run this 
 ``` bash
 tarantool src/test/resources/single-instance.lua
 ```
-
 Example of TarantoolClient set up
-https://github.com/tarantool/cartridge-java/blob/master/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleTest.java#L49-L58
+https://github.com/tarantool/cartridge-java/blob/2f8e826deb9833a5deb6d21177527a46e8fdd039/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleTest.java#L51-L59
 
 Example of client API usage
-https://github.com/tarantool/cartridge-java/blob/master/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleTest.java#L62-L74
+https://github.com/tarantool/cartridge-java/blob/2f8e826deb9833a5deb6d21177527a46e8fdd039/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleTest.java#L64-L79
 
 You can read more about Cartridge applications in its [documentation](https://www.tarantool.io/ru/doc/latest/how-to/getting_started_cartridge/).
 Also look at available Cartridge application [examples](https://github.com/tarantool/examples).
@@ -343,9 +342,9 @@ Stack Overflow with tag [tarantool](https://stackoverflow.com/questions/tagged/t
 or join our community support chats in Telegram: [English](https://t.me/tarantool)
 and [Russian](https://t.me/tarantool).
 
-## [Changelog](https://github.com/tarantool/cartridge-java/blob/master/CHANGELOG.md)
+## [Changelog](CHANGELOG.md)
 
-## [License](https://github.com/tarantool/cartridge-java/blob/master/LICENSE)
+## [License](LICENSE)
 
 ## Requirements
 

--- a/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleTest.java
+++ b/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleTest.java
@@ -27,6 +27,8 @@ import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
 
 /**
  * @author Ivan Dneprov
+ *
+ * WARNING: If you updated the code in this file, don't forget to update the readme permalinks!
  */
 @Testcontainers
 public class SingleInstanceExampleTest {


### PR DESCRIPTION
Change links to permalinks for proper document processing in GitHub Change links to local files to local links

I haven't forgotten about:
- [ ] Tests
- [ ] Changelog
- [x] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
