### PR TITLE
Add metadataFormatIsEmpty in TarantoolTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Remove config request timeout as default parameter in crud client
 - Add details for the case of space metadata fetching failure ([#200](https://github.com/tarantool/cartridge-java/issues/200))
+- Add metadataFormatIsEmpty in TarantoolTuple
 - Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 - Split retrying into more detailed modules ([#341](https://github.com/tarantool/cartridge-java/issues/341))
 - Add deep copy instead of shallow copy in default message pack mapper ([#166](https://github.com/tarantool/cartridge-java/issues/166))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 - Remove config request timeout as default parameter in crud client
 - Add details for the case of space metadata fetching failure ([#200](https://github.com/tarantool/cartridge-java/issues/200))
-- Add metadataFormatIsEmpty in TarantoolTuple
+- Add hasMetadata in TarantoolTuple
 - Close public access to TarantoolResult*Impl ([#326](https://github.com/tarantool/cartridge-java/issues/326))
 - Split retrying into more detailed modules ([#341](https://github.com/tarantool/cartridge-java/issues/341))
 - Add deep copy instead of shallow copy in default message pack mapper ([#166](https://github.com/tarantool/cartridge-java/issues/166))

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolTuple.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolTuple.java
@@ -15,6 +15,13 @@ import java.util.UUID;
  */
 public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
+     * Check whether tuple have information about space format
+     *
+     * @return true if we obtain fields by names
+     */
+    boolean metadataFormatIsEmpty();
+
+    /**
      * Get a tuple field by its position
      *
      * @param fieldPosition the field position from the the tuple start, starting from 0

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolTuple.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolTuple.java
@@ -15,11 +15,11 @@ import java.util.UUID;
  */
 public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
-     * Check whether tuple have information about space format
+     * Check whether this tuple includes information about space format
      *
-     * @return true if we obtain fields by names
+     * @return true if we can obtain the tuple fields by names
      */
-    boolean metadataFormatIsEmpty();
+    boolean hasMetadata();
 
     /**
      * Get a tuple field by its position

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -137,7 +137,7 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     }
 
     @Override
-    public boolean metadataFormatIsEmpty() {
+    public boolean hasMetadata() {
         return spaceMetadata == null || spaceMetadata.getSpaceFormatMetadata() == null ||
                    spaceMetadata.getSpaceFormatMetadata().isEmpty();
     }

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -137,6 +137,12 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     }
 
     @Override
+    public boolean metadataFormatIsEmpty() {
+        return spaceMetadata == null || spaceMetadata.getSpaceFormatMetadata() == null ||
+                   spaceMetadata.getSpaceFormatMetadata().isEmpty();
+    }
+
+    @Override
     public Optional<TarantoolField> getField(int fieldPosition) {
         Assert.state(fieldPosition >= 0, "Field position starts with 0");
 

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -404,7 +404,19 @@ public class ClusterTarantoolTupleClientIT {
         ).get();
 
         assertTrue(result.size() >= 3);
-        assertEquals(1605, result.get(0).getInteger("year"));
+        TarantoolTuple tuple = result.get(0);
+        assertFalse(tuple.metadataFormatIsEmpty());
+        assertEquals(1605, tuple.getInteger("year"));
+
+        result = client.call(
+            "user_function_complex_query",
+            Collections.singletonList(1000),
+            defaultMapper,
+            factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null)
+        ).get();
+        assertTrue(result.size() >= 3);
+        tuple = result.get(0);
+        assertTrue(tuple.metadataFormatIsEmpty());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -22,7 +22,7 @@ import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
-import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -405,7 +405,7 @@ public class ClusterTarantoolTupleClientIT {
 
         assertTrue(result.size() >= 3);
         TarantoolTuple tuple = result.get(0);
-        assertFalse(tuple.metadataFormatIsEmpty());
+        assertFalse(tuple.hasMetadata());
         assertEquals(1605, tuple.getInteger("year"));
 
         result = client.call(
@@ -416,7 +416,7 @@ public class ClusterTarantoolTupleClientIT {
         ).get();
         assertTrue(result.size() >= 3);
         tuple = result.get(0);
-        assertTrue(tuple.metadataFormatIsEmpty());
+        assertTrue(tuple.hasMetadata());
     }
 
     @Test


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->

It's needed when we expected crud and box responses by one mapper(AUTO mapper in cartridge-springdata). In case when we obtain box response and we didn't have prepared metadata from ddl/_vspace, we can't map these values to Entity without metadata and we can't check whether we have it or not. And we can't raise an exception that we don't have metadata before because we can take it from crud response. Springdata doesn't see a difference between crud and box responses, it only got TarantoolTupleResult

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Needed for https://github.com/tarantool/cartridge-springdata/issues/123
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
