### PR TITLE
Add can convert value to TupleResultConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Split retrying into more detailed modules ([#341](https://github.com/tarantool/cartridge-java/issues/341))
 - Add deep copy instead of shallow copy in default message pack mapper
 - Add a factory builder for constructing mapper hierarchies
+- Add can convert value to TupleResultConverter
 
 ## [0.10.1] - 2023-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Split retrying into more detailed modules ([#341](https://github.com/tarantool/cartridge-java/issues/341))
 - Add deep copy instead of shallow copy in default message pack mapper
 - Add a factory builder for constructing mapper hierarchies
-- Add can convert value to TupleResultConverter
+- Add "can convert value" check to TupleResultConverter
 
 ## [0.10.1] - 2023-01-13
 

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/ArrayValueToTarantoolTupleResultConverter.java
@@ -30,4 +30,9 @@ public class ArrayValueToTarantoolTupleResultConverter
     public TarantoolResult<TarantoolTuple> fromValue(ArrayValue value) {
         return tarantoolResultFactory.createTarantoolTupleResultImpl(value, tupleConverter);
     }
+
+    @Override
+    public boolean canConvertValue(ArrayValue value) {
+        return value.size() == 0 || value.get(0).isArrayValue();
+    }
 }

--- a/src/test/java/io/tarantool/driver/mappers/TarantoolCallResultMapperTest.java
+++ b/src/test/java/io/tarantool/driver/mappers/TarantoolCallResultMapperTest.java
@@ -108,7 +108,7 @@ public class TarantoolCallResultMapperTest {
         ArrayValue testTuples = ValueFactory.newArray(tupleOne.toMessagePackValue(defaultMapper));
 
         // Another corner case, tuple result mapper should not be used for this result format
-        assertThrows(TarantoolTupleConversionException.class, () -> defaultResultMapper.fromValue(testTuples));
+        assertThrows(MessagePackValueMapperException.class, () -> defaultResultMapper.fromValue(testTuples));
     }
 
     @Test


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->

It's needed when we want to take maps in the array. Springdata can map map structures. Using AUTO converter we can't map a simple array without tuples to the array and pass conversion control to the next layer.

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Needed for https://github.com/tarantool/cartridge-springdata/issues/123
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
