### PR TITLE
Add TarantoolTupleResultMapper factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `fields` option to ProxySpace ([#236](https://github.com/tarantool/cartridge-java/pull/236))
 - Move metadata parsing to separate converters ([#325](https://github.com/tarantool/cartridge-java/pull/325))
+- Add simple to use TarantoolTupleResultMapper factory ([#321](https://github.com/tarantool/cartridge-java/pull/321))
 - Parse metadata from crud response ([#272](https://github.com/tarantool/cartridge-java/pull/272))
 - Use netty part dependencies instead of netty-all ([#295](https://github.com/tarantool/cartridge-java/issues/295))
 - Refactor mappers and split `TarantoolResultConverter` ([#301](https://github.com/tarantool/cartridge-java/pull/301))

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -67,6 +67,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     private final TarantoolConnectionListeners listeners;
     private final AtomicReference<TarantoolMetadata> metadataHolder = new AtomicReference<>();
     private final ResultMapperFactoryFactoryImpl mapperFactoryFactory;
+
     private final SpacesMetadataProvider metadataProvider;
     private final ScheduledExecutorService timeoutScheduler;
     private TarantoolConnectionManager connectionManager;

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolTupleSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolTupleSpace.java
@@ -53,7 +53,7 @@ public class ProxyTarantoolTupleSpace
     @Override
     protected CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
     rowsMetadataTupleResultMapper() {
-        return client.getResultMapperFactoryFactory().singleValueTupleResultMapperFactory()
+        return client.getResultMapperFactoryFactory().getTarantoolTupleResultMapperFactory()
             .withSingleValueRowsMetadataToTarantoolTupleResultMapper(config.getMessagePackMapper(), getMetadata());
     }
 

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolTupleSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolTupleSpace.java
@@ -51,7 +51,7 @@ public class TarantoolTupleSpace extends
 
     @Override
     protected MessagePackValueMapper arrayTupleResultMapper() {
-        return client.getResultMapperFactoryFactory().arrayTupleResultMapperFactory()
+        return client.getResultMapperFactoryFactory().getTarantoolTupleResultMapperFactory()
             .withArrayValueToTarantoolTupleResultConverter(config.getMessagePackMapper(), getMetadata());
     }
 

--- a/src/main/java/io/tarantool/driver/mappers/TarantoolTupleResultMapperFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/TarantoolTupleResultMapperFactory.java
@@ -1,0 +1,141 @@
+package io.tarantool.driver.mappers;
+
+import io.tarantool.driver.api.MultiValueCallResult;
+import io.tarantool.driver.api.SingleValueCallResult;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+
+/**
+ * Provides factory that creates result mappers for parsing {@code TarantoolResult<TarantoolTuple>} from various
+ * structures
+ *
+ * @author Artyom Dubinin
+ */
+public interface TarantoolTupleResultMapperFactory {
+    /**
+     * Mapper parses result from a list of tuples.
+     * Use this mapper for handling containers with {@link TarantoolTuple} inside.
+     * The IProto method results by default contain lists of tuples.
+     * This mapper can be used at the inner level by other mapper factories that are handling higher-level containers.
+     * <p>
+     * input: array of tuples with MessagePack values inside ([t1, t2, ...])
+     * <br>
+     * mapper result: {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     * Returned TarantoolResult doesn't store metadata, and you can't get field by field name
+     *
+     * @return mapper that parses list of arrays to {@code TarantoolResult<TarantoolTuple>}
+     */
+    TarantoolResultMapper<TarantoolTuple> withArrayValueToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper);
+
+    /**
+     * Mapper parses result from a list of tuples.
+     * Use this mapper for handling containers with {@link TarantoolTuple} inside.
+     * The IProto method results by default contain lists of tuples.
+     * This mapper can be used at the inner level by other mapper factories that are handling higher-level containers.
+     * <p>
+     * input: array of tuples with MessagePack values inside ([t1, t2, ...])
+     * <br>
+     * mapper result: {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     * For example, it can be used to parse result from IPROTO_SELECT
+     *
+     * @return mapper that parses list of arrays to {@code TarantoolResult<TarantoolTuple>}
+     */
+    TarantoolResultMapper<TarantoolTuple> withArrayValueToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+
+    /**
+     * Mapper parses result from a map with list of tuples and metadata.
+     * Use this mapper for handling containers with {@link TarantoolTuple} inside.
+     * The crud method results by default contain map with list of tuples and metadata.
+     * This mapper can be used at the inner level by other mapper factories that are handling higher-level containers.
+     * <p>
+     * input: map with metadata and array of tuples with MessagePack values inside ([t1, t2, ...])
+     * <br>
+     * mapper result: {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     * Returned TarantoolResult doesn't store metadata, and you can't get field by field name
+     *
+     * @return mapper that parses map to {@code TarantoolResult<TarantoolTuple>}
+     */
+    TarantoolResultMapper<TarantoolTuple> withRowsMetadataToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper);
+
+    /**
+     * Mapper parses result from a map with list of tuples and metadata.
+     * Use this mapper for handling containers with {@link TarantoolTuple} inside.
+     * The crud method results by default contain map with list of tuples and metadata.
+     * This mapper can be used at the inner level by other mapper factories that are handling higher-level containers.
+     * <p>
+     * input: map with metadata and array of tuples with MessagePack values inside ([t1, t2, ...])
+     * <br>
+     * mapper result: {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     *
+     * @return mapper that parses map to {@code TarantoolResult<TarantoolTuple>}
+     */
+    TarantoolResultMapper<TarantoolTuple> withRowsMetadataToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+
+    /**
+     * Mapper for single the stored Lua function call result in the form <code>return result, err</code>
+     * with a list of tuples as a result.
+     * For example, this form of the result is used for some return from lua function like box.space.select
+     * <p>
+     * input: [x, y, ...], MessagePack array from a Lua function multi-return response
+     * <br>
+     * where <code>x</code> is a data structure with an array of tuples inside ([t1, t2, ...]) and <code>y</code>
+     * can be interpreted as an error structure if it is not empty and there are no more arguments after
+     * <code>y</code>`
+     * <br>
+     * mapper result: converted value of <code>x</code> to {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     * Mapper result and the inner contents depend on the parameters or the passed converters.
+     *
+     * @return default mapper for single value call result with a list of tuples
+     */
+    CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
+    withSingleValueArrayToTarantoolTupleResultMapper(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+
+    /**
+     * Mapper for single the stored Lua function call result in the form <code>return result, err</code>
+     * with a list of tuples as a result.
+     * For example, this form of the result is used for some return from lua function like crud.select
+     * <p>
+     * input: [x, y, ...], MessagePack array from a Lua function multi-return response
+     * <br>
+     * where <code>x</code> map with metadata and array of tuples with MessagePack values inside ([t1, t2, ...])
+     * <br>
+     * mapper result: converted value of <code>x</code> to {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     *
+     * @return mapper for single value call result with a list of tuples
+     */
+    CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
+    withSingleValueRowsMetadataToTarantoolTupleResultMapper(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+
+    /**
+     * Mapper for the stored Lua function call result, interpreted in a way that each returned item is a tuple.
+     * Use this factory for handling proxy function call results which return tuples as a multi-return result.
+     * <p>
+     * input: [x, y, z, ...], MessagePack array from a Lua function multi-return response
+     * <br>
+     * where <code>x, y, z</code> are some MessagePack values, each one representing a Tarantool tuple
+     * <br>
+     * mapper result: {@code TarantoolResult<TarantoolTuple>} converted from <code>[x, y, z, ...]</code>
+     * <p>
+     * Mapper result and its inner contents depend on the parameters or the passed converters.
+     *
+     * @return mapper for multi value call result as a list of tuples
+     */
+    CallResultMapper<
+        TarantoolResult<TarantoolTuple>,
+        MultiValueCallResult<TarantoolTuple, TarantoolResult<TarantoolTuple>>>
+    withMultiValueArrayToTarantoolTupleResultMapper(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+}

--- a/src/main/java/io/tarantool/driver/mappers/TarantoolTupleResultMapperFactoryImpl.java
+++ b/src/main/java/io/tarantool/driver/mappers/TarantoolTupleResultMapperFactoryImpl.java
@@ -1,0 +1,101 @@
+package io.tarantool.driver.mappers;
+
+import io.tarantool.driver.api.MultiValueCallResult;
+import io.tarantool.driver.api.SingleValueCallResult;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.mappers.factories.ArrayValueToTarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.factories.MultiValueWithTarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
+import io.tarantool.driver.mappers.factories.RowsMetadataToTarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.factories.SingleValueWithTarantoolTupleResultMapperFactory;
+
+/**
+ * @author Artyom Dubinin
+ */
+public final class TarantoolTupleResultMapperFactoryImpl implements TarantoolTupleResultMapperFactory {
+
+    private static final TarantoolTupleResultMapperFactoryImpl instance = new TarantoolTupleResultMapperFactoryImpl();
+
+    private final ArrayValueToTarantoolTupleResultMapperFactory arrayTupleResultMapperFactory;
+    private final RowsMetadataToTarantoolTupleResultMapperFactory rowsMetadataToTarantoolTupleResultMapperFactory;
+    private final SingleValueWithTarantoolTupleResultMapperFactory singleValueWithTarantoolTupleResultMapperFactory;
+    private final MultiValueWithTarantoolTupleResultMapperFactory multiValueWithTarantoolTupleResultMapperFactory;
+
+    private TarantoolTupleResultMapperFactoryImpl() {
+        ResultMapperFactoryFactoryImpl
+            mapperFactoryFactory = new ResultMapperFactoryFactoryImpl();
+        this.arrayTupleResultMapperFactory =
+            mapperFactoryFactory.arrayTupleResultMapperFactory();
+        this.rowsMetadataToTarantoolTupleResultMapperFactory =
+            mapperFactoryFactory.rowsMetadataTupleResultMapperFactory();
+        this.singleValueWithTarantoolTupleResultMapperFactory =
+            mapperFactoryFactory.singleValueTupleResultMapperFactory();
+        this.multiValueWithTarantoolTupleResultMapperFactory =
+            mapperFactoryFactory.multiValueTupleResultMapperFactory();
+    }
+
+    @Override
+    public TarantoolResultMapper<TarantoolTuple> withArrayValueToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper) {
+        return arrayTupleResultMapperFactory
+            .withArrayValueToTarantoolTupleResultConverter(messagePackMapper);
+    }
+
+    @Override
+    public TarantoolResultMapper<TarantoolTuple> withArrayValueToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return arrayTupleResultMapperFactory
+            .withArrayValueToTarantoolTupleResultConverter(messagePackMapper, spaceMetadata);
+    }
+
+    @Override
+    public TarantoolResultMapper<TarantoolTuple> withRowsMetadataToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper) {
+        return rowsMetadataToTarantoolTupleResultMapperFactory
+            .withRowsMetadataToTarantoolTupleResultConverter(messagePackMapper);
+    }
+
+    @Override
+    public TarantoolResultMapper<TarantoolTuple> withRowsMetadataToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return rowsMetadataToTarantoolTupleResultMapperFactory
+            .withRowsMetadataToTarantoolTupleResultConverter(messagePackMapper, spaceMetadata);
+    }
+
+    @Override
+    public CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
+    withSingleValueArrayToTarantoolTupleResultMapper(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return singleValueWithTarantoolTupleResultMapperFactory
+            .withSingleValueArrayToTarantoolTupleResultMapper(messagePackMapper, spaceMetadata);
+    }
+
+    @Override
+    public CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
+    withSingleValueRowsMetadataToTarantoolTupleResultMapper(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return singleValueWithTarantoolTupleResultMapperFactory
+            .withSingleValueRowsMetadataToTarantoolTupleResultMapper(messagePackMapper, spaceMetadata);
+    }
+
+    @Override
+    public CallResultMapper<
+        TarantoolResult<TarantoolTuple>,
+        MultiValueCallResult<TarantoolTuple, TarantoolResult<TarantoolTuple>>>
+    withMultiValueArrayToTarantoolTupleResultMapper(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return multiValueWithTarantoolTupleResultMapperFactory
+            .withMultiValueArrayToTarantoolTupleResultMapper(messagePackMapper, spaceMetadata);
+    }
+
+    /**
+     * Get factory instance.
+     *
+     * @return factory instance
+     */
+    public static TarantoolTupleResultMapperFactory getInstance() {
+        return instance;
+    }
+}

--- a/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactory.java
@@ -4,6 +4,7 @@ import io.tarantool.driver.api.MultiValueCallResult;
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 
 import java.util.List;
 
@@ -29,6 +30,22 @@ public interface ResultMapperFactoryFactory {
      * @return default factory for list of tuples results
      */
     ArrayValueToTarantoolTupleResultMapperFactory arrayTupleResultMapperFactory();
+
+    /**
+     * Default factory for call result with different structures.
+     * Use this factory for handling containers with {@link TarantoolTuple} inside.
+     * The IProto method results by default contain lists of tuples.
+     * The crud results by default contain map with list of tuple inside.
+     * This factory can be used at the inner level by other mapper factories that are handling higher-level containers.
+     * <p>
+     * input: structure with array of tuples with MessagePack values inside ([t1, t2, ...])
+     * <br>
+     * mapper result: {@code TarantoolResult<TarantoolTuple>}
+     * <p>
+     *
+     * @return default factory for list of tuples results
+     */
+    TarantoolTupleResultMapperFactory getTarantoolTupleResultMapperFactory();
 
     /**
      * Default factory for call result with a list of tuples in structure with metadata.

--- a/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactoryImpl.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactoryImpl.java
@@ -8,6 +8,8 @@ import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.DefaultMultiValueResultMapper;
 import io.tarantool.driver.mappers.DefaultSingleValueResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToMultiValueListConverter;
 import org.msgpack.value.Value;
@@ -34,6 +36,11 @@ public final class ResultMapperFactoryFactoryImpl implements ResultMapperFactory
     @Override
     public ArrayValueToTarantoolTupleResultMapperFactory arrayTupleResultMapperFactory() {
         return new ArrayValueToTarantoolTupleResultMapperFactory();
+    }
+
+    @Override
+    public TarantoolTupleResultMapperFactory getTarantoolTupleResultMapperFactory() {
+        return TarantoolTupleResultMapperFactoryImpl.getInstance();
     }
 
     @Override

--- a/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
@@ -8,6 +8,8 @@ import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
@@ -47,12 +49,13 @@ public class TarantoolSetup {
             .withCredentials(tarantoolContainer.getUsername(), tarantoolContainer.getPassword())
             .build();
 
-        ResultMapperFactoryFactoryImpl factory = new ResultMapperFactoryFactoryImpl();
+        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+            TarantoolTupleResultMapperFactoryImpl.getInstance();
+
         TarantoolSpaceMetadata spaceMetadata = tarantoolClient.metadata().getSpaceByName("test_space").get();
 
         defaultMapper = tarantoolClient.getConfig().getMessagePackMapper();
-        resultMapper = factory
-            .singleValueTupleResultMapperFactory()
+        resultMapper = tarantoolTupleResultMapperFactory
             .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata);
 
         log.info("Successfully connected to Tarantool, version = {}", tarantoolClient.getVersion());

--- a/src/test/java/io/tarantool/driver/core/proxy/ProxyOperationBuildersTest.java
+++ b/src/test/java/io/tarantool/driver/core/proxy/ProxyOperationBuildersTest.java
@@ -21,6 +21,8 @@ import io.tarantool.driver.core.metadata.TarantoolMetadata;
 import io.tarantool.driver.core.metadata.TestMetadataProvider;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
 import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
 import io.tarantool.driver.protocol.TarantoolIndexQuery;
@@ -40,11 +42,11 @@ public class ProxyOperationBuildersTest {
     private static final ClusterTarantoolTupleClient client = new ClusterTarantoolTupleClient();
     private final MessagePackMapper defaultMapper =
         DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-    private final ResultMapperFactoryFactoryImpl mapperFactoryFactory =
-        new ResultMapperFactoryFactoryImpl();
+    TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+        TarantoolTupleResultMapperFactoryImpl.getInstance();
     private final
     CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
-        defaultResultMapper = mapperFactoryFactory.singleValueTupleResultMapperFactory()
+        defaultResultMapper = tarantoolTupleResultMapperFactory
         .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null);
     private final TarantoolTupleFactory factory = new DefaultTarantoolTupleFactory(defaultMapper);
 

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -19,6 +19,8 @@ import io.tarantool.driver.exceptions.TarantoolSpaceFieldNotFoundException;
 import io.tarantool.driver.exceptions.TarantoolSpaceOperationException;
 import io.tarantool.driver.mappers.DefaultMessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
+import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
 import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
 import org.junit.jupiter.api.BeforeAll;
@@ -391,14 +393,14 @@ public class ClusterTarantoolTupleClientIT {
     @Test
     public void callForTarantoolResultTest() throws Exception {
         MessagePackMapper defaultMapper = client.getConfig().getMessagePackMapper();
-        ResultMapperFactoryFactoryImpl factory = new ResultMapperFactoryFactoryImpl();
+        TarantoolTupleResultMapperFactory factory =
+            TarantoolTupleResultMapperFactoryImpl.getInstance();
         TarantoolSpaceMetadata spaceMetadata = client.metadata().getSpaceByName("test_space").get();
         TarantoolResult<TarantoolTuple> result = client.call(
             "user_function_complex_query",
             Collections.singletonList(1000),
             defaultMapper,
-            factory.singleValueTupleResultMapperFactory()
-                .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata)
+            factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata)
         ).get();
 
         assertTrue(result.size() >= 3);

--- a/src/test/java/io/tarantool/driver/mappers/TarantoolCallResultMapperTest.java
+++ b/src/test/java/io/tarantool/driver/mappers/TarantoolCallResultMapperTest.java
@@ -26,10 +26,11 @@ public class TarantoolCallResultMapperTest {
 
     private static final MessagePackMapper defaultMapper =
         DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-    private final ResultMapperFactoryFactoryImpl mapperFactoryFactory = new ResultMapperFactoryFactoryImpl();
+    TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+        TarantoolTupleResultMapperFactoryImpl.getInstance();
     private final
     CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
-        defaultResultMapper = mapperFactoryFactory.singleValueTupleResultMapperFactory()
+        defaultResultMapper = tarantoolTupleResultMapperFactory
         .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null);
 
     private static List<Object> nestedList1;
@@ -48,11 +49,11 @@ public class TarantoolCallResultMapperTest {
     @Test
     void testSingleValueCallResultMapper() {
         MessagePackMapper defaultMapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-        ResultMapperFactoryFactoryImpl
-            mapperFactoryFactory = new ResultMapperFactoryFactoryImpl();
+        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+            TarantoolTupleResultMapperFactoryImpl.getInstance();
         CallResultMapper<TarantoolResult<TarantoolTuple>,
             SingleValueCallResult<TarantoolResult<TarantoolTuple>>> mapper =
-            mapperFactoryFactory.singleValueTupleResultMapperFactory()
+            tarantoolTupleResultMapperFactory
                 .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null);
 
         //[nil, message]
@@ -100,11 +101,11 @@ public class TarantoolCallResultMapperTest {
     @Test
     void testMultiValueCallResultMapper() {
         MessagePackMapper defaultMapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-        ResultMapperFactoryFactoryImpl
-            mapperFactoryFactory = new ResultMapperFactoryFactoryImpl();
+        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+            TarantoolTupleResultMapperFactoryImpl.getInstance();
         CallResultMapper<TarantoolResult<TarantoolTuple>,
             MultiValueCallResult<TarantoolTuple, TarantoolResult<TarantoolTuple>>> mapper =
-            mapperFactoryFactory.multiValueTupleResultMapperFactory()
+            tarantoolTupleResultMapperFactory
                 .withMultiValueArrayToTarantoolTupleResultMapper(defaultMapper, null);
 
         //[[], ...]

--- a/src/test/java/io/tarantool/driver/mappers/TarantoolResultMapperTest.java
+++ b/src/test/java/io/tarantool/driver/mappers/TarantoolResultMapperTest.java
@@ -27,10 +27,10 @@ class TarantoolResultMapperTest {
     @Test
     void testWithArrayTarantoolTuple() {
         MessagePackMapper defaultMapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-        ResultMapperFactoryFactoryImpl
-            mapperFactoryFactory = new ResultMapperFactoryFactoryImpl();
-        TarantoolResultMapper<TarantoolTuple> mapper = mapperFactoryFactory
-            .arrayTupleResultMapperFactory().withArrayValueToTarantoolTupleResultConverter(defaultMapper);
+        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+            TarantoolTupleResultMapperFactoryImpl.getInstance();
+        TarantoolResultMapper<TarantoolTuple> mapper = tarantoolTupleResultMapperFactory.
+            withArrayValueToTarantoolTupleResultConverter(defaultMapper);
         List<Object> nestedList1 = Arrays.asList("nested", "array", 1);
         TarantoolTuple tupleOne = new TarantoolTupleImpl(Arrays.asList("abc", 1234, nestedList1), defaultMapper);
         List<Object> nestedList2 = Arrays.asList("nested", "array", 2);
@@ -50,10 +50,10 @@ class TarantoolResultMapperTest {
     @Test
     void testWithRowsMetadataTarantoolTuple() {
         MessagePackMapper defaultMapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-        ResultMapperFactoryFactoryImpl
-            mapperFactoryFactory = new ResultMapperFactoryFactoryImpl();
-        TarantoolResultMapper<TarantoolTuple> mapper = mapperFactoryFactory
-            .rowsMetadataTupleResultMapperFactory().withRowsMetadataToTarantoolTupleResultConverter(defaultMapper);
+        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
+            TarantoolTupleResultMapperFactoryImpl.getInstance();
+        TarantoolResultMapper<TarantoolTuple> mapper = tarantoolTupleResultMapperFactory
+            .withRowsMetadataToTarantoolTupleResultConverter(defaultMapper);
         List<Object> nestedList1 = Arrays.asList("nested", "array", 1);
         TarantoolTuple tupleOne = new TarantoolTupleImpl(Arrays.asList("abc", 1234, nestedList1), defaultMapper);
         List<Object> nestedList2 = Arrays.asList("nested", "array", 2);


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->
We need it to create universal mapper that can parse crud and box responses.
Also with this factory we can't see inherited methods.

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #321
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
