### PR TITLE
Get rid of double executor in retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Bugfixes
 - Fix lack of closing when greeting fails ([#379](https://github.com/tarantool/cartridge-java/pull/379))
+- Get rid of double executor in retrying ([#382](https://github.com/tarantool/cartridge-java/pull/382))
 
 ## [0.11.1] - 2023-04-24
+
 ### Bugfixes
 - Fix hasMetadata logic
 

--- a/src/test/java/io/tarantool/driver/benchmark/BenchmarkRunner.java
+++ b/src/test/java/io/tarantool/driver/benchmark/BenchmarkRunner.java
@@ -164,4 +164,12 @@ public class BenchmarkRunner {
         bh.consume(plan.tarantoolClient.call(
             "empty_function", plan.arraysWithNestedMaps).join());
     }
+
+    @Benchmark
+    @Fork(1)
+    @BenchmarkMode(Mode.Throughput)
+    public void spaceCall(TarantoolSetup plan, Blackhole bh) {
+        bh.consume(plan.retryingTarantoolClient.space(
+            "test_space"));
+    }
 }

--- a/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
@@ -35,6 +35,7 @@ public class TarantoolSetup {
         .withLogConsumer(new Slf4jLogConsumer(log));
 
     TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> tarantoolClient;
+    TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> retryingTarantoolClient;
     MessagePackMapper defaultMapper;
     CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
         resultMapper;
@@ -48,6 +49,9 @@ public class TarantoolSetup {
             .withAddress(tarantoolContainer.getHost(), tarantoolContainer.getPort())
             .withCredentials(tarantoolContainer.getUsername(), tarantoolContainer.getPassword())
             .build();
+
+        retryingTarantoolClient
+            = TarantoolClientFactory.configureClient(tarantoolClient).withRetryingByNumberOfAttempts(3).build();
 
         TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
             TarantoolTupleResultMapperFactoryImpl.getInstance();


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->

Before changing:
```jmh
Benchmark                   Mode  Cnt      Score       Error  Units
BenchmarkRunner.spaceCall  thrpt    5  74844.508 ± 16460.492  ops/s
```


After changing:
```jmh
Benchmark                   Mode  Cnt       Score        Error  Units
BenchmarkRunner.spaceCall  thrpt    5  275476.264 ± 256775.771  ops/s
```

* Error means mean margin between iteration:

> This is the margin of error for the score. In most cases, that is a half of [confidence interval](http://en.wikipedia.org/wiki/Confidence_interval). Think about it as if there is a "±" sign between "Score" and "Score error". In fact, the human-readable log will show that:

```
Iteration   1: 334564.445 ops/s
Iteration   2: 226016.924 ops/s
Iteration   3: 343260.667 ops/s
Iteration   4: 190627.608 ops/s
Iteration   5: 282911.676 ops/s
```

I haven't forgotten about:
- [ ] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #382
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
