### PR TITLE
Add ability to use different converters via factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 - Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 - Add deep copy instead of shallow copy in default message pack mapper
-- Add factory builder to be able making mapper hierarchy
+- Add a factory builder for constructing mapper hierarchies
 
 ## [0.10.1] - 2023-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 - Add deep copy instead of shallow copy in default message pack mapper
+- Add factory builder to be able making mapper hierarchy
 
 ## [0.10.1] - 2023-01-13
 

--- a/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/RowsMetadataToTarantoolTupleResultConverter.java
@@ -51,7 +51,7 @@ public class RowsMetadataToTarantoolTupleResultConverter
 
     @Override
     public boolean canConvertValue(MapValue value) {
-        // [{"metadata" : [...], "rows": [...]}]
+        // {"metadata" : [...], "rows": [...]}
         Map<Value, Value> tupleMap = value.asMapValue().map();
         if (!hasRowsAndMetadata(tupleMap)) {
             return false;

--- a/src/main/java/io/tarantool/driver/mappers/AbstractResultMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/AbstractResultMapper.java
@@ -58,12 +58,12 @@ public abstract class AbstractResultMapper<T> implements MessagePackValueMapper 
         valueMapper.registerValueConverterWithoutTargetClass(valueType, resultConverter);
     }
 
-    public AbstractResultMapper(
+    public <O> AbstractResultMapper(
         MessagePackValueMapper valueMapper,
-        List<ValueConverterWithInputTypeWrapper<T>> converters,
+        List<ValueConverterWithInputTypeWrapper<O>> converters,
         Class<? extends T> resultClass) {
         this.valueMapper = valueMapper;
-        for (ValueConverterWithInputTypeWrapper<T> converter :
+        for (ValueConverterWithInputTypeWrapper<O> converter :
             converters) {
             valueMapper.registerValueConverter(
                 converter.getValueType(),
@@ -72,11 +72,11 @@ public abstract class AbstractResultMapper<T> implements MessagePackValueMapper 
         }
     }
 
-    public AbstractResultMapper(
+    public <O> AbstractResultMapper(
         MessagePackValueMapper valueMapper,
-        List<ValueConverterWithInputTypeWrapper<T>> converters) {
+        List<ValueConverterWithInputTypeWrapper<O>> converters) {
         this.valueMapper = valueMapper;
-        for (ValueConverterWithInputTypeWrapper<T> converter :
+        for (ValueConverterWithInputTypeWrapper<O> converter :
             converters) {
             valueMapper.registerValueConverterWithoutTargetClass(
                 converter.getValueType(),

--- a/src/main/java/io/tarantool/driver/mappers/factories/ArrayValueToTarantoolTupleResultMapperFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/ArrayValueToTarantoolTupleResultMapperFactory.java
@@ -5,6 +5,7 @@ import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.TarantoolResultMapper;
+import io.tarantool.driver.mappers.converters.ValueConverterWithInputTypeWrapper;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleConverter;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleResultConverter;
 import org.msgpack.value.ValueType;
@@ -49,10 +50,24 @@ public class ArrayValueToTarantoolTupleResultMapperFactory
             new ArrayValueToTarantoolTupleConverter(messagePackMapper, spaceMetadata));
     }
 
+    public ValueConverterWithInputTypeWrapper<Object> getArrayValueToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return getArrayValueToTarantoolTupleResultConverter(
+            new ArrayValueToTarantoolTupleConverter(messagePackMapper, spaceMetadata));
+    }
+
     public TarantoolResultMapper<TarantoolTuple> withArrayValueToTarantoolTupleResultConverter(
         ArrayValueToTarantoolTupleConverter tupleConverter) {
         return withConverterWithoutTargetClass(
             messagePackMapper.copy(),
+            ValueType.ARRAY,
+            new ArrayValueToTarantoolTupleResultConverter(tupleConverter)
+        );
+    }
+
+    public ValueConverterWithInputTypeWrapper<Object> getArrayValueToTarantoolTupleResultConverter(
+        ArrayValueToTarantoolTupleConverter tupleConverter) {
+        return new ValueConverterWithInputTypeWrapper<>(
             ValueType.ARRAY,
             new ArrayValueToTarantoolTupleResultConverter(tupleConverter)
         );

--- a/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactory.java
@@ -1,9 +1,14 @@
 package io.tarantool.driver.mappers.factories;
 
+import io.tarantool.driver.api.CallResult;
 import io.tarantool.driver.api.MultiValueCallResult;
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.mappers.CallResultMapper;
+import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 
 import java.util.List;
@@ -191,4 +196,21 @@ public interface ResultMapperFactoryFactory {
      * @return new or existing factory instance
      */
     <T> ArrayValueToTarantoolResultMapperFactory<T> rowsMetadataStructureResultMapperFactory();
+
+    Builder createMapper();
+
+    interface Builder {
+
+        Builder withSingleValueConverter(
+            MessagePackValueMapper messagePackMapper);
+
+        Builder withArrayValueToTarantoolTupleResultConverter(
+            MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+
+        MessagePackValueMapper buildMessagePackMapper(MessagePackValueMapper valueMapper);
+
+        CallResultMapper buildCallResultMapper(MessagePackValueMapper valueMapper);
+        Builder withRowsMetadataToTarantoolTupleResultMapper(
+            MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+    }
 }

--- a/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/ResultMapperFactoryFactory.java
@@ -1,11 +1,11 @@
 package io.tarantool.driver.mappers.factories;
 
-import io.tarantool.driver.api.CallResult;
 import io.tarantool.driver.api.MultiValueCallResult;
 import io.tarantool.driver.api.SingleValueCallResult;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.api.tuple.TarantoolTupleResult;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
@@ -197,20 +197,170 @@ public interface ResultMapperFactoryFactory {
      */
     <T> ArrayValueToTarantoolResultMapperFactory<T> rowsMetadataStructureResultMapperFactory();
 
-    Builder createMapper();
+    /**
+     * Return builder to create mapper which may depend on input clientMapper
+     * For example, you can create maper that can obtain crud and box results from lua
+     * and read it into {@link TarantoolTupleResult} structure.
+     * <pre>
+     * <code>
+     *     CallResultMapper callReturnMapper = factory.createMapper(valueMapper)
+     *             .withSingleValueConverter( // obtain first value from lua multi-value response
+     *                 factory.createMapper(valueMapper)
+     *                     .withArrayValueToTarantoolTupleResultConverter() // box type response
+     *                     .withRowsMetadataToTarantoolTupleResultMapper() // crud type response
+     *                     .buildCallResultMapper()
+     *             )
+     *             .buildCallResultMapper();
+     * </code>
+     * </pre>
+     * This mapper wouldn't have metadata to take fields by their names.
+     *
+     * @param messagePackMapper input client mapper
+     * @return Builder to create mapper with specific converters inside
+     */
+    Builder createMapper(MessagePackMapper messagePackMapper);
+
+    /**
+     * Return builder to create mapper which may depend on input clientMapper
+     * For example, you can create maper that can obtain crud and box results from lua
+     * and read it into {@link TarantoolTupleResult} structure.
+     * <pre>
+     * <code>
+     *     CallResultMapper callReturnMapper = factory.createMapper(valueMapper)
+     *             .withSingleValueConverter( // obtain first value from lua multi-value response
+     *                 factory.createMapper(valueMapper)
+     *                     .withArrayValueToTarantoolTupleResultConverter() // box type response
+     *                     .withRowsMetadataToTarantoolTupleResultMapper() // crud type response
+     *                     .buildCallResultMapper()
+     *             )
+     *             .buildCallResultMapper();
+     * </code>
+     * </pre>
+     *
+     * @param messagePackMapper input client mapper
+     * @param spaceMetadata metadata to get fields by names
+     * @return Builder to create mapper with specific converters inside
+     */
+    Builder createMapper(MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
 
     interface Builder {
 
+        /**
+         * Add a converter for mapping stored Lua function call results to {@link SingleValueCallResult}
+         * <p>
+         * input: [x, y, ...], MessagePack array from a Lua function multi-return response
+         * <br>
+         * where <code>x, y</code> are some MessagePack values. <code>x</code> is interpreted as a stored Lua function
+         * result and <code>y</code> may be interpreted as a stored Lua function error if it is not empty and there are
+         * no more arguments after <code>y</code>.
+         * <br>
+         * mapper result: some Java type converted from the value of <code>x</code> according to the mapper, passed as a
+         * parameter to builder constructor for parsing the result contents.
+         * <p>
+         * Converter result and its inner contents depend on the parameters or the passed converters.
+         *
+         * @return builder with single value converter
+         */
+        Builder withSingleValueConverter();
+
+        /**
+         * Add a converter for mapping stored Lua function call results to {@link SingleValueCallResult}
+         * <p>
+         * input: [x, y, ...], MessagePack array from a Lua function multi-return response
+         * <br>
+         * where <code>x, y</code> are some MessagePack values. <code>x</code> is interpreted as a stored Lua function
+         * result and <code>y</code> may be interpreted as a stored Lua function error if it is not empty and there are
+         * no more arguments after <code>y</code>.
+         * <br>
+         * mapper result: some Java type converted from the value of <code>x</code> according to the mapper, passed as a
+         * parameter to this one for parsing the result contents.
+         * <p>
+         * Converter result and its inner contents depend on the parameters or the passed converters.
+         *
+         * @param messagePackMapper to parse fields
+         * @return builder with single value converter
+         */
         Builder withSingleValueConverter(
             MessagePackValueMapper messagePackMapper);
 
+        /**
+         * Add converter parses result from a list of tuples.
+         * Use this converter for handling containers with {@link TarantoolTuple} inside.
+         * The IProto method results by default contain lists of tuples.
+         * This converter can be used at the inner level by other mapper factories that are handling higher-level
+         * containers.
+         * <p>
+         * input: array of tuples with MessagePack values inside ([t1, t2, ...])
+         * <br>
+         * converter result: {@code TarantoolResult<TarantoolTuple>}
+         * <p>
+         * For example, it can be used to parse result from IPROTO_SELECT.
+         * fields result: some Java type converted from the value of <code>x</code> according to the mapper, passed as a
+         * parameter to builder constructor for parsing the result contents.
+         *
+         * @return builder with converter that parses list of arrays to {@code TarantoolResult<TarantoolTuple>}
+         */
+        Builder withArrayValueToTarantoolTupleResultConverter();
+
+        /**
+         * Add converter parses result from a list of tuples.
+         * Use this converter for handling containers with {@link TarantoolTuple} inside.
+         * The IProto method results by default contain lists of tuples.
+         * This converter can be used at the inner level by other mapper factories that are handling higher-level
+         * containers.
+         * <p>
+         * input: array of tuples with MessagePack values inside ([t1, t2, ...])
+         * <br>
+         * converter result: {@code TarantoolResult<TarantoolTuple>}
+         * <p>
+         * For example, it can be used to parse result from IPROTO_SELECT
+         * fields result: some Java type converted from the value of <code>x</code> according to the mapper, passed as a
+         * parameter to this one for parsing the result contents.
+         *
+         * @param messagePackMapper to parse fields
+         * @return builder with converter that parses list of arrays to {@code TarantoolResult<TarantoolTuple>}
+         */
         Builder withArrayValueToTarantoolTupleResultConverter(
-            MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+            MessagePackMapper messagePackMapper);
 
-        MessagePackValueMapper buildMessagePackMapper(MessagePackValueMapper valueMapper);
+        /**
+         * Add converter parses result from a map with list of tuples and metadata.
+         * Use this converter for handling containers with {@link TarantoolTuple} inside.
+         * The crud method results by default contain map with list of tuples and metadata.
+         * This converter can be used at the inner level by other mapper factories that are handling higher-level
+         * containers.
+         * <p>
+         * input: map with metadata and array of tuples with MessagePack values inside ([t1, t2, ...])
+         * <br>
+         * fields result: some Java type converted from the value of <code>x</code> according to the mapper, passed as a
+         * parameter to builder constructor for parsing the result contents.
+         * <p>
+         *
+         * @return builder with converter that parses map to {@code TarantoolResult<TarantoolTuple>}
+         */
+        Builder withRowsMetadataToTarantoolTupleResultConverter();
 
-        CallResultMapper buildCallResultMapper(MessagePackValueMapper valueMapper);
-        Builder withRowsMetadataToTarantoolTupleResultMapper(
-            MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata);
+        /**
+         * Add converter parses result from a map with list of tuples and metadata.
+         * Use this converter for handling containers with {@link TarantoolTuple} inside.
+         * The crud method results by default contain map with list of tuples and metadata.
+         * This converter can be used at the inner level by other mapper factories that are handling higher-level
+         * containers.
+         * <p>
+         * input: map with metadata and array of tuples with MessagePack values inside ([t1, t2, ...])
+         * <br>
+         * fields result: some Java type converted from the value of <code>x</code> according to the mapper, passed as a
+         * parameter to this one for parsing the result contents.
+         * <p>
+         *
+         * @param messagePackMapper to parse fields
+         * @return builder with converter that parses map to {@code TarantoolResult<TarantoolTuple>}
+         */
+        Builder withRowsMetadataToTarantoolTupleResultConverter(
+            MessagePackMapper messagePackMapper);
+
+        CallResultMapper buildCallResultMapper();
+
+        CallResultMapper buildCallResultMapper(MessagePackMapper valueMapper);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/factories/RowsMetadataToTarantoolTupleResultMapperFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/RowsMetadataToTarantoolTupleResultMapperFactory.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.core.metadata.RowsMetadataToTarantoolTupleResultConve
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.TarantoolResultMapper;
+import io.tarantool.driver.mappers.converters.ValueConverterWithInputTypeWrapper;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToTarantoolTupleConverter;
 import org.msgpack.value.ValueType;
 
@@ -49,10 +50,24 @@ public class RowsMetadataToTarantoolTupleResultMapperFactory
             new ArrayValueToTarantoolTupleConverter(messagePackMapper, spaceMetadata));
     }
 
+    public ValueConverterWithInputTypeWrapper<Object> getRowsMetadataToTarantoolTupleResultConverter(
+        MessagePackMapper messagePackMapper, TarantoolSpaceMetadata spaceMetadata) {
+        return getRowsMetadataToTarantoolTupleResultConverter(
+            new ArrayValueToTarantoolTupleConverter(messagePackMapper, spaceMetadata));
+    }
+
     public TarantoolResultMapper<TarantoolTuple> withRowsMetadataToTarantoolTupleResultConverter(
         ArrayValueToTarantoolTupleConverter tupleConverter) {
         return withConverterWithoutTargetClass(
             messagePackMapper.copy(),
+            ValueType.MAP,
+            new RowsMetadataToTarantoolTupleResultConverter(tupleConverter)
+        );
+    }
+
+    public ValueConverterWithInputTypeWrapper<Object> getRowsMetadataToTarantoolTupleResultConverter(
+        ArrayValueToTarantoolTupleConverter tupleConverter) {
+        return new ValueConverterWithInputTypeWrapper<>(
             ValueType.MAP,
             new RowsMetadataToTarantoolTupleResultConverter(tupleConverter)
         );

--- a/src/main/java/io/tarantool/driver/mappers/factories/SingleValueResultMapperFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/SingleValueResultMapperFactory.java
@@ -5,9 +5,11 @@ import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.converters.ValueConverter;
+import io.tarantool.driver.mappers.converters.ValueConverterWithInputTypeWrapper;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToSingleValueCallResultConverter;
 import io.tarantool.driver.mappers.converters.value.ArrayValueToSingleValueCallResultSimpleConverter;
 import org.msgpack.value.Value;
+import org.msgpack.value.ValueType;
 
 /**
  * Factory for {@link CallResultMapper} instances used for handling Lua call results resulting in two possible
@@ -105,5 +107,13 @@ public class SingleValueResultMapperFactory<T> extends TarantoolCallResultMapper
         return withConverter(
             messagePackMapper.copy(), new ArrayValueToSingleValueCallResultConverter<>(structureValueMapper),
             resultClass);
+    }
+
+    public ValueConverterWithInputTypeWrapper<Object> getSingleValueResultConverter(
+        MessagePackValueMapper structureValueMapper) {
+        return new ValueConverterWithInputTypeWrapper<>(
+            ValueType.ARRAY,
+            new ArrayValueToSingleValueCallResultConverter<>(structureValueMapper)
+        );
     }
 }

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
@@ -16,7 +16,6 @@ import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
-import io.tarantool.driver.api.tuple.TarantoolTupleResult;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.auth.TarantoolCredentials;
@@ -443,14 +442,14 @@ public class ProxyTarantoolClientIT extends SharedCartridgeContainer {
 
         ResultMapperFactoryFactory factory =
             client.getResultMapperFactoryFactory();
-        CallResultMapper callReturnMapper = factory.createMapper()
+        CallResultMapper callReturnMapper = factory.createMapper(valueMapper)
             .withSingleValueConverter(
-                factory.createMapper()
-                    .withArrayValueToTarantoolTupleResultConverter(valueMapper, null)
-                    .withRowsMetadataToTarantoolTupleResultMapper(valueMapper, null)
-                    .buildMessagePackMapper(valueMapper.copy())
+                factory.createMapper(valueMapper)
+                    .withArrayValueToTarantoolTupleResultConverter()
+                    .withRowsMetadataToTarantoolTupleResultConverter()
+                    .buildCallResultMapper()
             )
-            .buildCallResultMapper(valueMapper.copy());
+            .buildCallResultMapper();
 
         Object crudResult =
             client.call("crud.select", Collections.singletonList("test_space"), callReturnMapper).join();


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->

To use mappers for custom behavior

```java
MessagePackMapper valueMapper = client.getConfig().getMessagePackMapper();

ResultMapperFactoryFactory factory =
    client.getResultMapperFactoryFactory();
CallResultMapper callReturnMapper = factory.createMapper()
            .withSingleValueConverter(
                factory.createMapper()
                    .withArrayValueToTarantoolTupleResultConverter(valueMapper, null)
                    .withRowsMetadataToTarantoolTupleResultMapper(valueMapper, null)
                    .buildMessagePackMapper(valueMapper.copy())
            )
            .buildCallResultMapper(valueMapper.copy());

Object crudResult =
    client.call("crud.select", Collections.singletonList("test_space"), returnMapper).join();
assertTrue(crudResult instanceof TarantoolTupleResultImpl);
Object boxResult =
    client.call("select_request_counters", new ArrayList<>(), returnMapper).join();
assertTrue(boxResult instanceof TarantoolTupleResultImpl);
Object primitiveObject = client.call("returning_number", new ArrayList<>(), callReturnMapper).join();
assertEquals(2, primitiveObject);
```

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes https://github.com/tarantool/cartridge-java/issues/320
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
