### PR TITLE
Access Changed from public to protected for TarantoolResultImpl and TarantoolTupleResultImpl #326

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Features
 - Add `fields` option to ProxySpace for controlling the result tuple fields ([#236](https://github.com/tarantool/cartridge-java/pull/236))
 - Parse metadata from crud response ([#272](https://github.com/tarantool/cartridge-java/pull/272))
-
+- Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 ### Bugfixes
 - Add parsing of the batch operation errors ([#334](https://github.com/tarantool/cartridge-java/issues/334))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-
+- Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 ## [0.10.1] - 2023-01-13
 
 ### Internal and API changes
@@ -13,7 +13,7 @@
 ### Features
 - Add `fields` option to ProxySpace for controlling the result tuple fields ([#236](https://github.com/tarantool/cartridge-java/pull/236))
 - Parse metadata from crud response ([#272](https://github.com/tarantool/cartridge-java/pull/272))
-- Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
+
 ### Bugfixes
 - Add parsing of the batch operation errors ([#334](https://github.com/tarantool/cartridge-java/issues/334))
 

--- a/src/main/java/io/tarantool/driver/core/TarantoolResultFactory.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolResultFactory.java
@@ -6,14 +6,19 @@ import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleCo
 import org.msgpack.value.ArrayValue;
 import org.msgpack.value.Value;
 
-public class TarantoolResultFactory<T> {
+/**
+ * Singleton Factory implementation to provide instance of TarantoolResultImpl objects.
+ *
+ * @author Rishal Dev Singh
+ */
+public class TarantoolResultFactory {
     private static final TarantoolResultFactory INSTANCE = new TarantoolResultFactory();
 
     public static TarantoolResultFactory getInstance() {
         return INSTANCE;
     }
 
-    public TarantoolResultImpl<T> createTarantoolResultImpl(ArrayValue value,
+    public <T> TarantoolResultImpl<T> createTarantoolResultImpl(ArrayValue value,
             ValueConverter<ArrayValue, T> valueConverter) {
         return new TarantoolResultImpl<>(value, valueConverter);
     }

--- a/src/main/java/io/tarantool/driver/core/TarantoolResultFactory.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolResultFactory.java
@@ -7,6 +7,11 @@ import org.msgpack.value.ArrayValue;
 import org.msgpack.value.Value;
 
 public class TarantoolResultFactory<T> {
+    private static final TarantoolResultFactory INSTANCE = new TarantoolResultFactory();
+
+    public static TarantoolResultFactory getInstance() {
+        return INSTANCE;
+    }
 
     public TarantoolResultImpl<T> createTarantoolResultImpl(ArrayValue value,
             ValueConverter<ArrayValue, T> valueConverter) {

--- a/src/main/java/io/tarantool/driver/core/TarantoolResultFactory.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolResultFactory.java
@@ -1,0 +1,26 @@
+package io.tarantool.driver.core;
+
+import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
+import io.tarantool.driver.mappers.converters.ValueConverter;
+import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleConverter;
+import org.msgpack.value.ArrayValue;
+import org.msgpack.value.Value;
+
+public class TarantoolResultFactory<T> {
+
+    public TarantoolResultImpl<T> createTarantoolResultImpl(ArrayValue value,
+            ValueConverter<ArrayValue, T> valueConverter) {
+        return new TarantoolResultImpl<>(value, valueConverter);
+    }
+
+    public TarantoolTupleResultImpl createTarantoolTupleResultImpl(Value value,
+            ArrayValueToTarantoolTupleConverter tupleConverter) {
+        return new TarantoolTupleResultImpl(value, tupleConverter);
+    }
+
+    public TarantoolTupleResultImpl createTarantoolTupleResultImpl(ArrayValue rawTuples,
+            TarantoolSpaceMetadata metadata,
+            ArrayValueToTarantoolTupleConverter tupleConverter) {
+        return new TarantoolTupleResultImpl(rawTuples, metadata, tupleConverter);
+    }
+}

--- a/src/main/java/io/tarantool/driver/core/TarantoolResultImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolResultImpl.java
@@ -27,7 +27,12 @@ public class TarantoolResultImpl<T> implements TarantoolResult<T> {
     protected TarantoolResultImpl() {
     }
 
-    public TarantoolResultImpl(ArrayValue value, ValueConverter<ArrayValue, T> valueConverter) {
+    protected TarantoolResultImpl buildTarantoolResultImpl(ArrayValue value,
+            ValueConverter<ArrayValue, T> valueConverter) {
+        return new TarantoolResultImpl(value, valueConverter);
+    }
+
+    protected TarantoolResultImpl(ArrayValue value, ValueConverter<ArrayValue, T> valueConverter) {
         // [[[],...]]
         setItems(value, valueConverter);
     }

--- a/src/main/java/io/tarantool/driver/core/TarantoolResultImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolResultImpl.java
@@ -27,11 +27,6 @@ public class TarantoolResultImpl<T> implements TarantoolResult<T> {
     protected TarantoolResultImpl() {
     }
 
-    protected TarantoolResultImpl buildTarantoolResultImpl(ArrayValue value,
-            ValueConverter<ArrayValue, T> valueConverter) {
-        return new TarantoolResultImpl(value, valueConverter);
-    }
-
     protected TarantoolResultImpl(ArrayValue value, ValueConverter<ArrayValue, T> valueConverter) {
         // [[[],...]]
         setItems(value, valueConverter);

--- a/src/main/java/io/tarantool/driver/core/TarantoolTupleResultImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolTupleResultImpl.java
@@ -19,26 +19,12 @@ public class TarantoolTupleResultImpl extends TarantoolResultImpl<TarantoolTuple
 
     protected TarantoolTupleResultImpl(
         ArrayValue rawTuples, TarantoolSpaceMetadata metadata,
-            ArrayValueToTarantoolTupleConverter tupleConverter) {
+        ArrayValueToTarantoolTupleConverter tupleConverter) {
         setItems(rawTuples, metadata, tupleConverter);
     }
 
     protected TarantoolTupleResultImpl(Value value, ArrayValueToTarantoolTupleConverter tupleConverter) {
         setItems(value.asArrayValue(), tupleConverter);
-    }
-
-    protected TarantoolTupleResultImpl() {
-    }
-
-    protected TarantoolTupleResultImpl buildTarantoolTupleResultImpl(ArrayValue rawTuples,
-            TarantoolSpaceMetadata metadata,
-            ArrayValueToTarantoolTupleConverter tupleConverter) {
-        return new TarantoolTupleResultImpl(rawTuples, metadata, tupleConverter);
-    }
-
-    protected TarantoolTupleResultImpl buildTarantoolTupleResultImpl(Value value,
-            ArrayValueToTarantoolTupleConverter tupleConverter) {
-        return new TarantoolTupleResultImpl(value, tupleConverter);
     }
 
     private void setItems(

--- a/src/main/java/io/tarantool/driver/core/TarantoolTupleResultImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolTupleResultImpl.java
@@ -17,14 +17,30 @@ import java.util.stream.Collectors;
  */
 public class TarantoolTupleResultImpl extends TarantoolResultImpl<TarantoolTuple> {
 
-    public TarantoolTupleResultImpl(
+    protected TarantoolTupleResultImpl(
         ArrayValue rawTuples, TarantoolSpaceMetadata metadata,
-        ArrayValueToTarantoolTupleConverter tupleConverter) {
+            ArrayValueToTarantoolTupleConverter tupleConverter) {
         setItems(rawTuples, metadata, tupleConverter);
     }
 
-    public TarantoolTupleResultImpl(Value value, ArrayValueToTarantoolTupleConverter tupleConverter) {
+    protected TarantoolTupleResultImpl(Value value, ArrayValueToTarantoolTupleConverter tupleConverter) {
         setItems(value.asArrayValue(), tupleConverter);
+    }
+
+    protected TarantoolTupleResultImpl() {
+
+    }
+
+    protected TarantoolTupleResultImpl buildTarantoolTupleResultImpl(ArrayValue rawTuples,
+            TarantoolSpaceMetadata metadata,
+            ArrayValueToTarantoolTupleConverter tupleConverter) {
+        return new TarantoolTupleResultImpl(rawTuples, metadata, tupleConverter);
+
+    }
+
+    protected TarantoolTupleResultImpl buildTarantoolTupleResultImpl(Value value,
+            ArrayValueToTarantoolTupleConverter tupleConverter) {
+        return new TarantoolTupleResultImpl(value, tupleConverter);
     }
 
     private void setItems(

--- a/src/main/java/io/tarantool/driver/core/TarantoolTupleResultImpl.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolTupleResultImpl.java
@@ -28,14 +28,12 @@ public class TarantoolTupleResultImpl extends TarantoolResultImpl<TarantoolTuple
     }
 
     protected TarantoolTupleResultImpl() {
-
     }
 
     protected TarantoolTupleResultImpl buildTarantoolTupleResultImpl(ArrayValue rawTuples,
             TarantoolSpaceMetadata metadata,
             ArrayValueToTarantoolTupleConverter tupleConverter) {
         return new TarantoolTupleResultImpl(rawTuples, metadata, tupleConverter);
-
     }
 
     protected TarantoolTupleResultImpl buildTarantoolTupleResultImpl(Value value,

--- a/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
@@ -1,10 +1,11 @@
 package io.tarantool.driver.core.metadata;
 
+import java.util.Map;
+
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.TarantoolResultFactory;
-import io.tarantool.driver.core.TarantoolTupleResultImpl;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleConverter;
 import org.msgpack.value.ArrayValue;
@@ -13,7 +14,7 @@ import org.msgpack.value.StringValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
 
-import java.util.Map;
+import static io.tarantool.driver.core.TarantoolResultFactory.getInstance;
 
 /**
  * @author Artyom Dubinin
@@ -30,12 +31,12 @@ public class RowsMetadataToTarantoolTupleResultConverter
         CRUDResponseToTarantoolSpaceMetadataConverter.getInstance();
 
     private final ArrayValueToTarantoolTupleConverter tupleConverter;
-    private final TarantoolResultFactory<TarantoolTuple> tarantoolResultFactory;
+    private final TarantoolResultFactory tarantoolResultFactory;
 
     public RowsMetadataToTarantoolTupleResultConverter(ArrayValueToTarantoolTupleConverter tupleConverter) {
         super();
         this.tupleConverter = tupleConverter;
-        this.tarantoolResultFactory = new TarantoolResultFactory<>();
+        this.tarantoolResultFactory = getInstance();
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
@@ -18,6 +18,7 @@ import java.util.Map;
  * @author Artyom Dubinin
  */
 public class RowsMetadataToTarantoolTupleResultConverter
+    extends TarantoolTupleResultImpl
     implements ValueConverter<MapValue, TarantoolResult<TarantoolTuple>> {
 
     private static final long serialVersionUID = -5228606294087295535L;
@@ -42,7 +43,7 @@ public class RowsMetadataToTarantoolTupleResultConverter
         ArrayValue rawMetadata = tupleMap.get(RESULT_META).asArrayValue();
         TarantoolSpaceMetadata parsedMetadata = spaceMetadataConverter.fromValue(rawMetadata);
 
-        return new TarantoolTupleResultImpl(rawTuples, parsedMetadata, tupleConverter);
+        return buildTarantoolTupleResultImpl(rawTuples, parsedMetadata, tupleConverter);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
@@ -3,6 +3,7 @@ package io.tarantool.driver.core.metadata;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.core.TarantoolResultFactory;
 import io.tarantool.driver.core.TarantoolTupleResultImpl;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleConverter;
@@ -18,7 +19,6 @@ import java.util.Map;
  * @author Artyom Dubinin
  */
 public class RowsMetadataToTarantoolTupleResultConverter
-    extends TarantoolTupleResultImpl
     implements ValueConverter<MapValue, TarantoolResult<TarantoolTuple>> {
 
     private static final long serialVersionUID = -5228606294087295535L;
@@ -30,10 +30,12 @@ public class RowsMetadataToTarantoolTupleResultConverter
         CRUDResponseToTarantoolSpaceMetadataConverter.getInstance();
 
     private final ArrayValueToTarantoolTupleConverter tupleConverter;
+    private final TarantoolResultFactory<TarantoolTuple> tarantoolResultFactory;
 
     public RowsMetadataToTarantoolTupleResultConverter(ArrayValueToTarantoolTupleConverter tupleConverter) {
         super();
         this.tupleConverter = tupleConverter;
+        this.tarantoolResultFactory = new TarantoolResultFactory<>();
     }
 
     @Override
@@ -43,7 +45,7 @@ public class RowsMetadataToTarantoolTupleResultConverter
         ArrayValue rawMetadata = tupleMap.get(RESULT_META).asArrayValue();
         TarantoolSpaceMetadata parsedMetadata = spaceMetadataConverter.fromValue(rawMetadata);
 
-        return buildTarantoolTupleResultImpl(rawTuples, parsedMetadata, tupleConverter);
+        return tarantoolResultFactory.createTarantoolTupleResultImpl(rawTuples, parsedMetadata, tupleConverter);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolResultConverter.java
@@ -9,6 +9,7 @@ import org.msgpack.value.ArrayValue;
  * @author Artyom Dubinin
  */
 public class ArrayValueToTarantoolResultConverter<T>
+    extends TarantoolResultImpl
     implements ValueConverter<ArrayValue, TarantoolResult<T>> {
 
     private static final long serialVersionUID = -1348387430063097175L;
@@ -16,6 +17,7 @@ public class ArrayValueToTarantoolResultConverter<T>
     private ValueConverter<ArrayValue, T> valueConverter;
 
     public ArrayValueToTarantoolResultConverter() {
+        super();
     }
 
     public ArrayValueToTarantoolResultConverter(ValueConverter<ArrayValue, T> valueConverter) {
@@ -24,6 +26,6 @@ public class ArrayValueToTarantoolResultConverter<T>
 
     @Override
     public TarantoolResult<T> fromValue(ArrayValue value) {
-        return new TarantoolResultImpl<>(value, valueConverter);
+        return buildTarantoolResultImpl(value, valueConverter);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolResultConverter.java
@@ -1,6 +1,7 @@
 package io.tarantool.driver.mappers.converters.value;
 
 import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.core.TarantoolResultFactory;
 import io.tarantool.driver.core.TarantoolResultImpl;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import org.msgpack.value.ArrayValue;
@@ -9,23 +10,24 @@ import org.msgpack.value.ArrayValue;
  * @author Artyom Dubinin
  */
 public class ArrayValueToTarantoolResultConverter<T>
-    extends TarantoolResultImpl
     implements ValueConverter<ArrayValue, TarantoolResult<T>> {
 
     private static final long serialVersionUID = -1348387430063097175L;
 
     private ValueConverter<ArrayValue, T> valueConverter;
+    private final TarantoolResultFactory<T> tarantoolResultFactory;
 
     public ArrayValueToTarantoolResultConverter() {
-        super();
+        this.tarantoolResultFactory = new TarantoolResultFactory<>();
     }
 
     public ArrayValueToTarantoolResultConverter(ValueConverter<ArrayValue, T> valueConverter) {
         this.valueConverter = valueConverter;
+        this.tarantoolResultFactory = new TarantoolResultFactory<>();
     }
 
     @Override
     public TarantoolResult<T> fromValue(ArrayValue value) {
-        return buildTarantoolResultImpl(value, valueConverter);
+        return tarantoolResultFactory.<T>createTarantoolResultImpl(value, valueConverter);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolResultConverter.java
@@ -15,15 +15,15 @@ public class ArrayValueToTarantoolResultConverter<T>
     private static final long serialVersionUID = -1348387430063097175L;
 
     private ValueConverter<ArrayValue, T> valueConverter;
-    private final TarantoolResultFactory<T> tarantoolResultFactory;
+    private final TarantoolResultFactory tarantoolResultFactory;
 
     public ArrayValueToTarantoolResultConverter() {
-        this.tarantoolResultFactory = new TarantoolResultFactory<>();
+        this.tarantoolResultFactory = TarantoolResultFactory.getInstance();
     }
 
     public ArrayValueToTarantoolResultConverter(ValueConverter<ArrayValue, T> valueConverter) {
         this.valueConverter = valueConverter;
-        this.tarantoolResultFactory = new TarantoolResultFactory<>();
+        this.tarantoolResultFactory = new TarantoolResultFactory();
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
@@ -10,6 +10,7 @@ import org.msgpack.value.ArrayValue;
  * @author Artyom Dubinin
  */
 public class ArrayValueToTarantoolTupleResultConverter
+    extends TarantoolResultImpl
     implements ValueConverter<ArrayValue, TarantoolResult<TarantoolTuple>> {
 
     private static final long serialVersionUID = -1348387430063097175L;
@@ -24,6 +25,6 @@ public class ArrayValueToTarantoolTupleResultConverter
 
     @Override
     public TarantoolResult<TarantoolTuple> fromValue(ArrayValue value) {
-        return new TarantoolTupleResultImpl(value, tupleConverter);
+        return buildTarantoolResultImpl(value, tupleConverter);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
@@ -6,6 +6,8 @@ import io.tarantool.driver.core.TarantoolResultFactory;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import org.msgpack.value.ArrayValue;
 
+import static io.tarantool.driver.core.TarantoolResultFactory.getInstance;
+
 /**
  * @author Artyom Dubinin
  */
@@ -15,13 +17,13 @@ public class ArrayValueToTarantoolTupleResultConverter
     private static final long serialVersionUID = -1348387430063097175L;
 
     private final ArrayValueToTarantoolTupleConverter tupleConverter;
-    private final TarantoolResultFactory<TarantoolTuple> tarantoolResultFactory;
+    private final TarantoolResultFactory tarantoolResultFactory;
 
     public ArrayValueToTarantoolTupleResultConverter(
         ArrayValueToTarantoolTupleConverter tupleConverter) {
         super();
         this.tupleConverter = tupleConverter;
-        this.tarantoolResultFactory = new TarantoolResultFactory<>();
+        this.tarantoolResultFactory = getInstance();
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
@@ -2,7 +2,7 @@ package io.tarantool.driver.mappers.converters.value;
 
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
-import io.tarantool.driver.core.TarantoolTupleResultImpl;
+import io.tarantool.driver.core.TarantoolResultImpl;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import org.msgpack.value.ArrayValue;
 

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
@@ -2,7 +2,7 @@ package io.tarantool.driver.mappers.converters.value;
 
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
-import io.tarantool.driver.core.TarantoolResultImpl;
+import io.tarantool.driver.core.TarantoolResultFactory;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import org.msgpack.value.ArrayValue;
 
@@ -10,21 +10,22 @@ import org.msgpack.value.ArrayValue;
  * @author Artyom Dubinin
  */
 public class ArrayValueToTarantoolTupleResultConverter
-    extends TarantoolResultImpl
     implements ValueConverter<ArrayValue, TarantoolResult<TarantoolTuple>> {
 
     private static final long serialVersionUID = -1348387430063097175L;
 
     private final ArrayValueToTarantoolTupleConverter tupleConverter;
+    private final TarantoolResultFactory<TarantoolTuple> tarantoolResultFactory;
 
     public ArrayValueToTarantoolTupleResultConverter(
         ArrayValueToTarantoolTupleConverter tupleConverter) {
         super();
         this.tupleConverter = tupleConverter;
+        this.tarantoolResultFactory = new TarantoolResultFactory<>();
     }
 
     @Override
     public TarantoolResult<TarantoolTuple> fromValue(ArrayValue value) {
-        return buildTarantoolResultImpl(value, tupleConverter);
+        return tarantoolResultFactory.createTarantoolTupleResultImpl(value, tupleConverter);
     }
 }


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->
For `TarantoolResultImpl`, `TarantoolTupleResultImpl`
Changing the access to protected because of its internal functionality. They are used in converters.

I haven't forgotten about:
- [ ] Tests
- [X] Changelog
- [x] Documentation
- [X] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [X] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #326
