### PR TITLE
Improve reusing Docker images between tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,17 +313,37 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/*IT.java</include>
                             </includes>
-                            <systemPropertyVariables>
-                                <logback.configurationFile>${logging.config}</logback.configurationFile>
-                                <logLevel>${logging.logLevel}</logLevel>
-                            </systemPropertyVariables>
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>process-test-resources</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>testResources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/test/resources</directory>
+                                            <filtering>true</filtering>
+                                            <includes>
+                                                <include>**/*.xml</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -334,7 +354,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
+                        <version>3.1.2</version>
                         <configuration>
                             <includes>
                                 <include>**/*ITEnterprise.java</include>
@@ -345,6 +365,30 @@
                             </systemPropertyVariables>
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>process-test-resources</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>testResources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/test/resources</directory>
+                                            <filtering>true</filtering>
+                                            <includes>
+                                                <include>**/*.xml</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/src/test/java/io/tarantool/driver/integration/CartridgeMixedInstancesContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/CartridgeMixedInstancesContainer.java
@@ -18,8 +18,11 @@ abstract class CartridgeMixedInstancesContainer {
     static {
         final HashMap<String, String> env = new HashMap<>();
         env.put("TARANTOOL_INSTANCES_FILE", "./instances_mixed.yml");
-        container = new TarantoolCartridgeContainer("cartridge/instances_mixed.yml",
-                                                    "cartridge/topology_mixed.lua")
+        container = new TarantoolCartridgeContainer(
+                        "Dockerfile",
+                        "cartridge-java-test-mixed",
+                        "cartridge/instances_mixed.yml",
+                        "cartridge/topology_mixed.lua")
                         .withDirectoryBinding("cartridge")
                         .withLogConsumer(new Slf4jLogConsumer(logger))
                         .waitingFor(Wait.forLogMessage(".*Listening HTTP on.*", 3))

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
@@ -683,7 +683,7 @@ public class ProxyTarantoolClientIT extends SharedCartridgeContainer {
     public void test_should_reconnect_ifReconnectIsInvoked() throws Exception {
         assertEquals(3, getAliveConnections());
 
-        container.execInContainer("cartridge", "stop", "--run-dir=/tmp/run", "second-router");
+        stopInstance("second-router", false);
         TarantoolUtils.retry(() -> {
             try {
                 client.getVersion();
@@ -692,7 +692,7 @@ public class ProxyTarantoolClientIT extends SharedCartridgeContainer {
                 throw new RuntimeException(e);
             }
         });
-        container.execInContainer("cartridge", "start", "--run-dir=/tmp/run", "--data-dir=/tmp/data", "-d");
+        startCartridge();
 
         TarantoolUtils.retry(20, 200, () -> {
             try {

--- a/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.TarantoolCartridgeContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -32,7 +33,8 @@ public abstract class SharedCartridgeContainer {
     }
 
     protected static void startCartridge() throws IOException, InterruptedException {
-        container.execInContainer("cartridge", "start", "--run-dir=/tmp/run", "--data-dir=/tmp/data", "-d");
+        container.execInContainer(
+            "cartridge", "start", "--run-dir=/tmp/run", "--data-dir=/tmp/data", "--log-dir=/tmp/log", "-d");
     }
 
     protected static void stopCartridge() throws IOException, InterruptedException {
@@ -47,16 +49,25 @@ public abstract class SharedCartridgeContainer {
 
     protected static void stopInstances(List<String> instancesName) throws IOException, InterruptedException {
         for (String instanceName : instancesName) {
-            stopInstance(instanceName);
+            stopInstance(instanceName, false);
         }
     }
 
-    protected static void startInstance(String instanceName) throws IOException, InterruptedException {
-        container.execInContainer(
-            "cartridge", "start", "--run-dir=/tmp/run", "--data-dir=/tmp/data", "-d", instanceName);
+    protected static ExecResult startInstance(String instanceName) throws IOException, InterruptedException {
+        return container.execInContainer(
+            "cartridge", "start",
+            "--run-dir=/tmp/run", "--data-dir=/tmp/data", "--log-dir=/tmp/log", "-d",
+            instanceName);
     }
 
-    protected static void stopInstance(String instanceName) throws IOException, InterruptedException {
-        container.execInContainer("cartridge", "stop", "--run-dir=/tmp/run", "--data-dir=/tmp/data", instanceName);
+    protected static ExecResult stopInstance(String instanceName, boolean force)
+        throws IOException, InterruptedException {
+        if (force) {
+            return container.execInContainer(
+                "cartridge", "stop", "--run-dir=/tmp/run", "--force", instanceName);
+        } else {
+            return container.execInContainer(
+                "cartridge", "stop", "--run-dir=/tmp/run", instanceName);
+        }
     }
 }

--- a/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
+++ b/src/test/java/io/tarantool/driver/integration/SharedCartridgeContainer.java
@@ -16,6 +16,8 @@ public abstract class SharedCartridgeContainer {
 
     protected static final TarantoolCartridgeContainer container =
         new TarantoolCartridgeContainer(
+            "Dockerfile",
+            "cartridge-java-test",
             "cartridge/instances.yml",
             "cartridge/topology.lua")
             .withDirectoryBinding("cartridge")

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,13 +1,24 @@
-<configuration debug="false">
+<configuration debug="true">
+    <variable name="logLevel" value="${logging.logLevel}"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <logger name="com.github.dockerjava" level="${logLevel:-DEBUG}"/>
+    <logger name="com.github.dockerjava.jaxrs" level="INFO"/>
+    <logger name="com.github.dockerjava.netty" level="INFO"/>
+    <logger name="com.github.dockerjava.httpclient5" level="INFO"/>
+    <logger name="com.github.dockerjava.okhttp" level="INFO"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc" level="INFO"/>
+    <logger name="com.github.dockerjava.api.command.BuildImageResultCallback" level="INFO"/>
+    <logger name="com.github.dockerjava.api.command.PullImageResultCallback" level="INFO"/>
+
+    <root level="${logLevel:-INFO}">
         <appender-ref ref="STDOUT"/>
     </root>
-
-    <logger name="org.testcontainers" level="INFO"/>
 </configuration>


### PR DESCRIPTION
Re-building images between test suites is unnecessary, and this can be mitigated by using image names.
This patch does the following:

- Improves reusing Docker images by assigning image names and using layers in the Dockerfile
- Improves logging for docker-java client