### PR TITLE
Add Datetime to Instant converter

### DIFF
--- a/.github/workflows/tests-ce.yml
+++ b/.github/workflows/tests-ce.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tarantool-version: [ "1.10", "2.8" ]
+        tarantool-version: [ "1.x", "2.10.6", "2.x" ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests-ce.yml
+++ b/.github/workflows/tests-ce.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tarantool-version: [ "1.x", "2.10.6", "2.x" ]
+        tarantool-version: [ "1.x", "2.10.6"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add deep copy instead of shallow copy in default message pack mapper ([#166](https://github.com/tarantool/cartridge-java/issues/166))
 - Add a factory builder for constructing mapper hierarchies
 - Add "can convert value" check to TupleResultConverter
+- Support Datetime type ([#293](https://github.com/tarantool/cartridge-java/pull/293))
 
 ## [0.10.1] - 2023-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add deep copy instead of shallow copy in default message pack mapper ([#166](https://github.com/tarantool/cartridge-java/issues/166))
 - Add a factory builder for constructing mapper hierarchies
 - Add "can convert value" check to TupleResultConverter
-- Support Datetime type ([#293](https://github.com/tarantool/cartridge-java/pull/293))
+- Support Datetime type ([#214](https://github.com/tarantool/cartridge-java/pull/214))
 
 ## [0.10.1] - 2023-01-13
 

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <dependency>
             <groupId>io.tarantool</groupId>
             <artifactId>testcontainers-java-tarantool</artifactId>
-            <version>0.5.3</version>
+            <version>0.5.4</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/io/tarantool/driver/api/tuple/TarantoolTuple.java
+++ b/src/main/java/io/tarantool/driver/api/tuple/TarantoolTuple.java
@@ -1,12 +1,13 @@
 package io.tarantool.driver.api.tuple;
 
-import io.tarantool.driver.protocol.Packable;
-
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+
+import io.tarantool.driver.protocol.Packable;
 
 /**
  * Basic Tarantool atom of data
@@ -24,7 +25,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get a tuple field by its position
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return field or empty optional if the field position is out of tuple length
      */
     Optional<TarantoolField> getField(int fieldPosition);
@@ -47,7 +48,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get a tuple field value by its position specifying the target value type
      *
-     * @param fieldPosition field position from the the tuple start, starting from 0
+     * @param fieldPosition field position from the tuple start, starting from 0
      * @param objectClass   target value type class
      * @param <O>           target value type
      * @return nullable value of a field wrapped in Optional, possibly converted to a Java type
@@ -57,7 +58,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Check if a tuple field exists and can be converted to the target value type
      *
-     * @param fieldPosition field position from the the tuple start, starting from 0
+     * @param fieldPosition field position from the tuple start, starting from 0
      * @param objectClass   target value type class
      * @return true, if the field exists and can be converted to the given type, false otherwise
      */
@@ -85,7 +86,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get a tuple field value as a raw object
      *
-     * @param fieldPosition field position from the the tuple start, starting from 0
+     * @param fieldPosition field position from the tuple start, starting from 0
      * @return nullable value of a field wrapped in Optional
      */
     Optional<?> getObject(int fieldPosition);
@@ -108,7 +109,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Set a tuple field by field position
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @param field         new field
      */
     void setField(int fieldPosition, TarantoolField field);
@@ -124,7 +125,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Set a tuple field value from an object by field position
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @param value         new field value
      */
     void putObject(int fieldPosition, Object value);
@@ -140,7 +141,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code byte[]}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     byte[] getByteArray(int fieldPosition);
@@ -156,7 +157,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code Boolean}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Boolean getBoolean(int fieldPosition);
@@ -172,7 +173,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code Double}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Double getDouble(int fieldPosition);
@@ -188,7 +189,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code Float}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Float getFloat(int fieldPosition);
@@ -204,7 +205,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code Integer}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Integer getInteger(int fieldPosition);
@@ -220,7 +221,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code Long}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Long getLong(int fieldPosition);
@@ -236,7 +237,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code String}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     String getString(int fieldPosition);
@@ -252,7 +253,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@code Character}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Character getCharacter(int fieldPosition);
@@ -268,7 +269,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@link UUID}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     UUID getUUID(int fieldPosition);
@@ -282,9 +283,25 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     UUID getUUID(String fieldName);
 
     /**
+     * Get the field value converted to {@link Instant}
+     *
+     * @param fieldPosition the field position from the tuple start, starting from 0
+     * @return value
+     */
+    Instant getInstant(int fieldPosition);
+
+    /**
+     * Get the field value converted to {@link Instant}
+     *
+     * @param fieldName the field name, must not be null
+     * @return value
+     */
+    Instant getInstant(String fieldName);
+
+    /**
      * Get the field value converted to {@link BigDecimal}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     BigDecimal getDecimal(int fieldPosition);
@@ -300,7 +317,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@link List}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     List<?> getList(int fieldPosition);
@@ -316,7 +333,7 @@ public interface TarantoolTuple extends Iterable<TarantoolField>, Packable {
     /**
      * Get the field value converted to {@link Map}
      *
-     * @param fieldPosition the field position from the the tuple start, starting from 0
+     * @param fieldPosition the field position from the tuple start, starting from 0
      * @return value
      */
     Map<?, ?> getMap(int fieldPosition);

--- a/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
+++ b/src/main/java/io/tarantool/driver/core/tuple/TarantoolTupleImpl.java
@@ -18,6 +18,7 @@ import org.msgpack.value.Value;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -366,6 +367,16 @@ public class TarantoolTupleImpl implements TarantoolTuple {
     @Override
     public UUID getUUID(String fieldName) {
         return getObject(fieldName, UUID.class).orElse(null);
+    }
+
+    @Override
+    public Instant getInstant(int fieldPosition) {
+        return getObject(fieldPosition, Instant.class).orElse(null);
+    }
+
+    @Override
+    public Instant getInstant(String fieldName) {
+        return getObject(fieldName, Instant.class).orElse(null);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultInstantToExtensionValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultInstantToExtensionValueConverter.java
@@ -1,0 +1,38 @@
+package io.tarantool.driver.mappers.converters.object;
+
+import io.tarantool.driver.mappers.converters.ObjectConverter;
+
+import org.msgpack.core.MessageBufferPacker;
+import org.msgpack.core.MessagePack;
+import org.msgpack.value.ExtensionValue;
+import org.msgpack.value.ValueFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Instant;
+
+/**
+ * Default {@link java.time.Instant} to {@link ExtensionValue} converter
+ *
+ * @author Anastasiia Romanova
+ * @author Artyom Dubinin
+ */
+public class DefaultInstantToExtensionValueConverter implements ObjectConverter<Instant, ExtensionValue> {
+
+    private static final long serialVersionUID = 20221025L;
+
+    private static final byte DATETIME_TYPE = 0x04;
+
+    private byte[] toBytes(Instant value) {
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[16]);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        buffer.putLong(value.getEpochSecond());
+        buffer.putInt(value.getNano());
+        return buffer.array();
+    }
+
+    @Override
+    public ExtensionValue toValue(Instant object) {
+        return ValueFactory.newExtension(DATETIME_TYPE, toBytes(object));
+    }
+}

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/defaults/DefaultExtensionValueToInstantConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/defaults/DefaultExtensionValueToInstantConverter.java
@@ -1,0 +1,36 @@
+package io.tarantool.driver.mappers.converters.value.defaults;
+
+import io.tarantool.driver.mappers.converters.ValueConverter;
+import org.msgpack.value.ExtensionValue;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Instant;
+
+/**
+ * Default {@link ExtensionValue} to {@link java.time.Instant} converter
+ *
+ * @author Anastasiia Romanova
+ * @author Artyom Dubinin
+ */
+public class DefaultExtensionValueToInstantConverter implements ValueConverter<ExtensionValue, Instant> {
+
+    private static final long serialVersionUID = 20221025L;
+    private static final byte DATETIME_TYPE = 0x04;
+
+    private Instant fromBytes(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        return Instant.ofEpochSecond(buffer.getLong()).plusNanos(buffer.getInt());
+    }
+
+    @Override
+    public Instant fromValue(ExtensionValue value) {
+        return fromBytes(value.getData());
+    }
+
+    @Override
+    public boolean canConvertValue(ExtensionValue value) {
+        return value.getType() == DATETIME_TYPE;
+    }
+}

--- a/src/main/java/io/tarantool/driver/mappers/factories/DefaultMessagePackMapperFactory.java
+++ b/src/main/java/io/tarantool/driver/mappers/factories/DefaultMessagePackMapperFactory.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.mappers.converters.object.DefaultByteArrayToBinaryVal
 import io.tarantool.driver.mappers.converters.object.DefaultCharacterToStringValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultDoubleToFloatValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultFloatToFloatValueConverter;
+import io.tarantool.driver.mappers.converters.object.DefaultInstantToExtensionValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultIntegerToIntegerValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultLongArrayToArrayValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultLongToIntegerValueConverter;
@@ -15,6 +16,7 @@ import io.tarantool.driver.mappers.converters.object.DefaultPackableObjectConver
 import io.tarantool.driver.mappers.converters.object.DefaultShortToIntegerValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultStringToStringValueConverter;
 import io.tarantool.driver.mappers.converters.object.DefaultUUIDToExtensionValueConverter;
+import io.tarantool.driver.mappers.converters.value.defaults.DefaultExtensionValueToInstantConverter;
 import io.tarantool.driver.mappers.converters.value.defaults.DefaultArrayValueToLongArrayConverter;
 import io.tarantool.driver.mappers.converters.value.defaults.DefaultBinaryValueToByteArrayConverter;
 import io.tarantool.driver.mappers.converters.value.defaults.DefaultBooleanValueToBooleanConverter;
@@ -43,6 +45,7 @@ import org.msgpack.value.StringValue;
 import org.msgpack.value.ValueType;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -82,6 +85,7 @@ public final class DefaultMessagePackMapperFactory {
             .withValueConverter(ValueType.EXTENSION, UUID.class, new DefaultExtensionValueToUUIDConverter())
             .withValueConverter(ValueType.EXTENSION, BigDecimal.class,
                 new DefaultExtensionValueToBigDecimalConverter())
+            .withValueConverter(ValueType.EXTENSION, Instant.class, new DefaultExtensionValueToInstantConverter())
             .withValueConverter(ValueType.NIL, Object.class, new DefaultNilValueToNullConverter())
             //TODO: Potential issue https://github.com/tarantool/cartridge-java/issues/118
             .withObjectConverter(Character.class, StringValue.class, new DefaultCharacterToStringValueConverter())
@@ -97,6 +101,7 @@ public final class DefaultMessagePackMapperFactory {
             .withObjectConverter(UUID.class, ExtensionValue.class, new DefaultUUIDToExtensionValueConverter())
             .withObjectConverter(BigDecimal.class, ExtensionValue.class,
                 new DefaultBigDecimalToExtensionValueConverter())
+            .withObjectConverter(Instant.class, ExtensionValue.class, new DefaultInstantToExtensionValueConverter())
             .build();
     }
 

--- a/src/test/java/io/tarantool/driver/TarantoolUtils.java
+++ b/src/test/java/io/tarantool/driver/TarantoolUtils.java
@@ -15,7 +15,7 @@ public final class TarantoolUtils {
     private TarantoolUtils() {
     }
 
-    public static boolean versionGreaterThen(String tarantoolVersion) {
+    public static boolean versionGreaterOrEqualThen(String tarantoolVersion) {
         Assert.notNull(tarantoolVersion, "tarantoolVersion must not be null");
         String tarantoolCiVersion = java.lang.System.getenv(TARANTOOL_VERSION);
         if (StringUtils.isEmpty(tarantoolCiVersion)) {
@@ -23,29 +23,37 @@ public final class TarantoolUtils {
         }
         TarantoolVersion ciVersion = new TarantoolVersion(tarantoolCiVersion);
         TarantoolVersion version = new TarantoolVersion(tarantoolVersion);
-        return ciVersion.getMajor() > version.getMajor() &&
-            ciVersion.getMinor() > version.getMinor();
+        return ciVersion.getMajor() >= version.getMajor() &&
+            ciVersion.getMinor() >= version.getMinor();
     }
 
     public static boolean versionWithUUID() {
-        return versionGreaterThen("2.4");
+        return versionGreaterOrEqualThen("2.4");
+    }
+
+    public static boolean versionWithInstant() {
+        return versionGreaterOrEqualThen("2.10");
     }
 
     public static boolean versionWithVarbinary() {
-        return versionGreaterThen("2.2.1");
+        return versionGreaterOrEqualThen("2.2.1");
     }
 
     public static class TarantoolVersion {
-        private final Integer major;
-        private final Integer minor;
+        private Integer major;
+        private Integer minor;
 
         public TarantoolVersion(String stringVersion) {
-            List<Integer> majorMinor = StringUtils.isEmpty(stringVersion) ? Collections.emptyList() :
+            List<String> majorMinor = StringUtils.isEmpty(stringVersion) ? Collections.emptyList() :
                 Arrays.stream(stringVersion.split("\\."))
-                    .map(Integer::parseInt)
                     .collect(Collectors.toList());
-            major = majorMinor.size() >= 1 ? majorMinor.get(0) : 0;
-            minor = majorMinor.size() >= 2 ? majorMinor.get(1) : 0;
+            if (majorMinor.size() >= 1) {
+                major = Integer.parseInt(majorMinor.get(0));
+            }
+            if (majorMinor.size() >= 2) {
+                String minorStr = majorMinor.get(1);
+                minor = minorStr.equals("x") ? 999 : Integer.parseInt(minorStr);
+            }
         }
 
         public Integer getMajor() {

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -49,47 +49,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
-public class ClusterTarantoolTupleClientIT {
+public class ClusterTarantoolTupleClientIT extends SharedTarantoolContainer {
 
     private static final String TEST_SPACE_NAME = "test_space";
     private static final Logger log = LoggerFactory.getLogger(ClusterTarantoolTupleClientIT.class);
 
-    @Container
-    private static final TarantoolContainer tarantoolContainer = new TarantoolContainer()
-        .withScriptFileName("org/testcontainers/containers/server.lua")
-        .withLogConsumer(new Slf4jLogConsumer(log));
-
-    private static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
     private static final DefaultMessagePackMapperFactory mapperFactory = DefaultMessagePackMapperFactory.getInstance();
 
     @BeforeAll
     public static void setUp() {
-        assertTrue(tarantoolContainer.isRunning());
+        startContainer();
         initClient();
     }
 
     public static void tearDown() throws Exception {
         client.close();
         assertThrows(TarantoolClientException.class, () -> client.metadata().getSpaceByName("_space"));
-    }
-
-    private static void initClient() {
-        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
-            tarantoolContainer.getUsername(), tarantoolContainer.getPassword());
-
-        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
-            tarantoolContainer.getHost(), tarantoolContainer.getPort());
-
-        TarantoolClientConfig config = new TarantoolClientConfig.Builder()
-            .withCredentials(credentials)
-            .withConnectTimeout(1000 * 5)
-            .withReadTimeout(1000 * 5)
-            .withRequestTimeout(1000 * 5)
-            .build();
-
-        log.info("Attempting connect to Tarantool");
-        client = new ClusterTarantoolTupleClient(config, serverAddress);
-        log.info("Successfully connected to Tarantool, version = {}", client.getVersion());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/ConvertersWithClusterClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ConvertersWithClusterClientIT.java
@@ -15,10 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
+import java.time.Instant;
+import java.util.UUID;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * @author Artyom Dubinin
@@ -61,6 +63,23 @@ public class ConvertersWithClusterClientIT extends SharedTarantoolContainer {
 
         //then
         Assertions.assertEquals(uuid, fields.getUUID("uuid_field"));
+    }
+
+    @Test
+    @EnabledIf("io.tarantool.driver.TarantoolUtils#versionWithInstant")
+    public void test_boxSelect_shouldReturnTupleWithInstant() throws Exception {
+        //given
+        Instant instant = Instant.now();
+        client.space("space_with_instant")
+                .insert(tupleFactory.create(1, instant)).get();
+
+        //when
+        TarantoolTuple fields = client
+                .space("space_with_instant")
+                .select(Conditions.equals("id", 1)).get().get(0);
+
+        //then
+        Assertions.assertEquals(instant, fields.getInstant("instant_field"));
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/ConvertersWithProxyClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ConvertersWithProxyClientIT.java
@@ -15,10 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
+import java.time.Instant;
+import java.util.UUID;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * @author Artyom Dubinin
@@ -62,6 +64,23 @@ public class ConvertersWithProxyClientIT extends SharedCartridgeContainer {
 
         //then
         Assertions.assertEquals(uuid, fields.getUUID("uuid_field"));
+    }
+
+    @Test
+    @EnabledIf("io.tarantool.driver.TarantoolUtils#versionWithInstant")
+    public void test_crudSelect_shouldReturnTupleWithInstant() throws Exception {
+        //given
+        Instant instant = Instant.now();
+        client.space("space_with_instant")
+                .insert(tupleFactory.create(1, instant)).get();
+
+        //when
+        TarantoolTuple fields = client
+                .space("space_with_instant")
+                .select(Conditions.equals("id", 1)).get().get(0);
+
+        //then
+        Assertions.assertEquals(instant, fields.getInstant("instant_field"));
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/SharedTarantoolContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedTarantoolContainer.java
@@ -9,7 +9,11 @@ abstract class SharedTarantoolContainer {
 
     private static final Logger logger = LoggerFactory.getLogger(SharedTarantoolContainer.class);
 
-    protected static final TarantoolContainer container = new TarantoolContainer()
+    protected static final String tarantoolVersion = System.getenv().get("TARANTOOL_VERSION");
+    protected static final TarantoolContainer container =
+        new TarantoolContainer(
+            String.format("tarantool/tarantool:%s-centos7",
+                tarantoolVersion != null ? tarantoolVersion : "2.10.5"))
         .withScriptFileName("org/testcontainers/containers/server.lua")
         .withLogConsumer(new Slf4jLogConsumer(logger));
 

--- a/src/test/java/io/tarantool/driver/integration/SharedTarantoolContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedTarantoolContainer.java
@@ -5,9 +5,19 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.TarantoolContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolClientConfig;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.TarantoolServerAddress;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import io.tarantool.driver.auth.TarantoolCredentials;
+import io.tarantool.driver.core.ClusterTarantoolTupleClient;
+
 abstract class SharedTarantoolContainer {
 
     private static final Logger logger = LoggerFactory.getLogger(SharedTarantoolContainer.class);
+    protected static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
 
     protected static final String tarantoolVersion = System.getenv().get("TARANTOOL_VERSION");
     protected static final TarantoolContainer container =
@@ -21,5 +31,24 @@ abstract class SharedTarantoolContainer {
         if (!container.isRunning()) {
             container.start();
         }
+    }
+
+    protected static void initClient() {
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+            container.getUsername(), container.getPassword());
+
+        TarantoolServerAddress serverAddress = new TarantoolServerAddress(
+            container.getHost(), container.getPort());
+
+        TarantoolClientConfig config = new TarantoolClientConfig.Builder()
+                                           .withCredentials(credentials)
+                                           .withConnectTimeout(1000 * 5)
+                                           .withReadTimeout(1000 * 5)
+                                           .withRequestTimeout(1000 * 5)
+                                           .build();
+
+        logger.info("Attempting connect to Tarantool");
+        client = new ClusterTarantoolTupleClient(config, serverAddress);
+        logger.info("Successfully connected to Tarantool, version = {}", client.getVersion());
     }
 }

--- a/src/test/java/io/tarantool/driver/mappers/DefaultInstantConverterTest.java
+++ b/src/test/java/io/tarantool/driver/mappers/DefaultInstantConverterTest.java
@@ -1,0 +1,54 @@
+package io.tarantool.driver.mappers;
+
+import io.tarantool.driver.mappers.converters.object.DefaultInstantToExtensionValueConverter;
+import io.tarantool.driver.mappers.converters.value.defaults.DefaultExtensionValueToInstantConverter;
+
+import org.junit.jupiter.api.Test;
+import org.msgpack.core.MessageBufferPacker;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.value.ExtensionValue;
+import org.msgpack.value.ImmutableExtensionValue;
+import org.msgpack.value.ValueFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultInstantConverterTest {
+    @Test
+    void toValue() throws IOException {
+        DefaultInstantToExtensionValueConverter converter = new DefaultInstantToExtensionValueConverter();
+        MessagePacker packer = MessagePack.newDefaultBufferPacker();
+        Base64.Encoder encoder = Base64.getEncoder();
+        Instant instant = LocalDateTime.parse("2022-10-25T12:03:58").toInstant(ZoneOffset.UTC);
+        byte[] result = ((MessageBufferPacker) packer.packValue(converter.toValue(instant))).toByteArray();
+        assertEquals("2ASu0FdjAAAAAAAAAAAAAAAA", encoder.encodeToString(result));
+    }
+
+    @Test
+    void fromValue() throws IOException {
+        DefaultExtensionValueToInstantConverter converter = new DefaultExtensionValueToInstantConverter();
+        Base64.Decoder base64decoder = Base64.getDecoder();
+        Instant instant = LocalDateTime.parse("2022-10-25T12:03:58").toInstant(ZoneOffset.UTC);
+        byte[] packed = base64decoder.decode("2ASu0FdjAAAAAAAAAAAAAAAA");
+        ExtensionValue value = MessagePack.newDefaultUnpacker(packed).unpackValue().asExtensionValue();
+        assertEquals(instant, converter.fromValue(value));
+    }
+
+    @Test
+    void canConvertValue() {
+        DefaultExtensionValueToInstantConverter converter = new DefaultExtensionValueToInstantConverter();
+        assertFalse(converter.canConvertValue(ValueFactory.newExtension((byte) 100, new byte[]{0})));
+        assertFalse(converter.canConvertValue(ValueFactory.newExtension((byte) 0x01, new byte[]{0})));
+        ImmutableExtensionValue value = ValueFactory.newExtension((byte) 0x04, new byte[]{0});
+        assertTrue(converter.canConvertValue(value));
+    }
+}

--- a/src/test/resources/cartridge/app/roles/api_storage.lua
+++ b/src/test/resources/cartridge/app/roles/api_storage.lua
@@ -147,6 +147,23 @@ local function init_space()
             { parts = { 'bucket_id' }, unique = false, if_not_exists = true, })
     end
 
+    if major >= 2 and minor >= 10 and patch > 1 then
+        -- test space for check instant
+        local space_with_instant = box.schema.space.create(
+            'space_with_instant',
+            {
+                format = {
+                    { 'id', 'unsigned' },
+                    { 'instant_field', 'datetime',},
+                    { 'bucket_id', 'unsigned' },
+                },
+                if_not_exists = true,
+            }
+        )
+        space_with_instant:create_index('id', { parts = { 'id' }, if_not_exists = true, })
+        space_with_instant:create_index('bucket_id', { parts = { 'bucket_id' }, unique = false, if_not_exists = true, })
+    end
+
     local space_with_string = box.schema.space.create(
         'space_with_string',
         {

--- a/src/test/resources/org/testcontainers/containers/server.lua
+++ b/src/test/resources/org/testcontainers/containers/server.lua
@@ -107,6 +107,34 @@ if major >= 2 and minor >= 2 and patch > 1 then
     )
     space_with_varbinary:create_index('id', { parts = { 'id' }, if_not_exists = true, })
 end
+if major >= 2 and minor >= 10 and patch > 1 then
+    -- test space for check instant
+    local space_with_instant = box.schema.space.create(
+            'space_with_instant',
+            {
+                format = {
+                    { 'id', 'unsigned' },
+                    { 'instant_field', 'datetime',},
+                },
+                if_not_exists = true,
+            }
+    )
+    space_with_instant:create_index('id', { parts = { 'id' }, if_not_exists = true, })
+end
+if major >= 2 and minor >= 10 and patch > 1 then
+    -- test space for check instant
+    local space_with_instant = box.schema.space.create(
+            'space_with_instant',
+            {
+                format = {
+                    { 'id', 'unsigned' },
+                    { 'instant_field', 'datetime',},
+                },
+                if_not_exists = true,
+            }
+    )
+    space_with_instant:create_index('id', { parts = { 'id' }, if_not_exists = true, })
+end
 
 --functions
 


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->

This converter can support parsing Datetime tarantool type to java Instant. Because Instant doesn't support timezone and offset we can't support full DateTime type features. 

Also to test new features we need to have variants of tarantool in CI so we did:
 - Changing tarantool container init to use version depending on CI TARANTOOL_VERSION variable. 
 - Updating cartridge-java-testcontainer so that the cartridge container is based on the same image as tarantool container (see https://github.com/tarantool/cartridge-java-testcontainers/commit/12927b943b84e5cea1a9b1995c4917b159b7c76c).

But we have one problem with versions. Tarantool on Docker hub has fixed patches only for 2.10 version if we speak about centos versions. Besides 2.10 versions we only can use 1.x, 2.x tags. That means the latest versions, for e.g. 1.10.15, 2.10.6. Then we have two ways:
 1) centos
   - use fixed 2.10
   - 1.x
 2) alpine
   - use fixed 2.8
   - use fixed 2.10
   - use fixed 1.10 
   - others

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #214
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
