### PR TITLE
Batch operation errors parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## [Unreleased]
 
-- Added `fields` option to ProxySpace ([#236](https://github.com/tarantool/cartridge-java/pull/236))
+### Features
+- Add `fields` option to ProxySpace for controlling the result tuple fields ([#236](https://github.com/tarantool/cartridge-java/pull/236))
+- Parse metadata from crud response ([#272](https://github.com/tarantool/cartridge-java/pull/272))
+
+### Bugfixes
+- Add parsing of the batch operation errors ([#334](https://github.com/tarantool/cartridge-java/issues/334))
+
+### Internal and API changes
 - Move metadata parsing to separate converters ([#325](https://github.com/tarantool/cartridge-java/pull/325))
 - Add simple to use TarantoolTupleResultMapper factory ([#321](https://github.com/tarantool/cartridge-java/pull/321))
-- Parse metadata from crud response ([#272](https://github.com/tarantool/cartridge-java/pull/272))
 - Use netty part dependencies instead of netty-all ([#295](https://github.com/tarantool/cartridge-java/issues/295))
 - Refactor mappers and split `TarantoolResultConverter` ([#301](https://github.com/tarantool/cartridge-java/pull/301))
 - **[breaking change]** `TarantoolResultConverter` was removed, use `DefaultArrayValueToTarantoolResultConverter` or `DefaultMapValueToTarantoolTupleResultConverter` instead ([#301](https://github.com/tarantool/cartridge-java/pull/301))
@@ -16,11 +22,14 @@
 - **[breaking change]** `*MapperFactory` methods were renamed ([#301](https://github.com/tarantool/cartridge-java/pull/301))
 - **[breaking change]** `*DefaultConverter` converters moved into `mappers.converters.value.defaults` package ([#301](https://github.com/tarantool/cartridge-java/pull/301))
 - **[breaking change]** All converters from `mappers.converters.value.custom` moved into `mappers.converters.value` package ([#301](https://github.com/tarantool/cartridge-java/pull/301))
-- Return jmh-generator-annprocess dependency
+- Return back the `jmh-generator-annprocess` dependency
 
 ## [0.9.2] - 2022-11-15
 
+### Features
 - Adding default mapper for long arrays ([#290](https://github.com/tarantool/cartridge-java/pull/290))
+
+### Internal and API changes
 - Add dependency management ([#296](https://github.com/tarantool/cartridge-java/pull/296))
 - Bump testcontainers-java-tarantool to 0.5.3 ([#296](https://github.com/tarantool/cartridge-java/pull/296))
 - Bump slf4j-api to 2.0.3 ([#296](https://github.com/tarantool/cartridge-java/pull/296))
@@ -34,9 +43,12 @@
 
 ## [0.9.1] - 2022-10-13
 
+### Features
+- Enable Short to Integer converters ([#282](https://github.com/tarantool/cartridge-java/issues/282))
+
+### Internal and API changes
 - Changed TarantoolNullField class to singleton ([#195](https://github.com/tarantool/cartridge-java/pull/275))
 - Bump netty to 4.1.78 ([#280](https://github.com/tarantool/cartridge-java/issues/280))
-- Enable Short to Integer converters ([#282](https://github.com/tarantool/cartridge-java/issues/282))
 
 ### Security
 - Bump jackson-databind to 2.14.1-rc1 ([#284](https://github.com/tarantool/cartridge-java/pull/284))

--- a/src/test/java/io/tarantool/driver/mappers/TarantoolCallResultMapperTest.java
+++ b/src/test/java/io/tarantool/driver/mappers/TarantoolCallResultMapperTest.java
@@ -5,10 +5,10 @@ import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.tuple.TarantoolTupleImpl;
+import io.tarantool.driver.exceptions.TarantoolFunctionCallException;
 import io.tarantool.driver.exceptions.TarantoolInternalException;
 import io.tarantool.driver.exceptions.TarantoolTupleConversionException;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
-import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.msgpack.value.ArrayValue;
@@ -48,17 +48,9 @@ public class TarantoolCallResultMapperTest {
 
     @Test
     void testSingleValueCallResultMapper() {
-        MessagePackMapper defaultMapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
-            TarantoolTupleResultMapperFactoryImpl.getInstance();
-        CallResultMapper<TarantoolResult<TarantoolTuple>,
-            SingleValueCallResult<TarantoolResult<TarantoolTuple>>> mapper =
-            tarantoolTupleResultMapperFactory
-                .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null);
-
         //[nil, message]
         ArrayValue errorResult = ValueFactory.newArray(ValueFactory.newNil(), ValueFactory.newString("ERROR"));
-        assertThrows(TarantoolInternalException.class, () -> mapper.fromValue(errorResult));
+        assertThrows(TarantoolInternalException.class, () -> defaultResultMapper.fromValue(errorResult));
 
         //[nil, {str=message, stack=stacktrace}]
         MapValue error = ValueFactory.newMap(
@@ -68,9 +60,9 @@ public class TarantoolCallResultMapperTest {
             ValueFactory.newString("stacktrace")
         );
         ArrayValue errorResult1 = ValueFactory.newArray(ValueFactory.newNil(), error);
-        assertThrows(TarantoolInternalException.class, () -> mapper.fromValue(errorResult1));
+        assertThrows(TarantoolInternalException.class, () -> defaultResultMapper.fromValue(errorResult1));
 
-        //[[[],...]]
+        //[[[], ...]]
         List<Object> nestedList1 = Arrays.asList("nested", "array", 1);
         TarantoolTuple tupleOne = new TarantoolTupleImpl(Arrays.asList("abc", 1234, nestedList1), defaultMapper);
         List<Object> nestedList2 = Arrays.asList("nested", "array", 2);
@@ -78,7 +70,7 @@ public class TarantoolCallResultMapperTest {
         ArrayValue testTuples = ValueFactory.newArray(
             tupleOne.toMessagePackValue(defaultMapper), tupleTwo.toMessagePackValue(defaultMapper));
         ArrayValue callResult = ValueFactory.newArray(testTuples);
-        SingleValueCallResult<TarantoolResult<TarantoolTuple>> result = mapper.fromValue(callResult);
+        SingleValueCallResult<TarantoolResult<TarantoolTuple>> result = defaultResultMapper.fromValue(callResult);
         TarantoolResult<TarantoolTuple> tuples = result.value();
 
         assertEquals(2, tuples.size());
@@ -88,21 +80,47 @@ public class TarantoolCallResultMapperTest {
         assertEquals("def", tuples.get(1).getString(0));
         assertEquals(5678, tuples.get(1).getInteger(1));
         assertEquals(nestedList2, tuples.get(1).getList(2));
+
+        //[[[], ...], [message]]
+        ArrayValue errorResult2 =
+            ValueFactory.newArray(testTuples, ValueFactory.newArray(ValueFactory.newString("ERROR")));
+        assertThrows(TarantoolInternalException.class, () -> defaultResultMapper.fromValue(errorResult2));
+
+        //[[[], ...], [{str=message, stack=stacktrace}, {str=message, stack=stacktrace}]]
+        MapValue error1 = ValueFactory.newMap(error.asMapValue().map());
+        ArrayValue errors = ValueFactory.newArray(error, error1);
+        ArrayValue errorResult3 = ValueFactory.newArray(testTuples, errors);
+        assertThrows(TarantoolInternalException.class, () -> defaultResultMapper.fromValue(errorResult3));
+    }
+
+    @Test
+    void testDefaultTarantoolTupleResponse_singleResultShouldThrowException_cornerCase() {
+        ArrayValue testTuples = ValueFactory.newArray(
+            tupleOne.toMessagePackValue(defaultMapper), tupleTwo.toMessagePackValue(defaultMapper));
+
+        // The second value is a MsgPack array, and it is parsed an error. However, the result format is
+        // actually wrong, so the exact error contents does not matter in this case.
+        assertThrows(TarantoolInternalException.class, () -> defaultResultMapper.fromValue(testTuples), "def");
     }
 
     @Test
     void testDefaultTarantoolTupleResponse_singleResultShouldThrowException() {
-        ArrayValue testTuples = ValueFactory.newArray(
-            tupleOne.toMessagePackValue(defaultMapper), tupleTwo.toMessagePackValue(defaultMapper));
+        ArrayValue testTuples = ValueFactory.newArray(tupleOne.toMessagePackValue(defaultMapper));
 
+        // Another corner case, tuple result mapper should not be used for this result format
         assertThrows(TarantoolTupleConversionException.class, () -> defaultResultMapper.fromValue(testTuples));
     }
 
     @Test
+    void testDefaultTarantoolTupleResponse_singleResultShouldThrowException_tooManyValues() {
+        ArrayValue testTuples = ValueFactory.newArray(tupleOne.toMessagePackValue(defaultMapper),
+            tupleOne.toMessagePackValue(defaultMapper), tupleOne.toMessagePackValue(defaultMapper));
+
+        assertThrows(TarantoolFunctionCallException.class, () -> defaultResultMapper.fromValue(testTuples));
+    }
+
+    @Test
     void testMultiValueCallResultMapper() {
-        MessagePackMapper defaultMapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-        TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
-            TarantoolTupleResultMapperFactoryImpl.getInstance();
         CallResultMapper<TarantoolResult<TarantoolTuple>,
             MultiValueCallResult<TarantoolTuple, TarantoolResult<TarantoolTuple>>> mapper =
             tarantoolTupleResultMapperFactory


### PR DESCRIPTION
I decided to not make a separate `SingleValueCallResult` parser for batch operations specifically because I believe that the return format must be fixed in tarantool/crud and it will change in the future. So I added a new case to the common parser and refactored it a bit.

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [ ] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Fixes #334
