### PR TITLE
Add default client request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Remove config request timeout as default parameter in crud client
 - Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 - Add deep copy instead of shallow copy in default message pack mapper
 

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
@@ -78,9 +78,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> delete(Conditions conditions) throws TarantoolClientException {
-        return delete(conditions, rowsMetadataTupleResultMapper(), ProxyDeleteOptions.create()
-            .withTimeout(config.getRequestTimeout())
-        );
+        return delete(conditions, rowsMetadataTupleResultMapper(), ProxyDeleteOptions.create());
     }
 
     @Override
@@ -113,9 +111,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> insert(T tuple) throws TarantoolClientException {
-        return insert(tuple, rowsMetadataTupleResultMapper(), ProxyInsertOptions.create()
-            .withTimeout(config.getRequestTimeout())
-        );
+        return insert(tuple, rowsMetadataTupleResultMapper(), ProxyInsertOptions.create());
     }
 
     @Override
@@ -147,7 +143,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
     @Override
     public CompletableFuture<R> insertMany(Collection<T> tuples) {
         return insertMany(tuples, rowsMetadataTupleResultMapper(), ProxyInsertManyOptions.create()
-            .withTimeout(config.getRequestTimeout())
             .withStopOnError(true)
             .withRollbackOnError(true)
         );
@@ -182,9 +177,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> replace(T tuple) throws TarantoolClientException {
-        return replace(tuple, rowsMetadataTupleResultMapper(), ProxyReplaceOptions.create()
-            .withTimeout(config.getRequestTimeout())
-        );
+        return replace(tuple, rowsMetadataTupleResultMapper(), ProxyReplaceOptions.create());
     }
 
     @Override
@@ -216,7 +209,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
     @Override
     public CompletableFuture<R> replaceMany(Collection<T> tuples) throws TarantoolClientException {
         return replaceMany(tuples, rowsMetadataTupleResultMapper(), ProxyReplaceManyOptions.create()
-            .withTimeout(config.getRequestTimeout())
             .withStopOnError(true)
             .withRollbackOnError(true)
         );
@@ -250,9 +242,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> select(Conditions conditions) throws TarantoolClientException {
-        return select(conditions, rowsMetadataTupleResultMapper(), ProxySelectOptions.create()
-            .withTimeout(config.getRequestTimeout())
-        );
+        return select(conditions, rowsMetadataTupleResultMapper(), ProxySelectOptions.create());
     }
 
     @Override
@@ -275,7 +265,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getSelectFunctionName())
             .withConditions(conditions)
-            .withOptions(options)
             .withArgumentsMapper(config.getMessagePackMapper())
             .withResultMapper(resultMapper)
             .withOptions(options)
@@ -288,7 +277,6 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
     public CompletableFuture<R> update(Conditions conditions, T tuple) {
         return update(conditions, makeOperationsFromTuple(tuple), rowsMetadataTupleResultMapper(),
             ProxyUpdateOptions.create()
-                .withTimeout(config.getRequestTimeout())
         );
     }
 
@@ -310,9 +298,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, TupleOperations operations) {
-        return update(conditions, operations, rowsMetadataTupleResultMapper(), ProxyUpdateOptions.create()
-            .withTimeout(config.getRequestTimeout())
-        );
+        return update(conditions, operations, rowsMetadataTupleResultMapper(), ProxyUpdateOptions.create());
     }
 
     @Override
@@ -346,9 +332,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> upsert(Conditions conditions, T tuple, TupleOperations operations) {
-        return upsert(conditions, tuple, operations, rowsMetadataTupleResultMapper(), ProxyUpsertOptions.create()
-            .withTimeout(config.getRequestTimeout())
-        );
+        return upsert(conditions, tuple, operations, rowsMetadataTupleResultMapper(), ProxyUpsertOptions.create());
     }
 
     @Override
@@ -389,9 +373,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
                 .withClient(client)
                 .withSpaceName(spaceName)
                 .withFunctionName(operationsMapping.getTruncateFunctionName())
