### PR TITLE
Add support of numerical index path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal and API changes
 - **[breaking change]** Split call API into calls with tuple result as return type and calls with generic Object return type ([#123](https://github.com/tarantool/cartridge-springdata/issues/123))
 - Add buildSingleValueResultMapper() in mapper builder for generic call result mappers. That will simplify the support for auto object converter in SpringData.
+- Change TarantoolIndexPartMetadata.path type from String to Object to store String or int values
 
 ## [0.11.2] - 2023-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Internal and API changes
 - **[breaking change]** Split call API into calls with tuple result as return type and calls with generic Object return type ([#123](https://github.com/tarantool/cartridge-springdata/issues/123))
 - Add buildSingleValueResultMapper() in mapper builder for generic call result mappers. That will simplify the support for auto object converter in SpringData.
-- Change TarantoolIndexPartMetadata.path type from String to Object to store String or int values
+
+### Bugfixes
+- Support both string and integer values in index fields metadata
 
 ## [0.11.2] - 2023-05-04
 

--- a/src/main/java/io/tarantool/driver/api/metadata/TarantoolIndexPartMetadata.java
+++ b/src/main/java/io/tarantool/driver/api/metadata/TarantoolIndexPartMetadata.java
@@ -5,7 +5,7 @@ package io.tarantool.driver.api.metadata;
  *
  * @author Sergey Volgin
  */
-public interface TarantoolIndexPartMetadata {
+public interface TarantoolIndexPartMetadata<T> {
     /**
      * Get field index in space format
      *
@@ -25,5 +25,5 @@ public interface TarantoolIndexPartMetadata {
      *
      * @return path inside field (may be null)
      */
-    Object getPath();
+    T getPath();
 }

--- a/src/main/java/io/tarantool/driver/api/metadata/TarantoolIndexPartMetadata.java
+++ b/src/main/java/io/tarantool/driver/api/metadata/TarantoolIndexPartMetadata.java
@@ -25,5 +25,5 @@ public interface TarantoolIndexPartMetadata {
      *
      * @return path inside field (may be null)
      */
-    String getPath();
+    Object getPath();
 }

--- a/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
@@ -187,12 +187,21 @@ public final class DDLTarantoolSpaceMetadataConverter implements ValueConverter<
                     Map<Value, Value> partsMap = parts.asMapValue().map();
 
                     Value fieldPathValue = partsMap.get(INDEX_PARTS_PATH_KEY);
-                    if (fieldPathValue == null || !fieldPathValue.isStringValue()) {
+                    if (fieldPathValue == null ||
+                        (!fieldPathValue.isStringValue() && !fieldPathValue.isIntegerValue())) {
                         throw new TarantoolClientException("Unsupported index metadata format: key '" +
-                            INDEX_PARTS_PATH_KEY + "' must have string value");
+                            INDEX_PARTS_PATH_KEY + "' must have string or int value");
                     }
-                    String fieldPath = fieldPathValue.asStringValue().asString();
-                    int fieldNumber = getFieldNumberFromFieldPath(fields, fieldPath);
+
+                    int fieldNumber;
+                    Object fieldPath;
+                    if (fieldPathValue.isStringValue()) {
+                        fieldPath = fieldPathValue.asStringValue().asString();
+                        fieldNumber = getFieldNumberFromFieldPath(fields, (String) fieldPath);
+                    } else {
+                        fieldNumber = fieldPathValue.asIntegerValue().asInt();
+                        fieldPath = fieldNumber;
+                    }
 
                     Value fieldTypeValue = partsMap.get(INDEX_PARTS_TYPE_KEY);
                     if (fieldTypeValue == null || !fieldTypeValue.isStringValue()) {

--- a/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/DDLTarantoolSpaceMetadataConverter.java
@@ -210,7 +210,7 @@ public final class DDLTarantoolSpaceMetadataConverter implements ValueConverter<
                     }
                     String fieldType = fieldTypeValue.asStringValue().asString();
 
-                    return new TarantoolIndexPartMetadataImpl(fieldNumber, fieldType, fieldPath);
+                    return new TarantoolIndexPartMetadataImpl<>(fieldNumber, fieldType, fieldPath);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/io/tarantool/driver/core/metadata/TarantoolIndexMetadataConverter.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/TarantoolIndexMetadataConverter.java
@@ -59,13 +59,13 @@ public class TarantoolIndexMetadataConverter implements ValueConverter<ArrayValu
         if (indexPartsValue.size() > 0) {
             if (indexPartsValue.get(0).isArrayValue()) {
                 indexParts = indexPartsValue.list().stream()
-                    .map(partValue -> new TarantoolIndexPartMetadataImpl(
+                    .map(partValue -> new TarantoolIndexPartMetadataImpl<>(
                         partValue.asArrayValue().get(0).asIntegerValue().asInt(),
                         partValue.asArrayValue().get(1).asStringValue().asString()
                     )).collect(Collectors.toList());
             } else {
                 indexParts = indexPartsValue.list().stream()
-                    .map(partValue -> new TarantoolIndexPartMetadataImpl(
+                    .map(partValue -> new TarantoolIndexPartMetadataImpl<>(
                         partValue.asMapValue().map().get(INDEX_FIELD_KEY).asIntegerValue().asInt(),
                         partValue.asMapValue().map().get(INDEX_TYPE_KEY).asStringValue().asString()
                     )).collect(Collectors.toList());

--- a/src/main/java/io/tarantool/driver/core/metadata/TarantoolIndexPartMetadataImpl.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/TarantoolIndexPartMetadataImpl.java
@@ -11,13 +11,13 @@ class TarantoolIndexPartMetadataImpl implements TarantoolIndexPartMetadata {
 
     private final int fieldIndex;
     private final String fieldType;
-    private final String path;
+    private final Object path;
 
     TarantoolIndexPartMetadataImpl(int fieldIndex, String fieldType) {
         this(fieldIndex, fieldType, null);
     }
 
-    TarantoolIndexPartMetadataImpl(int fieldIndex, String fieldType, String path) {
+    TarantoolIndexPartMetadataImpl(int fieldIndex, String fieldType, Object path) {
         this.fieldIndex = fieldIndex;
         this.fieldType = fieldType;
         this.path = path;
@@ -34,7 +34,7 @@ class TarantoolIndexPartMetadataImpl implements TarantoolIndexPartMetadata {
     }
 
     @Override
-    public String getPath() {
+    public Object getPath() {
         return path;
     }
 }

--- a/src/main/java/io/tarantool/driver/core/metadata/TarantoolIndexPartMetadataImpl.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/TarantoolIndexPartMetadataImpl.java
@@ -7,17 +7,17 @@ import io.tarantool.driver.api.metadata.TarantoolIndexPartMetadata;
  *
  * @author Sergey Volgin
  */
-class TarantoolIndexPartMetadataImpl implements TarantoolIndexPartMetadata {
+class TarantoolIndexPartMetadataImpl<T> implements TarantoolIndexPartMetadata {
 
     private final int fieldIndex;
     private final String fieldType;
-    private final Object path;
+    private final T path;
 
     TarantoolIndexPartMetadataImpl(int fieldIndex, String fieldType) {
         this(fieldIndex, fieldType, null);
     }
 
-    TarantoolIndexPartMetadataImpl(int fieldIndex, String fieldType, Object path) {
+    TarantoolIndexPartMetadataImpl(int fieldIndex, String fieldType, T path) {
         this.fieldIndex = fieldIndex;
         this.fieldType = fieldType;
         this.path = path;
@@ -34,7 +34,7 @@ class TarantoolIndexPartMetadataImpl implements TarantoolIndexPartMetadata {
     }
 
     @Override
-    public Object getPath() {
+    public T getPath() {
         return path;
     }
 }

--- a/src/test/java/io/tarantool/driver/api/conditions/ConditionsTest.java
+++ b/src/test/java/io/tarantool/driver/api/conditions/ConditionsTest.java
@@ -1,5 +1,7 @@
 package io.tarantool.driver.api.conditions;
 
+import io.tarantool.driver.api.metadata.TarantoolIndexMetadata;
+import io.tarantool.driver.api.metadata.TarantoolIndexPartMetadata;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
@@ -25,7 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -343,5 +347,31 @@ class ConditionsTest {
 
         assertEquals(conditions.toProxyQuery(testOperations, spaceMetadata),
             serializedConditions.toProxyQuery(testOperations, spaceMetadata));
+    }
+
+    @Test
+    public void testIndexMetadata_CanHandleBothStringAndIntFiledPath() {
+        Optional<TarantoolIndexMetadata> primaryIndex = testOperations.getIndexByName("test", "primary");
+        assertTrue(primaryIndex.isPresent());
+        Object path = primaryIndex.get().getIndexParts().get(0).getPath();
+        assertEquals(path.getClass(), Integer.class);
+        assertEquals(1, path);
+
+        Optional<TarantoolIndexMetadata> asecondaryIndex = testOperations.getIndexByName("test", "asecondary");
+        assertTrue(asecondaryIndex.isPresent());
+        path = asecondaryIndex.get().getIndexParts().get(0).getPath();
+        assertEquals(path.getClass(), String.class);
+        assertEquals(path, "second");
+
+        Optional<TarantoolIndexMetadata> asecondary1Index = testOperations.getIndexByName("test", "asecondary1");
+        assertTrue(asecondary1Index.isPresent());
+        List<TarantoolIndexPartMetadata> indexParts = asecondary1Index.get().getIndexParts();
+        assertEquals(indexParts.size(), 2);
+        path = indexParts.get(0).getPath();
+        assertEquals(path.getClass(), Integer.class);
+        assertEquals(path, 2);
+        path = indexParts.get(1).getPath();
+        assertEquals(path.getClass(), String.class);
+        assertEquals(path, "third");
     }
 }

--- a/src/test/java/io/tarantool/driver/core/metadata/TestMetadataContainer.java
+++ b/src/test/java/io/tarantool/driver/core/metadata/TestMetadataContainer.java
@@ -44,7 +44,7 @@ public class TestMetadataContainer implements TarantoolMetadataContainer {
         testPrimaryIndexMetadata.setIndexName("primary");
         testPrimaryIndexMetadata.setSpaceId(512);
         testPrimaryIndexMetadata.setIndexParts(Collections.singletonList(
-            new TarantoolIndexPartMetadataImpl(0, "string"))
+            new TarantoolIndexPartMetadataImpl(0, "string", 1))
         );
 
         testIndexMetadata2 = new TarantoolIndexMetadataImpl();
@@ -52,8 +52,8 @@ public class TestMetadataContainer implements TarantoolMetadataContainer {
         testIndexMetadata2.setIndexName("asecondary1");
         testIndexMetadata2.setSpaceId(512);
         List<TarantoolIndexPartMetadata> parts = new ArrayList<>();
-        parts.add(new TarantoolIndexPartMetadataImpl(1, "number"));
-        parts.add(new TarantoolIndexPartMetadataImpl(2, "number"));
+        parts.add(new TarantoolIndexPartMetadataImpl(1, "number", 2));
+        parts.add(new TarantoolIndexPartMetadataImpl(2, "number", "third"));
         testIndexMetadata2.setIndexParts(parts);
 
         testIndexMetadata3 = new TarantoolIndexMetadataImpl();
@@ -79,7 +79,8 @@ public class TestMetadataContainer implements TarantoolMetadataContainer {
         testIndexMetadata1.setIndexId(4);
         testIndexMetadata1.setIndexName("asecondary");
         testIndexMetadata1.setSpaceId(512);
-        testIndexMetadata1.setIndexParts(Collections.singletonList(new TarantoolIndexPartMetadataImpl(1, "number")));
+        testIndexMetadata1.setIndexParts(Collections.singletonList(new TarantoolIndexPartMetadataImpl(1, "number",
+            "second")));
     }
 
     @Override

--- a/src/test/resources/cartridge/app/roles/api_storage.lua
+++ b/src/test/resources/cartridge/app/roles/api_storage.lua
@@ -40,7 +40,7 @@ local function init_space()
         }
     )
 
-    test_space:create_index('id', { parts = { 'id' }, if_not_exists = true, })
+    test_space:create_index('id', { parts = { 1 }, if_not_exists = true, })
     test_space:create_index('bucket_id', { parts = { 'bucket_id' }, unique = false, if_not_exists = true, })
 
     local second_test_space = box.schema.space.create(


### PR DESCRIPTION
Change TarantoolIndexPartMetadata.path type from String to Object to store String or int values

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
Closes #395