-                .withOptions(ProxyTruncateOptions.create()
-                    .withTimeout(config.getRequestTimeout())
-                )
+                .withOptions(ProxyTruncateOptions.create())
                 .build()
             );
         } catch (TarantoolClientException e) {

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceDeleteOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceDeleteOptionsIT.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -87,7 +88,11 @@ public class ProxySpaceDeleteOptionsIT extends SharedCartridgeContainer {
         Conditions conditions = Conditions.equals(PK_FIELD_NAME, 1);
         profileSpace.delete(conditions).get();
         List<?> crudDeleteOpts = client.eval("return crud_delete_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudDeleteOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudDeleteOpts.get(0)).get("timeout"));
+
+        profileSpace.delete(conditions, ProxyDeleteOptions.create()).get();
+        crudDeleteOpts = client.eval("return crud_delete_opts").get();
+        assertNull(((HashMap) crudDeleteOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.delete(

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertManyOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertManyOptionsIT.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.proxy.ProxyInsertManyOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyReplaceManyOptions;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
@@ -25,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -123,12 +125,20 @@ public class ProxySpaceInsertManyOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.insertMany(tarantoolTuples).get();
         List<?> crudInsertManyOpts = client.eval("return crud_insert_many_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudInsertManyOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudInsertManyOpts.get(0)).get("timeout"));
 
-        // with option timeout
         tarantoolTuples = Arrays.asList(
             tupleFactory.create(3, null, "FIO", 50, 100),
             tupleFactory.create(4, null, "KEK", 75, 125)
+        );
+        profileSpace.insertMany(tarantoolTuples, ProxyInsertManyOptions.create()).get();
+        crudInsertManyOpts = client.eval("return crud_insert_many_opts").get();
+        assertNull(((HashMap) crudInsertManyOpts.get(0)).get("timeout"));
+
+        // with option timeout
+        tarantoolTuples = Arrays.asList(
+            tupleFactory.create(5, null, "FIO", 50, 100),
+            tupleFactory.create(6, null, "KEK", 75, 125)
         );
 
         profileSpace.insertMany(

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertOptionsIT.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.InsertOptions;
 import io.tarantool.driver.api.space.options.SelectOptions;
 import io.tarantool.driver.api.space.options.proxy.ProxyInsertOptions;
+import io.tarantool.driver.api.space.options.proxy.ProxyReplaceManyOptions;
 import io.tarantool.driver.api.space.options.proxy.ProxySelectOptions;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,7 +94,12 @@ public class ProxySpaceInsertOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.insert(tarantoolTuple).get();
         List<?> crudInsertOpts = client.eval("return crud_insert_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudInsertOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudInsertOpts.get(0)).get("timeout"));
+
+        profileSpace.delete(Conditions.equals(PK_FIELD_NAME, 1)).get();
+        profileSpace.insert(tarantoolTuple, ProxyInsertOptions.create()).get();
+        crudInsertOpts = client.eval("return crud_insert_opts").get();
+        assertNull(((HashMap) crudInsertOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.delete(Conditions.equals(PK_FIELD_NAME, 1)).get();

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceManyOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceManyOptionsIT.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -115,7 +116,11 @@ public class ProxySpaceReplaceManyOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.replaceMany(tarantoolTuples).get();
         List<?> crudReplaceManyOpts = client.eval("return crud_replace_many_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudReplaceManyOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudReplaceManyOpts.get(0)).get("timeout"));
+
+        profileSpace.replaceMany(tarantoolTuples, ProxyReplaceManyOptions.create()).get();
+        crudReplaceManyOpts = client.eval("return crud_replace_many_opts").get();
+        assertNull(((HashMap) crudReplaceManyOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.replaceMany(

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceOptionsIT.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -87,7 +88,14 @@ public class ProxySpaceReplaceOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.replace(tarantoolTuple).get();
         List<?> crudReplaceOpts = client.eval("return crud_replace_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudReplaceOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudReplaceOpts.get(0)).get("timeout"));
+
+        profileSpace.replace(
+            tarantoolTuple,
+            ProxyReplaceOptions.create()
+        ).get();
+        crudReplaceOpts = client.eval("return crud_replace_opts").get();
+        assertNull(((HashMap) crudReplaceOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.replace(

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceSelectOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceSelectOptionsIT.java
@@ -114,7 +114,14 @@ public class ProxySpaceSelectOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.select(Conditions.any()).get();
         List<?> crudSelectOpts = client.eval("return crud_select_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudSelectOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudSelectOpts.get(0)).get("timeout"));
+
+        profileSpace.select(
+            Conditions.any(),
+            ProxySelectOptions.create()
+        ).get();
+        crudSelectOpts = client.eval("return crud_select_opts").get();
+        assertNull(((HashMap) crudSelectOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.select(

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpdateOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpdateOptionsIT.java
@@ -87,7 +87,11 @@ public class ProxySpaceUpdateOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.update(conditions, tarantoolTuple).get();
         List<?> crudUpdateOpts = client.eval("return crud_update_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudUpdateOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudUpdateOpts.get(0)).get("timeout"));
+
+        profileSpace.update(conditions, tarantoolTuple, ProxyUpdateOptions.create()).get();
+        crudUpdateOpts = client.eval("return crud_update_opts").get();
+        assertNull(((HashMap) crudUpdateOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.update(

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpsertOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpsertOptionsIT.java
@@ -85,7 +85,12 @@ public class ProxySpaceUpsertOptionsIT extends SharedCartridgeContainer {
         // with config timeout
         profileSpace.upsert(conditions, tarantoolTuple, TupleOperations.set("age", 50)).get();
         List<?> crudUpsertOpts = client.eval("return crud_upsert_opts").get();
-        assertEquals(requestConfigTimeout, ((HashMap) crudUpsertOpts.get(0)).get("timeout"));
+        assertNull(((HashMap) crudUpsertOpts.get(0)).get("timeout"));
+
+        profileSpace.upsert(conditions, tarantoolTuple, TupleOperations.set("age", 50),
+            ProxyUpsertOptions.create()).get();
+        crudUpsertOpts = client.eval("return crud_upsert_opts").get();
+        assertNull(((HashMap) crudUpsertOpts.get(0)).get("timeout"));
 
         // with option timeout
         profileSpace.upsert(


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->
@ akudiyar changed the behaviour https://github.com/tarantool/cartridge-java/commit/57af227042cdc6402749e39a70a49ae61b94eb9a#diff-b2ae385ada02a75ad946141c7af41540970760d41d02d54209c00eabdc9bc8e3L175

I suggest make "OR" condition. If we have options.timeout, we use it, otherwise we use client.getTimeout()

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
