### PR TITLE
Add new benchmarks and mapper cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/
 *.swo
 .bloop/
 .metals/
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -280,10 +280,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.openjdk.jmh</groupId>
-          <artifactId>jmh-generator-annprocess</artifactId>
-          <version>1.35</version>
-          <scope>test</scope>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.35</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -413,12 +413,19 @@
                             <arguments>
                                 <argument>-classpath</argument>
                                 <classpath />
-                                <argument>org.openjdk.jmh.Main</argument>]
+                                <argument>org.openjdk.jmh.Main</argument>
+                                <argument>${benchmark}</argument>
+                                <argument>${benchmarkArgs}</argument>
                             </arguments>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+            <properties>
+                <skipTests>true</skipTests>
+                <benchmark>SingleInstanceBenchmarkRunner</benchmark>
+                <benchmarkArgs></benchmarkArgs>
+            </properties>
         </profile>
         <profile>
             <id>release</id>

--- a/src/main/java/io/tarantool/driver/api/TarantoolCallOperations.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolCallOperations.java
@@ -125,7 +125,7 @@ public interface TarantoolCallOperations {
      * @param <T>             desired function call result type
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param entityClass     target result entity class
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
@@ -133,7 +133,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> entityClass)
         throws TarantoolClientException;
 
@@ -143,7 +143,7 @@ public interface TarantoolCallOperations {
      * @param <T>             desired function call result type
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
@@ -151,7 +151,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> call(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
@@ -162,7 +162,7 @@ public interface TarantoolCallOperations {
      * @param <T>             target result content type
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultClass     target result entity class
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
@@ -170,7 +170,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> resultClass)
         throws TarantoolClientException;
 
@@ -181,7 +181,7 @@ public interface TarantoolCallOperations {
      * @param <T>             target result content type
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param valueConverter  MessagePack value to entity converter for each result item
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
@@ -189,7 +189,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException;
 
@@ -200,7 +200,7 @@ public interface TarantoolCallOperations {
      * @param <T>             target result content type
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
@@ -208,7 +208,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
@@ -315,7 +315,7 @@ public interface TarantoolCallOperations {
      * @param <R>                     target result type
      * @param functionName            function name, must not be null or empty
      * @param arguments               list of function arguments
-     * @param argumentsMapper         mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultContainerSupplier supplier function for new empty result collection
      * @param resultClass             target result entity class
      * @return some result
@@ -324,7 +324,7 @@ public interface TarantoolCallOperations {
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass)
         throws TarantoolClientException;
@@ -336,7 +336,7 @@ public interface TarantoolCallOperations {
      * @param <R>                     target result type
      * @param functionName            function name, must not be null or empty
      * @param arguments               list of function arguments
-     * @param argumentsMapper         mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultContainerSupplier supplier function for new empty result collection
      * @param valueConverter          MessagePack value to entity converter for each result item
      * @return some result
@@ -345,7 +345,7 @@ public interface TarantoolCallOperations {
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException;
@@ -357,7 +357,7 @@ public interface TarantoolCallOperations {
      * @param <R>             target result type
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
@@ -365,7 +365,7 @@ public interface TarantoolCallOperations {
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException;
 

--- a/src/main/java/io/tarantool/driver/api/TarantoolCallOperations.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolCallOperations.java
@@ -2,7 +2,6 @@ package io.tarantool.driver.api;
 
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.mappers.CallResultMapper;
-import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactory;
@@ -55,18 +54,6 @@ public interface TarantoolCallOperations {
     CompletableFuture<List<?>> call(String functionName, Collection<?> arguments) throws TarantoolClientException;
 
     /**
-     * Execute a function defined on Tarantool instance
-     *
-     * @param functionName function name, must not be null or empty
-     * @param arguments    list of function arguments
-     * @param mapper       mapper for arguments object-to-MessagePack entity conversion and result values conversion
-     * @return some result
-     * @throws TarantoolClientException if the client is not connected
-     */
-    CompletableFuture<List<?>> call(String functionName, Collection<?> arguments, MessagePackMapper mapper)
-        throws TarantoolClientException;
-
-    /**
      * Execute a function defined on Tarantool instance. The call result is interpreted as an array of tuples. The value
      * mapper specified in the client configuration will be used for converting the result values from MessagePack
      * arrays to the specified entity type.
@@ -85,13 +72,13 @@ public interface TarantoolCallOperations {
      *
      * @param <T>          desired function call result type
      * @param functionName function name, must not be null or empty
-     * @param resultMapper mapper for result value MessagePack entity-to-object conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
     <T> CompletableFuture<T> call(
         String functionName,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -120,14 +107,14 @@ public interface TarantoolCallOperations {
      * @param functionName function name, must not be null or empty
      * @param arguments    list of function arguments. The object mapper specified in the client configuration
      *                     will be used for arguments conversion to MessagePack entities
-     * @param resultMapper mapper for result value MessagePack entity-to-object conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
     <T> CompletableFuture<T> call(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -157,7 +144,7 @@ public interface TarantoolCallOperations {
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
      * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
-     * @param resultMapper    mapper for result value MessagePack entity-to-object conversion
+     * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
@@ -165,7 +152,7 @@ public interface TarantoolCallOperations {
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -214,7 +201,7 @@ public interface TarantoolCallOperations {
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
      * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
-     * @param resultMapper    mapper for result conversion
+     * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
@@ -222,7 +209,7 @@ public interface TarantoolCallOperations {
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -266,14 +253,14 @@ public interface TarantoolCallOperations {
      * @param <T>          target result content type
      * @param functionName function name, must not be null or empty
      * @param arguments    list of function arguments
-     * @param resultMapper mapper for result conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -312,13 +299,13 @@ public interface TarantoolCallOperations {
      *
      * @param <T>          target result content type
      * @param functionName function name, must not be null or empty
-     * @param resultMapper mapper for result conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -371,7 +358,7 @@ public interface TarantoolCallOperations {
      * @param functionName    function name, must not be null or empty
      * @param arguments       list of function arguments
      * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
-     * @param resultMapper    mapper for result conversion
+     * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
@@ -379,7 +366,7 @@ public interface TarantoolCallOperations {
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper)
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -427,14 +414,14 @@ public interface TarantoolCallOperations {
      * @param <R>          target result type
      * @param functionName function name, must not be null or empty
      * @param arguments    list of function arguments
-     * @param resultMapper mapper for result conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper)
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -477,13 +464,13 @@ public interface TarantoolCallOperations {
      * @param <T>          target result content type
      * @param <R>          target result type
      * @param functionName function name, must not be null or empty
-     * @param resultMapper mapper for result conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected or some other error occurred
      */
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper)
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**

--- a/src/main/java/io/tarantool/driver/api/TarantoolCallOperations.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolCallOperations.java
@@ -133,7 +133,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> entityClass)
         throws TarantoolClientException;
 
@@ -151,7 +151,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> call(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
@@ -170,7 +170,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> resultClass)
         throws TarantoolClientException;
 
@@ -189,7 +189,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException;
 
@@ -208,7 +208,7 @@ public interface TarantoolCallOperations {
     <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException;
 
@@ -324,7 +324,7 @@ public interface TarantoolCallOperations {
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass)
         throws TarantoolClientException;
@@ -345,7 +345,7 @@ public interface TarantoolCallOperations {
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException;
@@ -365,7 +365,7 @@ public interface TarantoolCallOperations {
     <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException;
 

--- a/src/main/java/io/tarantool/driver/api/TarantoolEvalOperations.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolEvalOperations.java
@@ -72,7 +72,7 @@ public interface TarantoolEvalOperations {
      *
      * @param expression      lua expression, must not be null or empty
      * @param arguments       the list of function arguments
-     * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
+     * @param argumentsMapperSupplier mapper supplier for arguments object-to-MessagePack entity conversion
      * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected
@@ -80,6 +80,6 @@ public interface TarantoolEvalOperations {
     CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException;
 }

--- a/src/main/java/io/tarantool/driver/api/TarantoolEvalOperations.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolEvalOperations.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.mappers.MessagePackValueMapper;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * Aggregates all value operation variants
@@ -43,11 +44,11 @@ public interface TarantoolEvalOperations {
      * keyword <code>return</code>.
      *
      * @param expression   lua expression, must not be null or empty
-     * @param resultMapper mapper for result value MessagePack entity-to-object conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected
      */
-    CompletableFuture<List<?>> eval(String expression, MessagePackValueMapper resultMapper)
+    CompletableFuture<List<?>> eval(String expression, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -57,11 +58,12 @@ public interface TarantoolEvalOperations {
      * @param expression   lua expression, must not be null or empty
      * @param arguments    the list of function arguments. The object mapper specified in the client configuration
      *                     will be used for arguments conversion to MessagePack entities
-     * @param resultMapper mapper for result value MessagePack entity-to-object conversion
+     * @param resultMapperSupplier mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected
      */
-    CompletableFuture<List<?>> eval(String expression, Collection<?> arguments, MessagePackValueMapper resultMapper)
+    CompletableFuture<List<?>> eval(
+        String expression, Collection<?> arguments, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -71,7 +73,7 @@ public interface TarantoolEvalOperations {
      * @param expression      lua expression, must not be null or empty
      * @param arguments       the list of function arguments
      * @param argumentsMapper mapper for arguments object-to-MessagePack entity conversion
-     * @param resultMapper    mapper for result value MessagePack entity-to-object conversion
+     * @param resultMapperSupplier    mapper supplier for result value MessagePack entity-to-object conversion
      * @return some result
      * @throws TarantoolClientException if the client is not connected
      */
@@ -79,5 +81,5 @@ public interface TarantoolEvalOperations {
         String expression,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        MessagePackValueMapper resultMapper) throws TarantoolClientException;
+        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException;
 }

--- a/src/main/java/io/tarantool/driver/api/TarantoolEvalOperations.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolEvalOperations.java
@@ -48,7 +48,7 @@ public interface TarantoolEvalOperations {
      * @return some result
      * @throws TarantoolClientException if the client is not connected
      */
-    CompletableFuture<List<?>> eval(String expression, Supplier<MessagePackValueMapper> resultMapperSupplier)
+    CompletableFuture<List<?>> eval(String expression, Supplier<? extends MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -63,7 +63,7 @@ public interface TarantoolEvalOperations {
      * @throws TarantoolClientException if the client is not connected
      */
     CompletableFuture<List<?>> eval(
-        String expression, Collection<?> arguments, Supplier<MessagePackValueMapper> resultMapperSupplier)
+        String expression, Collection<?> arguments, Supplier<? extends MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException;
 
     /**
@@ -80,6 +80,6 @@ public interface TarantoolEvalOperations {
     CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
-        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException;
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException;
 }

--- a/src/main/java/io/tarantool/driver/api/connection/TarantoolConnection.java
+++ b/src/main/java/io/tarantool/driver/api/connection/TarantoolConnection.java
@@ -2,13 +2,11 @@ package io.tarantool.driver.api.connection;
 
 import io.netty.channel.Channel;
 import io.tarantool.driver.TarantoolVersion;
+import io.tarantool.driver.core.TarantoolRequestMetadata;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletableFuture;
-
-import org.msgpack.value.Value;
 
 public interface TarantoolConnection extends AutoCloseable {
     /**
@@ -38,9 +36,9 @@ public interface TarantoolConnection extends AutoCloseable {
      * Send a prepared request to the Tarantool server and flush the buffer
      *
      * @param request      the request
-     * @return result future
+     * @return request metadata containing the request result future
      */
-    CompletableFuture<Value> sendRequest(TarantoolRequest request);
+    TarantoolRequestMetadata sendRequest(TarantoolRequest request);
 
     /**
      * Get the Netty channel baking this connection

--- a/src/main/java/io/tarantool/driver/api/connection/TarantoolConnection.java
+++ b/src/main/java/io/tarantool/driver/api/connection/TarantoolConnection.java
@@ -3,11 +3,12 @@ package io.tarantool.driver.api.connection;
 import io.netty.channel.Channel;
 import io.tarantool.driver.TarantoolVersion;
 import io.tarantool.driver.exceptions.TarantoolClientException;
-import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
+
+import org.msgpack.value.Value;
 
 public interface TarantoolConnection extends AutoCloseable {
     /**
@@ -37,11 +38,9 @@ public interface TarantoolConnection extends AutoCloseable {
      * Send a prepared request to the Tarantool server and flush the buffer
      *
      * @param request      the request
-     * @param resultMapper the mapper for response body
-     * @param <T>          result type
      * @return result future
      */
-    <T> CompletableFuture<T> sendRequest(TarantoolRequest request, MessagePackValueMapper resultMapper);
+    CompletableFuture<Value> sendRequest(TarantoolRequest request);
 
     /**
      * Get the Netty channel baking this connection

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -260,7 +260,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
             String functionName, Collection<?> arguments, Class<T> tupleClass)
         throws TarantoolClientException {
-        return callForTupleResult(functionName, arguments, config.getMessagePackMapper(), tupleClass);
+        return callForTupleResult(functionName, arguments, config::getMessagePackMapper, tupleClass);
     }
 
     @Override
@@ -269,17 +269,17 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Collection<?> arguments,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return call(functionName, arguments, config.getMessagePackMapper(), resultMapperSupplier);
+        return call(functionName, arguments, config::getMessagePackMapper, resultMapperSupplier);
     }
 
     @Override
     public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> tupleClass)
         throws TarantoolClientException {
-        return call(functionName, arguments, argumentsMapper,
+        return call(functionName, arguments, argumentsMapperSupplier,
             () -> mapperFactoryFactory.getTarantoolResultMapper(config.getMessagePackMapper(), tupleClass));
     }
 
@@ -287,10 +287,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<T> call(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override
@@ -299,7 +299,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Collection<?> arguments,
         Class<S> resultClass)
         throws TarantoolClientException {
-        return callForSingleResult(functionName, arguments, config.getMessagePackMapper(), resultClass);
+        return callForSingleResult(functionName, arguments, config::getMessagePackMapper, resultClass);
     }
 
     @Override
@@ -308,7 +308,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Collection<?> arguments,
         ValueConverter<Value, S> valueConverter)
         throws TarantoolClientException {
-        return callForSingleResult(functionName, arguments, config.getMessagePackMapper(), valueConverter);
+        return callForSingleResult(functionName, arguments, config::getMessagePackMapper, valueConverter);
     }
 
     @Override
@@ -316,7 +316,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         String functionName,
         Collection<?> arguments,
         Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier) throws TarantoolClientException {
-        return callForSingleResult(functionName, arguments, config.getMessagePackMapper(), resultMapperSupplier);
+        return callForSingleResult(functionName, arguments, config::getMessagePackMapper, resultMapperSupplier);
     }
 
     @Override
@@ -342,10 +342,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public <S> CompletableFuture<S> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Class<S> resultClass)
         throws TarantoolClientException {
-        return callForSingleResult(functionName, arguments, argumentsMapper,
+        return callForSingleResult(functionName, arguments, argumentsMapperSupplier,
             () -> mapperFactoryFactory.getDefaultSingleValueMapper(config.getMessagePackMapper(), resultClass));
     }
 
@@ -353,22 +353,22 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public <S> CompletableFuture<S> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, S> valueConverter)
         throws TarantoolClientException {
         Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier = () ->
             mapperFactoryFactory.getSingleValueResultMapper(valueConverter);
-        return callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override
     public <S> CompletableFuture<S> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return makeRequestForSingleResult(functionName, arguments, null, argumentsMapper, resultMapperSupplier)
+        return makeRequestForSingleResult(functionName, arguments, null, argumentsMapperSupplier, resultMapperSupplier)
             .thenApply(CallResult::value);
     }
 
@@ -380,7 +380,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Class<T> resultClass)
         throws TarantoolClientException {
         return callForMultiResult(
-            functionName, arguments, config.getMessagePackMapper(), resultContainerSupplier, resultClass);
+            functionName, arguments, config::getMessagePackMapper, resultContainerSupplier, resultClass);
     }
 
     @Override
@@ -389,7 +389,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Collection<?> arguments,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter) throws TarantoolClientException {
-        return callForMultiResult(functionName, arguments, config.getMessagePackMapper(),
+        return callForMultiResult(functionName, arguments, config::getMessagePackMapper,
             resultContainerSupplier, valueConverter);
     }
 
@@ -399,7 +399,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Collection<?> arguments,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return callForMultiResult(functionName, arguments, config.getMessagePackMapper(), resultMapperSupplier);
+        return callForMultiResult(functionName, arguments, config::getMessagePackMapper, resultMapperSupplier);
     }
 
     @Override
@@ -432,11 +432,11 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass)
         throws TarantoolClientException {
-        return callForMultiResult(functionName, arguments, argumentsMapper,
+        return callForMultiResult(functionName, arguments, argumentsMapperSupplier,
             () -> mapperFactoryFactory.getDefaultMultiValueMapper(config.getMessagePackMapper(), resultClass));
     }
 
@@ -444,23 +444,23 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier = () ->
             mapperFactoryFactory.getMultiValueResultMapper(resultContainerSupplier, valueConverter);
-        return callForMultiResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return callForMultiResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return makeRequestForMultiResult(functionName, arguments, null, argumentsMapper, resultMapperSupplier)
+        return makeRequestForMultiResult(functionName, arguments, null, argumentsMapperSupplier, resultMapperSupplier)
             .thenApply(CallResult::value);
     }
 
@@ -468,25 +468,25 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         String functionName,
         Collection<?> arguments,
         TarantoolRequestSignature requestSignature,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
-        return makeRequest(functionName, arguments, requestSignature, argumentsMapper, resultMapperSupplier);
+        return makeRequest(functionName, arguments, requestSignature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     private <T, R extends List<T>> CompletableFuture<CallResult<R>> makeRequestForMultiResult(
         String functionName,
         Collection<?> arguments,
         TarantoolRequestSignature requestSignature,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier) {
-        return makeRequest(functionName, arguments, requestSignature, argumentsMapper, resultMapperSupplier);
+        return makeRequest(functionName, arguments, requestSignature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     private <S> CompletableFuture<S> makeRequest(
         String functionName,
         Collection<?> arguments,
         TarantoolRequestSignature requestSignature,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<? extends MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
         try {
@@ -499,7 +499,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
             builder.withSignature(requestSignature);
             MessagePackValueMapper resultMapper = resultMapperSupplier.get();
 
-            TarantoolCallRequest request = builder.build(argumentsMapper);
+            TarantoolCallRequest request = builder.build(argumentsMapperSupplier.get());
             return connectionManager().getConnection()
                 .thenCompose(c -> c.sendRequest(request).getFuture())
                 .thenApply(resultMapper::fromValue);
@@ -529,20 +529,20 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     public CompletableFuture<List<?>> eval(
         String expression, Collection<?> arguments, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
-        return eval(expression, arguments, config.getMessagePackMapper(), resultMapperSupplier);
+        return eval(expression, arguments, config::getMessagePackMapper, resultMapperSupplier);
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         try {
             TarantoolEvalRequest request = new TarantoolEvalRequest.Builder()
                 .withExpression(expression)
                 .withArguments(arguments)
-                .build(argumentsMapper);
+                .build(argumentsMapperSupplier.get());
             MessagePackValueMapper resultMapper = resultMapperSupplier.get();
             return connectionManager().getConnection()
                 .thenCompose(c -> c.sendRequest(request).getFuture())

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -495,7 +495,9 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
             }
 
             TarantoolCallRequest request = builder.build(argumentsMapper);
-            return connectionManager().getConnection().thenCompose(c -> c.sendRequest(request, resultMapper));
+            return connectionManager().getConnection()
+                .thenCompose(c -> c.sendRequest(request))
+                .thenApply(resultMapper::fromValue);
         } catch (TarantoolProtocolException e) {
             throw new TarantoolClientException(e);
         }
@@ -536,7 +538,9 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
                 .withExpression(expression)
                 .withArguments(arguments)
                 .build(argumentsMapper);
-            return connectionManager().getConnection().thenCompose(c -> c.sendRequest(request, resultMapper));
+            return connectionManager().getConnection()
+                .thenCompose(c -> c.sendRequest(request))
+                .thenApply(resultMapper::fromValue);
         } catch (TarantoolProtocolException e) {
             throw new TarantoolClientException(e);
         }

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -516,20 +516,20 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
     @Override
     public CompletableFuture<List<?>> eval(String expression, Collection<?> arguments)
         throws TarantoolClientException {
-        return eval(expression, arguments, config.getMessagePackMapper());
+        return eval(expression, arguments, config::getMessagePackMapper);
     }
 
     @Override
-    public CompletableFuture<List<?>> eval(String expression, MessagePackValueMapper resultMapper)
+    public CompletableFuture<List<?>> eval(String expression, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
-        return eval(expression, Collections.emptyList(), resultMapper);
+        return eval(expression, Collections.emptyList(), resultMapperSupplier);
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
-        String expression, Collection<?> arguments, MessagePackValueMapper resultMapper)
+        String expression, Collection<?> arguments, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
-        return eval(expression, arguments, config.getMessagePackMapper(), resultMapper);
+        return eval(expression, arguments, config.getMessagePackMapper(), resultMapperSupplier);
     }
 
     @Override
@@ -537,12 +537,13 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         String expression,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        MessagePackValueMapper resultMapper) throws TarantoolClientException {
+        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         try {
             TarantoolEvalRequest request = new TarantoolEvalRequest.Builder()
                 .withExpression(expression)
                 .withArguments(arguments)
                 .build(argumentsMapper);
+            MessagePackValueMapper resultMapper = resultMapperSupplier.get();
             return connectionManager().getConnection()
                 .thenCompose(c -> c.sendRequest(request).getFuture())
                 .thenApply(resultMapper::fromValue);

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -496,7 +496,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
 
             TarantoolCallRequest request = builder.build(argumentsMapper);
             return connectionManager().getConnection()
-                .thenCompose(c -> c.sendRequest(request))
+                .thenCompose(c -> c.sendRequest(request).getFuture())
                 .thenApply(resultMapper::fromValue);
         } catch (TarantoolProtocolException e) {
             throw new TarantoolClientException(e);
@@ -539,7 +539,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
                 .withArguments(arguments)
                 .build(argumentsMapper);
             return connectionManager().getConnection()
-                .thenCompose(c -> c.sendRequest(request))
+                .thenCompose(c -> c.sendRequest(request).getFuture())
                 .thenApply(resultMapper::fromValue);
         } catch (TarantoolProtocolException e) {
             throw new TarantoolClientException(e);

--- a/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
@@ -209,7 +209,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> entityClass) throws TarantoolClientException {
         return client.callForTupleResult(functionName, arguments, argumentsMapperSupplier, entityClass);
     }
@@ -218,7 +218,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T> CompletableFuture<T> call(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
         return client.call(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
@@ -228,7 +228,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> resultClass)
         throws TarantoolClientException {
         return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultClass);
@@ -238,7 +238,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
         return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, valueConverter);
@@ -248,7 +248,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
         return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
@@ -301,7 +301,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass) throws TarantoolClientException {
         return client.callForMultiResult(
@@ -312,7 +312,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter) throws TarantoolClientException {
         return client.callForMultiResult(
@@ -323,7 +323,7 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
         return client.callForMultiResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
@@ -395,14 +395,15 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     }
 
     @Override
-    public CompletableFuture<List<?>> eval(String expression, Supplier<MessagePackValueMapper> resultMapperSupplier)
+    public CompletableFuture<List<?>> eval(
+        String expression, Supplier<? extends MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
         return client.eval(expression, resultMapperSupplier);
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
-        String expression, Collection<?> arguments, Supplier<MessagePackValueMapper> resultMapperSupplier)
+        String expression, Collection<?> arguments, Supplier<? extends MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
         return client.eval(expression, arguments, resultMapperSupplier);
     }
@@ -411,8 +412,8 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
-        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         return client.eval(expression, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 

--- a/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
@@ -20,7 +20,6 @@ import io.tarantool.driver.core.metadata.TarantoolMetadata;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.exceptions.TarantoolSpaceNotFoundException;
 import io.tarantool.driver.mappers.CallResultMapper;
-import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.converters.ValueConverter;
@@ -183,12 +182,6 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     }
 
     @Override
-    public CompletableFuture<List<?>> call(String functionName, Collection<?> arguments, MessagePackMapper mapper)
-        throws TarantoolClientException {
-        return client.call(functionName, arguments, mapper);
-    }
-
-    @Override
     public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(String functionName, Class<T> entityClass)
         throws TarantoolClientException {
         return client.callForTupleResult(functionName, entityClass);
@@ -196,8 +189,8 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
 
     @Override
     public <T> CompletableFuture<T> call(String functionName,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) throws TarantoolClientException {
-        return client.call(functionName, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) throws TarantoolClientException {
+        return client.call(functionName, resultMapperSupplier);
     }
 
     @Override
@@ -208,8 +201,8 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
 
     @Override
     public <T> CompletableFuture<T> call(String functionName, Collection<?> arguments,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) throws TarantoolClientException {
-        return client.call(functionName, arguments, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) throws TarantoolClientException {
+        return client.call(functionName, arguments, resultMapperSupplier);
     }
 
     @Override
@@ -219,10 +212,12 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     }
 
     @Override
-    public <T> CompletableFuture<T> call(String functionName, Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper, CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+    public <T> CompletableFuture<T> call(String functionName,
+        Collection<?> arguments,
+        MessagePackObjectMapper argumentsMapper,
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.call(functionName, arguments, argumentsMapper, resultMapper);
+        return client.call(functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     @Override
@@ -250,9 +245,9 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapper);
+        return client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     @Override
@@ -275,8 +270,8 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) throws TarantoolClientException {
-        return client.callForSingleResult(functionName, arguments, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) throws TarantoolClientException {
+        return client.callForSingleResult(functionName, arguments, resultMapperSupplier);
     }
 
     @Override
@@ -294,8 +289,8 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) throws TarantoolClientException {
-        return client.callForSingleResult(functionName, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) throws TarantoolClientException {
+        return client.callForSingleResult(functionName, resultMapperSupplier);
     }
 
     @Override
@@ -325,8 +320,9 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper) throws TarantoolClientException {
-        return client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
+        throws TarantoolClientException {
+        return client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     @Override
@@ -353,8 +349,9 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper) throws TarantoolClientException {
-        return client.callForMultiResult(functionName, arguments, resultMapper);
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
+        throws TarantoolClientException {
+        return client.callForMultiResult(functionName, arguments, resultMapperSupplier);
     }
 
     @Override
@@ -378,9 +375,9 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper)
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.callForMultiResult(functionName, resultMapper);
+        return client.callForMultiResult(functionName, resultMapperSupplier);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
@@ -206,48 +206,52 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     }
 
     @Override
-    public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(String functionName, Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper, Class<T> entityClass) throws TarantoolClientException {
-        return client.callForTupleResult(functionName, arguments, argumentsMapper, entityClass);
+    public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
+        String functionName,
+        Collection<?> arguments,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Class<T> entityClass) throws TarantoolClientException {
+        return client.callForTupleResult(functionName, arguments, argumentsMapperSupplier, entityClass);
     }
 
     @Override
-    public <T> CompletableFuture<T> call(String functionName,
+    public <T> CompletableFuture<T> call(
+        String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.call(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return client.call(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> resultClass)
         throws TarantoolClientException {
-        return client.callForSingleResult(functionName, arguments, argumentsMapper, resultClass);
+        return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultClass);
     }
 
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
-        return client.callForSingleResult(functionName, arguments, argumentsMapper, valueConverter);
+        return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, valueConverter);
     }
 
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override
@@ -297,32 +301,32 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass) throws TarantoolClientException {
         return client.callForMultiResult(
-            functionName, arguments, argumentsMapper, resultContainerSupplier, resultClass);
+            functionName, arguments, argumentsMapperSupplier, resultContainerSupplier, resultClass);
     }
 
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter) throws TarantoolClientException {
         return client.callForMultiResult(
-            functionName, arguments, argumentsMapper, resultContainerSupplier, valueConverter);
+            functionName, arguments, argumentsMapperSupplier, resultContainerSupplier, valueConverter);
     }
 
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return client.callForMultiResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override
@@ -407,9 +411,9 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     public CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
-        return client.eval(expression, arguments, argumentsMapper, resultMapperSupplier);
+        return client.eval(expression, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
@@ -391,16 +391,16 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
     }
 
     @Override
-    public CompletableFuture<List<?>> eval(String expression, MessagePackValueMapper resultMapper)
+    public CompletableFuture<List<?>> eval(String expression, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.eval(expression, resultMapper);
+        return client.eval(expression, resultMapperSupplier);
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
-        String expression, Collection<?> arguments, MessagePackValueMapper resultMapper)
+        String expression, Collection<?> arguments, Supplier<MessagePackValueMapper> resultMapperSupplier)
         throws TarantoolClientException {
-        return client.eval(expression, arguments, resultMapper);
+        return client.eval(expression, arguments, resultMapperSupplier);
     }
 
     @Override
@@ -408,8 +408,8 @@ public abstract class ProxyTarantoolClient<T extends Packable, R extends Collect
         String expression,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        MessagePackValueMapper resultMapper) throws TarantoolClientException {
-        return client.eval(expression, arguments, argumentsMapper, resultMapper);
+        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        return client.eval(expression, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
@@ -173,7 +173,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> entityClass) throws TarantoolClientException {
         return wrapOperation(
             () -> client.callForTupleResult(functionName, arguments, argumentsMapperSupplier, entityClass));
@@ -183,7 +183,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<T> call(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
         return wrapOperation(() -> client.call(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier));
@@ -193,7 +193,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> resultClass) throws TarantoolClientException {
         return wrapOperation(
             () -> client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultClass));
@@ -203,7 +203,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
         return wrapOperation(() ->
@@ -214,7 +214,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
         return wrapOperation(
@@ -270,7 +270,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass)
         throws TarantoolClientException {
@@ -282,7 +282,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
@@ -294,7 +294,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
         return wrapOperation(
@@ -376,7 +376,7 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     @Override
     public CompletableFuture<List<?>> eval(
         String expression,
-        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        Supplier<? extends MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         return wrapOperation(() -> client.eval(expression, resultMapperSupplier));
     }
 
@@ -384,15 +384,15 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        Supplier<? extends MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         return wrapOperation(() -> client.eval(expression, arguments, resultMapperSupplier));
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
         String expression, Collection<?> arguments,
-        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
-        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
+        Supplier<? extends MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         return wrapOperation(() -> client.eval(expression, arguments, argumentsMapperSupplier, resultMapperSupplier));
     }
 

--- a/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
@@ -170,49 +170,55 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     }
 
     @Override
-    public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(String functionName, Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper, Class<T> entityClass) throws TarantoolClientException {
-        return wrapOperation(() -> client.callForTupleResult(functionName, arguments, argumentsMapper, entityClass));
+    public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(
+        String functionName,
+        Collection<?> arguments,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
+        Class<T> entityClass) throws TarantoolClientException {
+        return wrapOperation(
+            () -> client.callForTupleResult(functionName, arguments, argumentsMapperSupplier, entityClass));
     }
 
     @Override
-    public <T> CompletableFuture<T> call(String functionName,
+    public <T> CompletableFuture<T> call(
+        String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return wrapOperation(() -> client.call(functionName, arguments, argumentsMapper, resultMapperSupplier));
+        return wrapOperation(() -> client.call(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier));
     }
 
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> resultClass) throws TarantoolClientException {
-        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, argumentsMapper, resultClass));
+        return wrapOperation(
+            () -> client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultClass));
     }
 
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
         return wrapOperation(() ->
-            client.callForSingleResult(functionName, arguments, argumentsMapper, valueConverter));
+            client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, valueConverter));
     }
 
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
         return wrapOperation(
-            () -> client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier));
+            () -> client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier));
     }
 
     @Override
@@ -264,35 +270,35 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass)
         throws TarantoolClientException {
         return wrapOperation(() -> client.callForMultiResult(
-            functionName, arguments, argumentsMapper, resultContainerSupplier, resultClass));
+            functionName, arguments, argumentsMapperSupplier, resultContainerSupplier, resultClass));
     }
 
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
         return wrapOperation(() -> client.callForMultiResult(
-            functionName, arguments, argumentsMapper, resultContainerSupplier, valueConverter));
+            functionName, arguments, argumentsMapperSupplier, resultContainerSupplier, valueConverter));
     }
 
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
         return wrapOperation(
-            () -> client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapperSupplier));
+            () -> client.callForMultiResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier));
     }
 
     @Override
@@ -385,9 +391,9 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     @Override
     public CompletableFuture<List<?>> eval(
         String expression, Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
-        return wrapOperation(() -> client.eval(expression, arguments, argumentsMapper, resultMapperSupplier));
+        return wrapOperation(() -> client.eval(expression, arguments, argumentsMapperSupplier, resultMapperSupplier));
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
@@ -370,24 +370,24 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     @Override
     public CompletableFuture<List<?>> eval(
         String expression,
-        MessagePackValueMapper resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.eval(expression, resultMapper));
+        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, resultMapperSupplier));
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
         String expression,
         Collection<?> arguments,
-        MessagePackValueMapper resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.eval(expression, arguments, resultMapper));
+        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, arguments, resultMapperSupplier));
     }
 
     @Override
     public CompletableFuture<List<?>> eval(
         String expression, Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        MessagePackValueMapper resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.eval(expression, arguments, argumentsMapper, resultMapper));
+        Supplier<MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
+        return wrapOperation(() -> client.eval(expression, arguments, argumentsMapper, resultMapperSupplier));
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
@@ -15,7 +15,6 @@ import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.core.space.RetryingTarantoolSpace;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.mappers.CallResultMapper;
-import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.converters.ValueConverter;
@@ -147,14 +146,6 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     }
 
     @Override
-    public CompletableFuture<List<?>> call(
-        String functionName,
-        Collection<?> arguments,
-        MessagePackMapper mapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.call(functionName, arguments, mapper));
-    }
-
-    @Override
     public <T> CompletableFuture<TarantoolResult<T>> callForTupleResult(String functionName, Class<T> entityClass)
         throws TarantoolClientException {
         return wrapOperation(() -> client.callForTupleResult(functionName, entityClass));
@@ -162,8 +153,8 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
 
     @Override
     public <T> CompletableFuture<T> call(String functionName,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.call(functionName, resultMapper));
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, resultMapperSupplier));
     }
 
     @Override
@@ -174,8 +165,8 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
 
     @Override
     public <T> CompletableFuture<T> call(String functionName, Collection<?> arguments,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.call(functionName, arguments, resultMapper));
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) throws TarantoolClientException {
+        return wrapOperation(() -> client.call(functionName, arguments, resultMapperSupplier));
     }
 
     @Override
@@ -185,10 +176,12 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     }
 
     @Override
-    public <T> CompletableFuture<T> call(String functionName, Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper, CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+    public <T> CompletableFuture<T> call(String functionName,
+        Collection<?> arguments,
+        MessagePackObjectMapper argumentsMapper,
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return wrapOperation(() -> client.call(functionName, arguments, argumentsMapper, resultMapper));
+        return wrapOperation(() -> client.call(functionName, arguments, argumentsMapper, resultMapperSupplier));
     }
 
     @Override
@@ -216,9 +209,10 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapper));
+        return wrapOperation(
+            () -> client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier));
     }
 
     @Override
@@ -241,9 +235,9 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, resultMapper));
+        return wrapOperation(() -> client.callForSingleResult(functionName, arguments, resultMapperSupplier));
     }
 
     @Override
@@ -261,9 +255,9 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     @Override
     public <T> CompletableFuture<T> callForSingleResult(
         String functionName,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper)
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return wrapOperation(() -> client.callForSingleResult(functionName, resultMapper));
+        return wrapOperation(() -> client.callForSingleResult(functionName, resultMapperSupplier));
     }
 
     @Override
@@ -295,9 +289,10 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper)
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
         throws TarantoolClientException {
-        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapper));
+        return wrapOperation(
+            () -> client.callForMultiResult(functionName, arguments, argumentsMapper, resultMapperSupplier));
     }
 
     @Override
@@ -326,8 +321,9 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
         Collection<?> arguments,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, resultMapper));
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
+        throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, arguments, resultMapperSupplier));
     }
 
     @Override
@@ -351,8 +347,9 @@ public abstract class RetryingTarantoolClient<T extends Packable, R extends Coll
     @Override
     public <T, R extends List<T>> CompletableFuture<R> callForMultiResult(
         String functionName,
-        CallResultMapper<R, MultiValueCallResult<T, R>> resultMapper) throws TarantoolClientException {
-        return wrapOperation(() -> client.callForMultiResult(functionName, resultMapper));
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier)
+        throws TarantoolClientException {
+        return wrapOperation(() -> client.callForMultiResult(functionName, resultMapperSupplier));
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
@@ -32,9 +32,6 @@ public class TarantoolRequestMetadata {
 
     @Override
     public String toString() {
-        Optional<TarantoolRequestSignature> requestSignature = request.getSignature();
-        return !requestSignature.isPresent() ?
-            String.format("request id: %d", getRequestId()) :
-            String.format("request signature: %s", requestSignature.get());
+        return request.toString();
     }
 }

--- a/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
@@ -1,8 +1,8 @@
 package io.tarantool.driver.core;
 
-import io.tarantool.driver.mappers.MessagePackValueMapper;
-
 import java.util.concurrent.CompletableFuture;
+
+import org.msgpack.value.Value;
 
 /**
  * Intermediate request metadata holder
@@ -10,19 +10,13 @@ import java.util.concurrent.CompletableFuture;
  * @author Alexey Kuzin
  */
 public class TarantoolRequestMetadata {
-    private final CompletableFuture<?> feature;
-    private final MessagePackValueMapper mapper;
+    private final CompletableFuture<Value> future;
 
-    protected TarantoolRequestMetadata(CompletableFuture<?> feature, MessagePackValueMapper mapper) {
-        this.feature = feature;
-        this.mapper = mapper;
+    protected TarantoolRequestMetadata(CompletableFuture<Value> future) {
+        this.future = future;
     }
 
-    public CompletableFuture<?> getFuture() {
-        return feature;
-    }
-
-    public MessagePackValueMapper getMapper() {
-        return mapper;
+    public CompletableFuture<Value> getFuture() {
+        return future;
     }
 }

--- a/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
@@ -1,8 +1,12 @@
 package io.tarantool.driver.core;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.msgpack.value.Value;
+
+import io.tarantool.driver.protocol.TarantoolRequest;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 
 /**
  * Intermediate request metadata holder
@@ -10,13 +14,27 @@ import org.msgpack.value.Value;
  * @author Alexey Kuzin
  */
 public class TarantoolRequestMetadata {
+    private final TarantoolRequest request;
     private final CompletableFuture<Value> future;
 
-    protected TarantoolRequestMetadata(CompletableFuture<Value> future) {
-        this.future = future;
+    protected TarantoolRequestMetadata(TarantoolRequest request, CompletableFuture<Value> requestFuture) {
+        this.request = request;
+        this.future = requestFuture;
     }
 
     public CompletableFuture<Value> getFuture() {
         return future;
+    }
+
+    public Long getRequestId() {
+        return request.getHeader().getSync();
+    }
+
+    @Override
+    public String toString() {
+        Optional<TarantoolRequestSignature> requestSignature = request.getSignature();
+        return !requestSignature.isPresent() ?
+            String.format("request id: %d", getRequestId()) :
+            String.format("request signature: %s", requestSignature.get());
     }
 }

--- a/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionImpl.java
+++ b/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionImpl.java
@@ -8,8 +8,9 @@ import io.tarantool.driver.api.connection.TarantoolConnectionCloseListener;
 import io.tarantool.driver.api.connection.TarantoolConnectionFailureListener;
 import io.tarantool.driver.core.RequestFutureManager;
 import io.tarantool.driver.exceptions.TarantoolClientException;
-import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolRequest;
+
+import org.msgpack.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,12 +66,12 @@ public class TarantoolConnectionImpl implements TarantoolConnection {
     }
 
     @Override
-    public <T> CompletableFuture<T> sendRequest(TarantoolRequest request, MessagePackValueMapper resultMapper) {
+    public CompletableFuture<Value> sendRequest(TarantoolRequest request) {
         if (!isConnected()) {
             throw new TarantoolClientException("Not connected to Tarantool server");
         }
 
-        CompletableFuture<T> requestFuture = requestManager.submitRequest(request, resultMapper);
+        CompletableFuture<Value> requestFuture = requestManager.submitRequest(request);
         channel.writeAndFlush(request).addListener(f -> {
             if (!f.isSuccess()) {
                 requestFuture.completeExceptionally(

--- a/src/main/java/io/tarantool/driver/core/metadata/SpacesMetadataProvider.java
+++ b/src/main/java/io/tarantool/driver/core/metadata/SpacesMetadataProvider.java
@@ -64,6 +64,6 @@ public class SpacesMetadataProvider implements TarantoolMetadataProvider {
         CallResultMapper<TarantoolResult<T>, SingleValueCallResult<TarantoolResult<T>>> resultMapper =
             client.getResultMapperFactoryFactory().<T>singleValueTarantoolResultMapperFactory()
                 .withSingleValueArrayTarantoolResultConverter(resultConverter, resultClass);
-        return client.call(selectCmd, resultMapper);
+        return client.call(selectCmd, () -> resultMapper);
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/AbstractProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/AbstractProxyOperation.java
@@ -25,17 +25,17 @@ abstract class AbstractProxyOperation<T> implements ProxyOperation<T> {
     protected final TarantoolCallOperations client;
     protected final String functionName;
     protected final Collection<?> arguments;
-    private final MessagePackObjectMapper argumentsMapper;
-    protected final Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier;
+    private final Supplier<MessagePackObjectMapper> argumentsMapperSupplier;
+    private final Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier;
 
     AbstractProxyOperation(
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
         this.client = client;
-        this.argumentsMapper = argumentsMapper;
+        this.argumentsMapperSupplier = argumentsMapperSupplier;
         this.arguments = arguments;
         this.functionName = functionName;
         this.resultMapperSupplier = resultMapperSupplier;
@@ -53,13 +53,17 @@ abstract class AbstractProxyOperation<T> implements ProxyOperation<T> {
         return arguments;
     }
 
+    public Supplier<MessagePackObjectMapper> getArgumentsMapperSupplier() {
+        return argumentsMapperSupplier;
+    }
+
     public Supplier<CallResultMapper<T, SingleValueCallResult<T>>> getResultMapperSupplier() {
         return resultMapperSupplier;
     }
 
     @Override
     public CompletableFuture<T> execute() {
-        return client.callForSingleResult(functionName, arguments, argumentsMapper, resultMapperSupplier);
+        return client.callForSingleResult(functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     abstract static
@@ -68,7 +72,7 @@ abstract class AbstractProxyOperation<T> implements ProxyOperation<T> {
         protected TarantoolCallOperations client;
         protected String functionName;
         protected EnumMap<ProxyOperationArgument, Object> arguments;
-        protected MessagePackObjectMapper argumentsMapper;
+        protected Supplier<MessagePackObjectMapper> argumentsMapperSupplier;
         protected Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier;
 
         GenericOperationsBuilder() {
@@ -115,11 +119,11 @@ abstract class AbstractProxyOperation<T> implements ProxyOperation<T> {
         /**
          * Specify entity-to-MessagePack mapper for arguments contents conversion
          *
-         * @param objectMapper mapper for arguments entity-to-MessagePack entity conversion
+         * @param argumentsMapperSupplier mapper supplier for arguments entity-to-MessagePack entity conversion
          * @return builder
          */
-        public B withArgumentsMapper(MessagePackObjectMapper objectMapper) {
-            this.argumentsMapper = objectMapper;
+        public B withArgumentsMapperSupplier(Supplier<MessagePackObjectMapper> argumentsMapperSupplier) {
+            this.argumentsMapperSupplier = argumentsMapperSupplier;
             return self();
         }
 

--- a/src/main/java/io/tarantool/driver/core/proxy/DeleteProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/DeleteProxyOperation.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for delete
@@ -22,8 +23,8 @@ public final class DeleteProxyOperation<T> extends AbstractProxyOperation<T> {
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -44,7 +45,8 @@ public final class DeleteProxyOperation<T> extends AbstractProxyOperation<T> {
         public DeleteProxyOperation<T> build() {
 
             return new DeleteProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/DeleteProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/DeleteProxyOperation.java
@@ -22,9 +22,9 @@ public final class DeleteProxyOperation<T> extends AbstractProxyOperation<T> {
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -46,7 +46,7 @@ public final class DeleteProxyOperation<T> extends AbstractProxyOperation<T> {
 
             return new DeleteProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/InsertManyProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/InsertManyProxyOperation.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for inserting many records at once
@@ -24,8 +25,8 @@ public final class InsertManyProxyOperation<T extends Packable, R extends Collec
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -45,7 +46,8 @@ public final class InsertManyProxyOperation<T extends Packable, R extends Collec
 
         public InsertManyProxyOperation<T, R> build() {
             return new InsertManyProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/InsertManyProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/InsertManyProxyOperation.java
@@ -24,9 +24,9 @@ public final class InsertManyProxyOperation<T extends Packable, R extends Collec
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -47,7 +47,7 @@ public final class InsertManyProxyOperation<T extends Packable, R extends Collec
         public InsertManyProxyOperation<T, R> build() {
             return new InsertManyProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/InsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/InsertProxyOperation.java
@@ -24,9 +24,9 @@ public final class InsertProxyOperation<T extends Packable, R extends Collection
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -48,7 +48,7 @@ public final class InsertProxyOperation<T extends Packable, R extends Collection
 
             return new InsertProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/InsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/InsertProxyOperation.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for insert
@@ -24,8 +25,8 @@ public final class InsertProxyOperation<T extends Packable, R extends Collection
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -46,7 +47,8 @@ public final class InsertProxyOperation<T extends Packable, R extends Collection
         public InsertProxyOperation<T, R> build() {
 
             return new InsertProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/ReplaceManyProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/ReplaceManyProxyOperation.java
@@ -24,9 +24,9 @@ public final class ReplaceManyProxyOperation<T extends Packable, R extends Colle
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -48,7 +48,7 @@ public final class ReplaceManyProxyOperation<T extends Packable, R extends Colle
 
             return new ReplaceManyProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/ReplaceManyProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/ReplaceManyProxyOperation.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for replacing many records at once
@@ -24,8 +25,8 @@ public final class ReplaceManyProxyOperation<T extends Packable, R extends Colle
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -46,7 +47,8 @@ public final class ReplaceManyProxyOperation<T extends Packable, R extends Colle
         public ReplaceManyProxyOperation<T, R> build() {
 
             return new ReplaceManyProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/ReplaceProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/ReplaceProxyOperation.java
@@ -25,9 +25,9 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -49,7 +49,7 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
 
             return new ReplaceProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/ReplaceProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/ReplaceProxyOperation.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for replace
@@ -25,8 +26,8 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -47,7 +48,8 @@ public final class ReplaceProxyOperation<T extends Packable, R extends Collectio
         public ReplaceProxyOperation<T, R> build() {
 
             return new ReplaceProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/SelectProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/SelectProxyOperation.java
@@ -14,6 +14,7 @@ import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for select
@@ -29,8 +30,8 @@ public final class SelectProxyOperation<T> extends AbstractProxyOperation<T> {
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -70,7 +71,8 @@ public final class SelectProxyOperation<T> extends AbstractProxyOperation<T> {
                 .ifPresent(after -> options.put(ProxyOption.AFTER.toString(), after));
 
             return new SelectProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/SelectProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/SelectProxyOperation.java
@@ -29,9 +29,9 @@ public final class SelectProxyOperation<T> extends AbstractProxyOperation<T> {
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -72,7 +72,7 @@ public final class SelectProxyOperation<T> extends AbstractProxyOperation<T> {
 
             return new SelectProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/UpdateProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/UpdateProxyOperation.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for update
@@ -22,8 +23,8 @@ public final class UpdateProxyOperation<T> extends AbstractProxyOperation<T> {
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<T, SingleValueCallResult<T>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -44,7 +45,8 @@ public final class UpdateProxyOperation<T> extends AbstractProxyOperation<T> {
         public UpdateProxyOperation<T> build() {
 
             return new UpdateProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/UpdateProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/UpdateProxyOperation.java
@@ -22,9 +22,9 @@ public final class UpdateProxyOperation<T> extends AbstractProxyOperation<T> {
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<T, SingleValueCallResult<T>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -46,7 +46,7 @@ public final class UpdateProxyOperation<T> extends AbstractProxyOperation<T> {
 
             return new UpdateProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/UpsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/UpsertProxyOperation.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.Packable;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Proxy operation for upsert
@@ -24,8 +25,8 @@ public final class UpsertProxyOperation<T extends Packable, R extends Collection
         String functionName,
         Collection<?> arguments,
         MessagePackObjectMapper argumentsMapper,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper) {
-        super(client, functionName, arguments, argumentsMapper, resultMapper);
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
+        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
     }
 
     /**
@@ -46,7 +47,8 @@ public final class UpsertProxyOperation<T extends Packable, R extends Collection
         public UpsertProxyOperation<T, R> build() {
 
             return new UpsertProxyOperation<>(
-                this.client, this.functionName, this.arguments.values(), this.argumentsMapper, this.resultMapper);
+                this.client, this.functionName, this.arguments.values(),
+                this.argumentsMapper, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/proxy/UpsertProxyOperation.java
+++ b/src/main/java/io/tarantool/driver/core/proxy/UpsertProxyOperation.java
@@ -24,9 +24,9 @@ public final class UpsertProxyOperation<T extends Packable, R extends Collection
         TarantoolCallOperations client,
         String functionName,
         Collection<?> arguments,
-        MessagePackObjectMapper argumentsMapper,
+        Supplier<MessagePackObjectMapper> argumentsMapperSupplier,
         Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier) {
-        super(client, functionName, arguments, argumentsMapper, resultMapperSupplier);
+        super(client, functionName, arguments, argumentsMapperSupplier, resultMapperSupplier);
     }
 
     /**
@@ -48,7 +48,7 @@ public final class UpsertProxyOperation<T extends Packable, R extends Collection
 
             return new UpsertProxyOperation<>(
                 this.client, this.functionName, this.arguments.values(),
-                this.argumentsMapper, this.resultMapperSupplier);
+                this.argumentsMapperSupplier, this.resultMapperSupplier);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
@@ -104,7 +104,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getDeleteFunctionName())
             .withIndexQuery(indexQuery)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -135,7 +135,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getInsertFunctionName())
             .withTuple(tuple)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -170,7 +170,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getInsertManyFunctionName())
             .withTuples(tuples)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -201,7 +201,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getReplaceFunctionName())
             .withTuple(tuple)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -235,7 +235,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getReplaceManyFunctionName())
             .withTuples(tuples)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -268,7 +268,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getSelectFunctionName())
             .withConditions(conditions)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -325,7 +325,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withIndexQuery(indexQuery)
             .withTupleOperation(operations)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 
@@ -361,7 +361,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withTuple(tuple)
             .withTupleOperation(operations)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapper(resultMapper)
+            .withResultMapperSupplier(() -> resultMapper)
             .withOptions(options)
             .build();
 

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
@@ -104,7 +104,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getDeleteFunctionName())
             .withIndexQuery(indexQuery)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -135,7 +135,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getInsertFunctionName())
             .withTuple(tuple)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -170,7 +170,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getInsertManyFunctionName())
             .withTuples(tuples)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -201,7 +201,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getReplaceFunctionName())
             .withTuple(tuple)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -235,7 +235,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getReplaceManyFunctionName())
             .withTuples(tuples)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -268,7 +268,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withSpaceName(spaceName)
             .withFunctionName(operationsMapping.getSelectFunctionName())
             .withConditions(conditions)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -325,7 +325,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getUpdateFunctionName())
             .withIndexQuery(indexQuery)
             .withTupleOperation(operations)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
@@ -361,7 +361,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getUpsertFunctionName())
             .withTuple(tuple)
             .withTupleOperation(operations)
-            .withArgumentsMapper(config.getMessagePackMapper())
+            .withArgumentsMapperSupplier(config::getMessagePackMapper)
             .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
@@ -46,6 +46,7 @@ import org.msgpack.value.ArrayValue;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * Basic proxy {@link TarantoolSpaceOperations} implementation, which uses calls to API functions defined in
@@ -80,7 +81,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> delete(Conditions conditions) throws TarantoolClientException {
-        return delete(conditions, rowsMetadataTupleResultMapper(), ProxyDeleteOptions.create());
+        return delete(conditions, this::rowsMetadataTupleResultMapper, ProxyDeleteOptions.create());
     }
 
     @Override
@@ -88,12 +89,12 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return delete(conditions, rowsMetadataTupleResultMapper(), options);
+        return delete(conditions, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> delete(
         Conditions conditions,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         DeleteOptions options)
         throws TarantoolClientException {
         TarantoolIndexQuery indexQuery = conditions.toIndexQuery(metadataOperations, spaceMetadata);
@@ -104,7 +105,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getDeleteFunctionName())
             .withIndexQuery(indexQuery)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -113,7 +114,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> insert(T tuple) throws TarantoolClientException {
-        return insert(tuple, rowsMetadataTupleResultMapper(), ProxyInsertOptions.create());
+        return insert(tuple, this::rowsMetadataTupleResultMapper, ProxyInsertOptions.create());
     }
 
     @Override
@@ -121,12 +122,12 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return insert(tuple, rowsMetadataTupleResultMapper(), options);
+        return insert(tuple, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> insert(
         T tuple,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         InsertOptions options)
         throws TarantoolClientException {
         InsertProxyOperation<T, R> operation = new InsertProxyOperation.Builder<T, R>()
@@ -135,7 +136,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getInsertFunctionName())
             .withTuple(tuple)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -144,7 +145,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> insertMany(Collection<T> tuples) {
-        return insertMany(tuples, rowsMetadataTupleResultMapper(), ProxyInsertManyOptions.create()
+        return insertMany(tuples, this::rowsMetadataTupleResultMapper, ProxyInsertManyOptions.create()
             .withStopOnError(StopOnError.TRUE)
             .withRollbackOnError(RollbackOnError.TRUE)
         );
@@ -156,12 +157,12 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return insertMany(tuples, rowsMetadataTupleResultMapper(), options);
+        return insertMany(tuples, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> insertMany(
         Collection<T> tuples,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         InsertManyOptions options)
         throws TarantoolClientException {
         InsertManyProxyOperation<T, R> operation = new InsertManyProxyOperation.Builder<T, R>()
@@ -170,7 +171,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getInsertManyFunctionName())
             .withTuples(tuples)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -179,7 +180,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> replace(T tuple) throws TarantoolClientException {
-        return replace(tuple, rowsMetadataTupleResultMapper(), ProxyReplaceOptions.create());
+        return replace(tuple, this::rowsMetadataTupleResultMapper, ProxyReplaceOptions.create());
     }
 
     @Override
@@ -187,12 +188,12 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return replace(tuple, rowsMetadataTupleResultMapper(), options);
+        return replace(tuple, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> replace(
         T tuple,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         ReplaceOptions options)
         throws TarantoolClientException {
         ReplaceProxyOperation<T, R> operation = new ReplaceProxyOperation.Builder<T, R>()
@@ -201,7 +202,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getReplaceFunctionName())
             .withTuple(tuple)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -210,7 +211,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> replaceMany(Collection<T> tuples) throws TarantoolClientException {
-        return replaceMany(tuples, rowsMetadataTupleResultMapper(), ProxyReplaceManyOptions.create()
+        return replaceMany(tuples, this::rowsMetadataTupleResultMapper, ProxyReplaceManyOptions.create()
             .withStopOnError(StopOnError.TRUE)
             .withRollbackOnError(RollbackOnError.TRUE)
         );
@@ -221,12 +222,12 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return replaceMany(tuples, rowsMetadataTupleResultMapper(), options);
+        return replaceMany(tuples, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> replaceMany(
         Collection<T> tuples,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         ReplaceManyOptions options)
         throws TarantoolClientException {
         ReplaceManyProxyOperation<T, R> operation = new ReplaceManyProxyOperation.Builder<T, R>()
@@ -235,7 +236,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getReplaceManyFunctionName())
             .withTuples(tuples)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -244,7 +245,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> select(Conditions conditions) throws TarantoolClientException {
-        return select(conditions, rowsMetadataTupleResultMapper(), ProxySelectOptions.create());
+        return select(conditions, this::rowsMetadataTupleResultMapper, ProxySelectOptions.create());
     }
 
     @Override
@@ -254,12 +255,12 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return select(conditions, rowsMetadataTupleResultMapper(), options);
+        return select(conditions, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> select(
         Conditions conditions,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         SelectOptions options)
         throws TarantoolClientException {
         SelectProxyOperation<R> operation = new SelectProxyOperation.Builder<R>(metadataOperations, spaceMetadata)
@@ -268,7 +269,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withFunctionName(operationsMapping.getSelectFunctionName())
             .withConditions(conditions)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -277,7 +278,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, T tuple) {
-        return update(conditions, makeOperationsFromTuple(tuple), rowsMetadataTupleResultMapper(),
+        return update(conditions, makeOperationsFromTuple(tuple), this::rowsMetadataTupleResultMapper,
             ProxyUpdateOptions.create()
         );
     }
@@ -287,7 +288,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return update(conditions, makeOperationsFromTuple(tuple), rowsMetadataTupleResultMapper(), options);
+        return update(conditions, makeOperationsFromTuple(tuple), this::rowsMetadataTupleResultMapper, options);
     }
 
     /**
@@ -300,7 +301,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> update(Conditions conditions, TupleOperations operations) {
-        return update(conditions, operations, rowsMetadataTupleResultMapper(), ProxyUpdateOptions.create());
+        return update(conditions, operations, this::rowsMetadataTupleResultMapper, ProxyUpdateOptions.create());
     }
 
     @Override
@@ -308,13 +309,13 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return update(conditions, operations, rowsMetadataTupleResultMapper(), options);
+        return update(conditions, operations, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> update(
         Conditions conditions,
         TupleOperations operations,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         UpdateOptions options) {
         TarantoolIndexQuery indexQuery = conditions.toIndexQuery(metadataOperations, spaceMetadata);
 
@@ -325,7 +326,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withIndexQuery(indexQuery)
             .withTupleOperation(operations)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 
@@ -334,7 +335,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
 
     @Override
     public CompletableFuture<R> upsert(Conditions conditions, T tuple, TupleOperations operations) {
-        return upsert(conditions, tuple, operations, rowsMetadataTupleResultMapper(), ProxyUpsertOptions.create());
+        return upsert(conditions, tuple, operations, this::rowsMetadataTupleResultMapper, ProxyUpsertOptions.create());
     }
 
     @Override
@@ -344,14 +345,14 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
         if (options == null) {
             throw new IllegalArgumentException("Options should not be null");
         }
-        return upsert(conditions, tuple, operations, rowsMetadataTupleResultMapper(), options);
+        return upsert(conditions, tuple, operations, this::rowsMetadataTupleResultMapper, options);
     }
 
     private CompletableFuture<R> upsert(
         Conditions conditions,
         T tuple,
         TupleOperations operations,
-        CallResultMapper<R, SingleValueCallResult<R>> resultMapper,
+        Supplier<CallResultMapper<R, SingleValueCallResult<R>>> resultMapperSupplier,
         UpsertOptions options) {
 
         UpsertProxyOperation<T, R> operation = new UpsertProxyOperation.Builder<T, R>()
@@ -361,7 +362,7 @@ public abstract class ProxyTarantoolSpace<T extends Packable, R extends Collecti
             .withTuple(tuple)
             .withTupleOperation(operations)
             .withArgumentsMapper(config.getMessagePackMapper())
-            .withResultMapperSupplier(() -> resultMapper)
+            .withResultMapperSupplier(resultMapperSupplier)
             .withOptions(options)
             .build();
 

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolTupleSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolTupleSpace.java
@@ -24,6 +24,9 @@ public class ProxyTarantoolTupleSpace
 
     private final TarantoolClientConfig config;
     private final TarantoolCallOperations client;
+    private final
+        CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
+        rowsMetadataTupleResultMapper;
 
     /**
      * Basic constructor
@@ -43,6 +46,9 @@ public class ProxyTarantoolTupleSpace
         super(config, client, mappingConfig, metadataOperations, spaceMetadata);
         this.config = config;
         this.client = client;
+        this.rowsMetadataTupleResultMapper = client
+            .getResultMapperFactoryFactory().getTarantoolTupleResultMapperFactory()
+            .withSingleValueRowsMetadataToTarantoolTupleResultMapper(config.getMessagePackMapper(), getMetadata());
     }
 
     @Override
@@ -53,8 +59,7 @@ public class ProxyTarantoolTupleSpace
     @Override
     protected CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
     rowsMetadataTupleResultMapper() {
-        return client.getResultMapperFactoryFactory().getTarantoolTupleResultMapperFactory()
-            .withSingleValueRowsMetadataToTarantoolTupleResultMapper(config.getMessagePackMapper(), getMetadata());
+        return rowsMetadataTupleResultMapper;
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
@@ -261,7 +261,7 @@ public abstract class TarantoolSpace<T extends Packable, R extends Collection<T>
 
     private CompletableFuture<R> sendRequest(TarantoolRequest request, MessagePackValueMapper resultMapper) {
         return connectionManager.getConnection()
-            .thenCompose(c -> c.sendRequest(request))
+            .thenCompose(c -> c.sendRequest(request).getFuture())
             .thenApply(resultMapper::fromValue);
     }
 

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
@@ -260,7 +260,9 @@ public abstract class TarantoolSpace<T extends Packable, R extends Collection<T>
     protected abstract MessagePackValueMapper arrayTupleResultMapper();
 
     private CompletableFuture<R> sendRequest(TarantoolRequest request, MessagePackValueMapper resultMapper) {
-        return connectionManager.getConnection().thenCompose(c -> c.sendRequest(request, resultMapper));
+        return connectionManager.getConnection()
+            .thenCompose(c -> c.sendRequest(request))
+            .thenApply(resultMapper::fromValue);
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolTupleSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolTupleSpace.java
@@ -23,6 +23,7 @@ public class TarantoolTupleSpace extends
 
     private final TarantoolCallOperations client;
     private final TarantoolClientConfig config;
+    private final MessagePackValueMapper arrayTupleResultMapper;
 
     /**
      * Basic constructor
@@ -42,6 +43,8 @@ public class TarantoolTupleSpace extends
         super(config, connectionManager, metadataOperations, spaceMetadata);
         this.client = client;
         this.config = config;
+        this.arrayTupleResultMapper = client.getResultMapperFactoryFactory().getTarantoolTupleResultMapperFactory()
+            .withArrayValueToTarantoolTupleResultConverter(config.getMessagePackMapper(), getMetadata());
     }
 
     @Override
@@ -51,8 +54,7 @@ public class TarantoolTupleSpace extends
 
     @Override
     protected MessagePackValueMapper arrayTupleResultMapper() {
-        return client.getResultMapperFactoryFactory().getTarantoolTupleResultMapperFactory()
-            .withArrayValueToTarantoolTupleResultConverter(config.getMessagePackMapper(), getMetadata());
+        return arrayTupleResultMapper;
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultCollectionToArrayValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultCollectionToArrayValueConverter.java
@@ -30,6 +30,6 @@ public class DefaultCollectionToArrayValueConverter implements ObjectConverter<C
         for (Object value : object) {
             values[i++] = value == null ? ValueFactory.newNil() : mapper.toValue(value);
         }
-        return ValueFactory.newArray(values, false);
+        return ValueFactory.newArray(values, true);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultListToArrayValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultListToArrayValueConverter.java
@@ -30,6 +30,6 @@ public class DefaultListToArrayValueConverter implements ObjectConverter<List<?>
         for (Object value : object) {
             values[i++] = value == null ? ValueFactory.newNil() : mapper.toValue(value);
         }
-        return ValueFactory.newArray(values, false);
+        return ValueFactory.newArray(values, true);
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequest.java
@@ -85,6 +85,13 @@ public abstract class TarantoolRequest {
         }
     }
 
+    @Override
+    public String toString() {
+        return !signature.isPresent() ?
+            String.format("request id: %d", header.getSync()) :
+            String.format("request signature: %s", signature.get());
+    }
+
     /**
      * Base class for request builder implementations
      */

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
@@ -1,0 +1,62 @@
+package io.tarantool.driver.protocol;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a request signature, uniquely defining the operation and the argument types.
+ * May include some argument values as well.
+ *
+ * @author Alexey Kuzin
+ */
+public class TarantoolRequestSignature {
+
+    private List<Object> components = new LinkedList<>();
+    private int hashCode = 1;
+
+    /**
+     * Constructor.
+     *
+     * @param initialComponents initial signature components, must be hashable
+     */
+    public TarantoolRequestSignature(Object... initialComponents) {
+        for (Object component: initialComponents) {
+            components.add(component);
+            hashCode = 31 * hashCode + Objects.hashCode(component);
+        }
+    }
+
+    /**
+     * Add a signature component to the end of the components list
+     *
+     * @param component signature component, must be hashable
+     * @return this signature object instance
+     */
+    public TarantoolRequestSignature addComponent(Object component) {
+        components.add(component);
+        hashCode = 31 * hashCode + Objects.hashCode(component);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof TarantoolRequestSignature &&
+            Objects.equals(this.components, ((TarantoolRequestSignature) other).components);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("[");
+        for (Object component: components) {
+            sb.append(String.valueOf(component)).append(",");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
@@ -1,5 +1,7 @@
 package io.tarantool.driver.protocol;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -68,5 +70,22 @@ public class TarantoolRequestSignature {
         }
         sb.append("]");
         return sb.toString();
+    }
+
+    /**
+     * Factory method for a typical RPC usage
+     *
+     * @param functionName name of the remote function
+     * @param arguments list of arguments for the remote function
+     * @param resultClass type of the expected result. It's necessary for polymorphic functions, e.g. accepting a
+     * Tarantool space as an argument
+     * @return new request signature
+     */
+    public static TarantoolRequestSignature create(String functionName, Collection<?> arguments, Class<?> resultClass) {
+        List<Object> components = new ArrayList<>(arguments.size() + 2);
+        components.add(functionName);
+        components.addAll(arguments);
+        components.add(resultClass.getName());
+        return new TarantoolRequestSignature(components.toArray(new Object[]{}));
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
@@ -5,10 +5,14 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.tarantool.driver.mappers.MessagePackObjectMapper;
+import io.tarantool.driver.mappers.MessagePackValueMapper;
 
 /**
- * Represents a request signature, uniquely defining the operation and the argument types.
- * May include some argument values as well.
+ * Represents a request signature, uniquely defining the operation and the
+ * argument types. May include some argument values as well.
  *
  * The hashcode calculation is not thread safe.
  *
@@ -22,13 +26,14 @@ public class TarantoolRequestSignature {
     /**
      * Constructor.
      *
-     * Stores either the component values if the component is of type String or the class names
-     * and calculates the hashcode from the passed initial set of components.
+     * Stores either the component values if the component is of type String or the
+     * class names and calculates the hashcode from the passed initial set of
+     * components.
      *
      * @param initialComponents initial signature components
      */
     public TarantoolRequestSignature(Object... initialComponents) {
-        for (Object component: initialComponents) {
+        for (Object component : initialComponents) {
             String componentValue = component instanceof String ? (String) component : component.getClass().getName();
             components.add(componentValue);
             hashCode = 31 * hashCode + Objects.hashCode(componentValue);
@@ -38,8 +43,8 @@ public class TarantoolRequestSignature {
     /**
      * Add a signature component to the end of the components list
      *
-     * Appends either the component value if the component is of type String or the component class
-     * to the components list and re-calculates the hashcode.
+     * Appends either the component value if the component is of type String or the
+     * component class to the components list and re-calculates the hashcode.
      *
      * @param component signature component
      * @return this signature object instance
@@ -58,14 +63,14 @@ public class TarantoolRequestSignature {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof TarantoolRequestSignature &&
-            Objects.equals(this.components, ((TarantoolRequestSignature) other).components);
+        return other instanceof TarantoolRequestSignature
+                && Objects.equals(this.components, ((TarantoolRequestSignature) other).components);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("[");
-        for (Object component: components) {
+        for (Object component : components) {
             sb.append(String.valueOf(component)).append(",");
         }
         sb.append("]");
@@ -75,19 +80,26 @@ public class TarantoolRequestSignature {
     /**
      * Factory method for a typical RPC usage
      *
-     * @param functionName name of the remote function
-     * @param arguments list of arguments for the remote function
-     * @param resultClass type of the expected result. It's necessary for polymorphic functions, e.g. accepting a
-     * Tarantool space as an argument
+     * @param functionName            name of the remote function
+     * @param arguments               list of arguments for the remote function
+     * @param resultClass             type of the expected result. It's necessary
+     *                                for polymorphic functions, e.g. accepting a
+     *                                Tarantool space as an argument
+     * @param argumentsMapperSupplier arguments mapper supplier
+     * @param resultMapperSupplier    result mapper supplier
      * @return new request signature
      */
-    public static TarantoolRequestSignature create(String functionName, Collection<?> arguments, Class<?> resultClass) {
-        List<Object> components = new ArrayList<>(arguments.size() + 2);
+    public static TarantoolRequestSignature create(String functionName, Collection<?> arguments, Class<?> resultClass,
+            Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
+            Supplier<? extends MessagePackValueMapper> resultMapperSupplier) {
+        List<Object> components = new ArrayList<>(arguments.size() + 4);
         components.add(functionName);
         for (Object argument : arguments) {
             components.add(argument.getClass().getName());
         }
         components.add(resultClass.getName());
-        return new TarantoolRequestSignature(components.toArray(new Object[]{}));
+        components.add(Integer.toHexString(argumentsMapperSupplier.hashCode()));
+        components.add(Integer.toHexString(resultMapperSupplier.hashCode()));
+        return new TarantoolRequestSignature(components.toArray(new Object[] {}));
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
@@ -8,34 +8,44 @@ import java.util.Objects;
  * Represents a request signature, uniquely defining the operation and the argument types.
  * May include some argument values as well.
  *
+ * The hashcode calculation is not thread safe.
+ *
  * @author Alexey Kuzin
  */
 public class TarantoolRequestSignature {
 
-    private List<Object> components = new LinkedList<>();
+    private List<String> components = new LinkedList<>();
     private int hashCode = 1;
 
     /**
      * Constructor.
      *
-     * @param initialComponents initial signature components, must be hashable
+     * Stores either the component values if the component is of type String or the class names
+     * and calculates the hashcode from the passed initial set of components.
+     *
+     * @param initialComponents initial signature components
      */
     public TarantoolRequestSignature(Object... initialComponents) {
         for (Object component: initialComponents) {
-            components.add(component);
-            hashCode = 31 * hashCode + Objects.hashCode(component);
+            String componentValue = component instanceof String ? (String) component : component.getClass().getName();
+            components.add(componentValue);
+            hashCode = 31 * hashCode + Objects.hashCode(componentValue);
         }
     }
 
     /**
      * Add a signature component to the end of the components list
      *
-     * @param component signature component, must be hashable
+     * Appends either the component value if the component is of type String or the component class
+     * to the components list and re-calculates the hashcode.
+     *
+     * @param component signature component
      * @return this signature object instance
      */
     public TarantoolRequestSignature addComponent(Object component) {
-        components.add(component);
-        hashCode = 31 * hashCode + Objects.hashCode(component);
+        String componentValue = component instanceof String ? (String) component : component.getClass().getName();
+        components.add(componentValue);
+        hashCode = 31 * hashCode + Objects.hashCode(componentValue);
         return this;
     }
 

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolRequestSignature.java
@@ -84,7 +84,9 @@ public class TarantoolRequestSignature {
     public static TarantoolRequestSignature create(String functionName, Collection<?> arguments, Class<?> resultClass) {
         List<Object> components = new ArrayList<>(arguments.size() + 2);
         components.add(functionName);
-        components.addAll(arguments);
+        for (Object argument : arguments) {
+            components.add(argument.getClass().getName());
+        }
         components.add(resultClass.getName());
         return new TarantoolRequestSignature(components.toArray(new Object[]{}));
     }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolAuthRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolAuthRequest.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
 import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 import io.tarantool.driver.utils.Assert;
 
@@ -25,14 +26,14 @@ public final class TarantoolAuthRequest extends TarantoolRequest {
     private static final int IPROTO_USER_NAME = 0x23;
     private static final int IPROTO_AUTH_DATA = 0x21;
 
-    private TarantoolAuthRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_AUTH, body);
+    private TarantoolAuthRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_AUTH, body, signature);
     }
 
     /**
      * Tarantool authentication request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         private final Map<Integer, Object> authMap;
 
@@ -41,6 +42,11 @@ public final class TarantoolAuthRequest extends TarantoolRequest {
          */
         public Builder() {
             authMap = new HashMap<>(2, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         public Builder withUsername(String username) {
@@ -63,7 +69,7 @@ public final class TarantoolAuthRequest extends TarantoolRequest {
                     "Username and auth data must be specified for Tarantool auth request");
             }
             MessagePackObjectMapper mapper = DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
-            return new TarantoolAuthRequest(new TarantoolRequestBody(authMap, mapper));
+            return new TarantoolAuthRequest(new TarantoolRequestBody(authMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolCallRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolCallRequest.java
@@ -5,6 +5,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.Collection;
@@ -20,19 +21,24 @@ import java.util.Map;
  */
 public final class TarantoolCallRequest extends TarantoolRequest {
 
-    private TarantoolCallRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_CALL, body);
+    private TarantoolCallRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_CALL, body, signature);
     }
 
     /**
      * Tarantool call request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(2, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         /**
@@ -69,7 +75,7 @@ public final class TarantoolCallRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Function name must be specified in the call request");
             }
 
-            return new TarantoolCallRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolCallRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolDeleteRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolDeleteRequest.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.HashMap;
@@ -23,19 +24,24 @@ import java.util.Map;
  */
 public final class TarantoolDeleteRequest extends TarantoolRequest {
 
-    private TarantoolDeleteRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_DELETE, body);
+    private TarantoolDeleteRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_DELETE, body, signature);
     }
 
     /**
      * Tarantool delete request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(3, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         /**
@@ -93,7 +99,7 @@ public final class TarantoolDeleteRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Key values must be specified in the delete request");
             }
 
-            return new TarantoolDeleteRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolDeleteRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolEvalRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolEvalRequest.java
@@ -5,6 +5,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.Collection;
@@ -20,19 +21,24 @@ import java.util.Map;
  */
 public final class TarantoolEvalRequest extends TarantoolRequest {
 
-    private TarantoolEvalRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_EVAL, body);
+    private TarantoolEvalRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_EVAL, body, signature);
     }
 
     /**
      * Tarantool eval request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(2, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         /**
@@ -69,7 +75,7 @@ public final class TarantoolEvalRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Lua expression must be specified in the eval request");
             }
 
-            return new TarantoolEvalRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolEvalRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolInsertRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolInsertRequest.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.HashMap;
@@ -20,19 +21,24 @@ import java.util.Map;
  */
 public final class TarantoolInsertRequest extends TarantoolRequest {
 
-    private TarantoolInsertRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_INSERT, body);
+    private TarantoolInsertRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_INSERT, body, signature);
     }
 
     /**
      * Tarantool insert request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(2, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         /**
@@ -72,7 +78,7 @@ public final class TarantoolInsertRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Tuple value must be specified for the insert request");
             }
 
-            return new TarantoolInsertRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolInsertRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolReplaceRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolReplaceRequest.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.HashMap;
@@ -20,19 +21,24 @@ import java.util.Map;
  */
 public final class TarantoolReplaceRequest extends TarantoolRequest {
 
-    private TarantoolReplaceRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_REPLACE, body);
+    private TarantoolReplaceRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_REPLACE, body, signature);
     }
 
     /**
      * Tarantool replace request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(2, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         /**
@@ -72,7 +78,7 @@ public final class TarantoolReplaceRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Tuple value must be specified for the replace request");
             }
 
-            return new TarantoolReplaceRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolReplaceRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolSelectRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolSelectRequest.java
@@ -6,6 +6,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.HashMap;
@@ -21,19 +22,24 @@ import java.util.Map;
  */
 public final class TarantoolSelectRequest extends TarantoolRequest {
 
-    private TarantoolSelectRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_SELECT, body);
+    private TarantoolSelectRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_SELECT, body, signature);
     }
 
     /**
      * Tarantool select request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(6, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         /**
@@ -128,7 +134,7 @@ public final class TarantoolSelectRequest extends TarantoolRequest {
             if (!bodyMap.containsKey(TarantoolRequestFieldType.IPROTO_KEY.getCode())) {
                 throw new TarantoolProtocolException("Key values must be specified in the select request");
             }
-            return new TarantoolSelectRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolSelectRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpdateRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpdateRequest.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.HashMap;
@@ -25,19 +26,24 @@ public final class TarantoolUpdateRequest extends TarantoolRequest {
     /**
      * (non-Javadoc)
      */
-    private TarantoolUpdateRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_UPDATE, body);
+    private TarantoolUpdateRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_UPDATE, body, signature);
     }
 
     /**
      * Tarantool update request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(4, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         public Builder withSpaceId(int spaceId) {
@@ -74,7 +80,7 @@ public final class TarantoolUpdateRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Update operations must be specified for the update request");
             }
 
-            return new TarantoolUpdateRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolUpdateRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpsertRequest.java
+++ b/src/main/java/io/tarantool/driver/protocol/requests/TarantoolUpsertRequest.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.protocol.TarantoolProtocolException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 import io.tarantool.driver.protocol.TarantoolRequestBody;
 import io.tarantool.driver.protocol.TarantoolRequestFieldType;
+import io.tarantool.driver.protocol.TarantoolRequestSignature;
 import io.tarantool.driver.protocol.TarantoolRequestType;
 
 import java.util.HashMap;
@@ -25,19 +26,24 @@ public final class TarantoolUpsertRequest extends TarantoolRequest {
     /**
      * (non-Javadoc)
      */
-    private TarantoolUpsertRequest(TarantoolRequestBody body) {
-        super(TarantoolRequestType.IPROTO_UPSERT, body);
+    private TarantoolUpsertRequest(TarantoolRequestBody body, TarantoolRequestSignature signature) {
+        super(TarantoolRequestType.IPROTO_UPSERT, body, signature);
     }
 
     /**
      * Tarantool update request builder
      */
-    public static class Builder {
+    public static class Builder extends TarantoolRequest.Builder<Builder> {
 
         Map<Integer, Object> bodyMap;
 
         public Builder() {
             this.bodyMap = new HashMap<>(4, 1);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
         }
 
         public Builder withSpaceId(int spaceId) {
@@ -74,7 +80,7 @@ public final class TarantoolUpsertRequest extends TarantoolRequest {
                 throw new TarantoolProtocolException("Update operations must be specified for the upsert request");
             }
 
-            return new TarantoolUpsertRequest(new TarantoolRequestBody(bodyMap, mapper));
+            return new TarantoolUpsertRequest(new TarantoolRequestBody(bodyMap, mapper), signature);
         }
     }
 }

--- a/src/test/java/io/tarantool/driver/benchmark/BenchmarkRunner.java
+++ b/src/test/java/io/tarantool/driver/benchmark/BenchmarkRunner.java
@@ -70,7 +70,7 @@ public class BenchmarkRunner {
         TarantoolResult<TarantoolTuple> tuples = plan.tarantoolClient.call(
             "return_arrays_with_different_types",
             Collections.emptyList(),
-            plan.defaultMapper,
+            plan.defaultMapperSupplier,
             plan.resultMapperSupplier
         ).join();
 
@@ -108,7 +108,7 @@ public class BenchmarkRunner {
         TarantoolResult<TarantoolTuple> tuples = plan.tarantoolClient.call(
             "return_arrays_with_different_types",
             Collections.emptyList(),
-            plan.defaultMapper,
+            plan.defaultMapperSupplier,
             plan.resultMapperSupplier
         ).join();
 

--- a/src/test/java/io/tarantool/driver/benchmark/BenchmarkRunner.java
+++ b/src/test/java/io/tarantool/driver/benchmark/BenchmarkRunner.java
@@ -71,7 +71,7 @@ public class BenchmarkRunner {
             "return_arrays_with_different_types",
             Collections.emptyList(),
             plan.defaultMapper,
-            plan.resultMapper
+            plan.resultMapperSupplier
         ).join();
 
         assertEquals(1000, tuples.size());
@@ -109,7 +109,7 @@ public class BenchmarkRunner {
             "return_arrays_with_different_types",
             Collections.emptyList(),
             plan.defaultMapper,
-            plan.resultMapper
+            plan.resultMapperSupplier
         ).join();
 
         assertEquals(1000, tuples.size());

--- a/src/test/java/io/tarantool/driver/benchmark/ClusterBenchmarkRunner.java
+++ b/src/test/java/io/tarantool/driver/benchmark/ClusterBenchmarkRunner.java
@@ -1,0 +1,134 @@
+package io.tarantool.driver.benchmark;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(value = 1, jvmArgsAppend = "-Xmx1G")
+public class ClusterBenchmarkRunner {
+    private static final String TEST_SPACE = "test_space";
+    private static final String TEST_PROFILE = "test__profile";
+
+    public static void main(String[] args) throws Exception {
+        org.openjdk.jmh.Main.main(args);
+    }
+
+    @Benchmark
+    @Measurement(iterations = 10)
+    @OperationsPerInvocation(2)
+    public void getSpaceObject(ClusterTarantoolSetup plan, Blackhole bh) {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+            plan.tarantoolClient.space(TEST_SPACE);
+        bh.consume(testSpace);
+
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+            plan.tarantoolClient.space(TEST_PROFILE);
+        bh.consume(profileSpace);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Measurement(iterations = 10)
+    @OperationsPerInvocation(2000)
+    public void writeData(ClusterTarantoolSetup plan, FuturesHolder futuresHolder, Spaces spaces, Blackhole bh) {
+        // Fill 10000 rows into both spaces
+        TarantoolTuple tarantoolTuple;
+        String uuid;
+        int nextId = 0;
+        for (int i = 0; i < 1_000; i++) {
+            uuid = UUID.randomUUID().toString();
+            nextId = plan.nextTestSpaceId + i;
+            tarantoolTuple = plan.tupleFactory.create(1_000_000 + nextId, null, uuid, 200_000 + nextId);
+            futuresHolder.allFutures.add(spaces.testSpace.insert(tarantoolTuple));
+            tarantoolTuple = plan.tupleFactory.create(1_000_000 + nextId, null, uuid, 50_000 + nextId, 100_000 + i);
+            futuresHolder.allFutures.add(spaces.profileSpace.insert(tarantoolTuple));
+        }
+        nextId++;
+        plan.nextTestSpaceId = nextId;
+        plan.nextProfileSpaceId = nextId;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Measurement(iterations = 10)
+    @OperationsPerInvocation(1000)
+    public void readDataUsingCallAPI(ClusterTarantoolSetup plan, FuturesHolder futuresHolder, Blackhole bh) {
+        boolean coin = Math.random() - 0.5 > 0;
+        String spaceName = coin ? TEST_SPACE : TEST_PROFILE;
+        long nextId;
+        for (int i = 0; i < 1_000; i++) {
+            nextId = Math.round(Math.random() * 10_000) + 1_000_000;
+            futuresHolder.allFutures.add(
+                plan.tarantoolClient.callForSingleResult(
+                    "custom_crud_get_one_record", Arrays.asList(spaceName, nextId), List.class)
+            );
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @Measurement(iterations = 10)
+    @OperationsPerInvocation(1000)
+    public void readDataUsingSpaceAPI(
+        ClusterTarantoolSetup plan, FuturesHolder futuresHolder, Spaces spaces, Blackhole bh) {
+        boolean coin = Math.random() - 0.5 > 0;
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> space = coin ?
+            spaces.testSpace : spaces.profileSpace;
+        String pkFieldName = coin ? "id" : "profile_id";
+        long nextId;
+        for (int i = 0; i < 1_000; i++) {
+            nextId = Math.round(Math.random() * 10_000) + 1_000_000;
+            futuresHolder.allFutures.add(
+                space.select(Conditions.indexEquals(pkFieldName, Collections.singletonList(nextId)))
+            );
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class FuturesHolder {
+        final List<CompletableFuture<?>> allFutures = new ArrayList<>(2_000);
+
+        @Setup(Level.Invocation)
+        public void doSetup() {
+            allFutures.clear();
+        }
+
+        @TearDown(Level.Invocation)
+        public void doTeardown() {
+            allFutures.forEach(CompletableFuture::join);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class Spaces {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace;
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace;
+
+        @Setup(Level.Iteration)
+        public void doSetup(ClusterTarantoolSetup plan) {
+            testSpace = plan.tarantoolClient.space(TEST_SPACE);
+            profileSpace = plan.tarantoolClient.space(TEST_PROFILE);
+        }
+    }
+}

--- a/src/test/java/io/tarantool/driver/benchmark/ClusterTarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/ClusterTarantoolSetup.java
@@ -1,0 +1,80 @@
+package io.tarantool.driver.benchmark;
+
+import java.time.Duration;
+
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolClientFactory;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.TarantoolServerAddress;
+import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
+import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
+import io.tarantool.driver.mappers.MessagePackMapper;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.TarantoolCartridgeContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+@State(Scope.Benchmark)
+public class ClusterTarantoolSetup {
+    public Logger logger = LoggerFactory.getLogger(ClusterTarantoolSetup.class);
+
+    final MessagePackMapper defaultMapper =
+        DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
+    final TarantoolTupleFactory tupleFactory = new DefaultTarantoolTupleFactory(defaultMapper);
+
+    final TarantoolCartridgeContainer tarantoolContainer =
+        new TarantoolCartridgeContainer(
+            "Dockerfile",
+            "cartridge-java-test",
+            "cartridge/instances.yml",
+            "cartridge/topology.lua")
+            .withDirectoryBinding("cartridge")
+            .withLogConsumer(new Slf4jLogConsumer(logger))
+            .waitingFor(Wait.forLogMessage(".*Listening HTTP on.*", 5))
+            .withStartupTimeout(Duration.ofMinutes(2));
+
+    TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> tarantoolClient;
+
+    int nextTestSpaceId;
+    int nextProfileSpaceId;
+
+    private void initClient() {
+        tarantoolClient = TarantoolClientFactory.createClient()
+            .withAddresses(
+                new TarantoolServerAddress(tarantoolContainer.getRouterHost(), tarantoolContainer.getMappedPort(3301)),
+                new TarantoolServerAddress(tarantoolContainer.getRouterHost(), tarantoolContainer.getMappedPort(3302)),
+                new TarantoolServerAddress(tarantoolContainer.getRouterHost(), tarantoolContainer.getMappedPort(3303))
+            )
+            .withCredentials(tarantoolContainer.getUsername(), tarantoolContainer.getPassword())
+            .withConnections(10)
+            .withEventLoopThreadsNumber(10)
+            .withRequestTimeout(10000)
+            .withProxyMethodMapping()
+            .build();
+    }
+
+    @Setup(Level.Trial)
+    public void doSetup() {
+        System.out.println("Do Setup");
+        if (!tarantoolContainer.isRunning()) {
+            tarantoolContainer.start();
+        }
+        initClient();
+    }
+
+    @TearDown(Level.Trial)
+    public void doTearDown() throws Exception {
+        System.out.println("Do TearDown");
+        tarantoolClient.close();
+        tarantoolContainer.close();
+    }
+}

--- a/src/test/java/io/tarantool/driver/benchmark/SingleInstanceBenchmarkRunner.java
+++ b/src/test/java/io/tarantool/driver/benchmark/SingleInstanceBenchmarkRunner.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class BenchmarkRunner {
+public class SingleInstanceBenchmarkRunner {
     public static void main(String[] args) throws Exception {
         org.openjdk.jmh.Main.main(args);
     }
@@ -29,7 +29,7 @@ public class BenchmarkRunner {
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
     @OperationsPerInvocation(1000)
-    public void acceptingDiffTypes(TarantoolSetup plan, Blackhole bh) {
+    public void acceptingDiffTypes(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         List<?> result = plan.tarantoolClient.call(
             "return_arrays_with_different_types"
         ).join();
@@ -66,7 +66,7 @@ public class BenchmarkRunner {
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
     @OperationsPerInvocation(1000)
-    public void acceptingDiffTypesAsTuplesAndUnpackIt(TarantoolSetup plan, Blackhole bh) {
+    public void acceptingDiffTypesAsTuplesAndUnpackIt(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         TarantoolResult<TarantoolTuple> tuples = plan.tarantoolClient.call(
             "return_arrays_with_different_types",
             Collections.emptyList(),
@@ -104,7 +104,7 @@ public class BenchmarkRunner {
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
     @OperationsPerInvocation(1000)
-    public void acceptingDiffTypesAsTuplesAndUnpackItWithTargetType(TarantoolSetup plan, Blackhole bh) {
+    public void acceptingDiffTypesAsTuplesAndUnpackItWithTargetType(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         TarantoolResult<TarantoolTuple> tuples = plan.tarantoolClient.call(
             "return_arrays_with_different_types",
             Collections.emptyList(),
@@ -142,7 +142,7 @@ public class BenchmarkRunner {
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
     @OperationsPerInvocation(1000)
-    public void passingArrayOfArraysWithDiffTypes(TarantoolSetup plan, Blackhole bh) {
+    public void passingArrayOfArraysWithDiffTypes(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         bh.consume(plan.tarantoolClient.call(
             "empty_function", plan.arraysWithDiffElements).join());
     }
@@ -151,7 +151,7 @@ public class BenchmarkRunner {
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
     @OperationsPerInvocation(1000)
-    public void passingArrayOfArraysWithNestedArrays(TarantoolSetup plan, Blackhole bh) {
+    public void passingArrayOfArraysWithNestedArrays(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         bh.consume(plan.tarantoolClient.call(
             "empty_function", plan.arraysWithNestedArrays).join());
     }
@@ -160,7 +160,7 @@ public class BenchmarkRunner {
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
     @OperationsPerInvocation(1000)
-    public void passingArrayOfArraysWithNestedMaps(TarantoolSetup plan, Blackhole bh) {
+    public void passingArrayOfArraysWithNestedMaps(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         bh.consume(plan.tarantoolClient.call(
             "empty_function", plan.arraysWithNestedMaps).join());
     }
@@ -168,7 +168,7 @@ public class BenchmarkRunner {
     @Benchmark
     @Fork(1)
     @BenchmarkMode(Mode.Throughput)
-    public void spaceCall(TarantoolSetup plan, Blackhole bh) {
+    public void spaceCall(SingleInstanceTarantoolSetup plan, Blackhole bh) {
         bh.consume(plan.retryingTarantoolClient.space(
             "test_space"));
     }

--- a/src/test/java/io/tarantool/driver/benchmark/SingleInstanceTarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/SingleInstanceTarantoolSetup.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.function.Supplier;
 
 @State(Scope.Benchmark)
-public class TarantoolSetup {
-    public Logger log = LoggerFactory.getLogger(TarantoolSetup.class);
+public class SingleInstanceTarantoolSetup {
+    public Logger log = LoggerFactory.getLogger(SingleInstanceTarantoolSetup.class);
 
     public TarantoolContainer tarantoolContainer = new TarantoolContainer()
         .withScriptFileName("org/testcontainers/containers/benchmark.lua")

--- a/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
@@ -10,7 +10,6 @@ import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
-import io.tarantool.driver.mappers.factories.ResultMapperFactoryFactoryImpl;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -25,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Supplier;
 
 @State(Scope.Benchmark)
 public class TarantoolSetup {
@@ -39,6 +39,8 @@ public class TarantoolSetup {
     MessagePackMapper defaultMapper;
     CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
         resultMapper;
+    Supplier<CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>>
+        resultMapperSupplier;
     List<List<Object>> arraysWithDiffElements;
     List<List<Object>> arraysWithNestedArrays;
     List<List<Object>> arraysWithNestedMaps;
@@ -61,6 +63,7 @@ public class TarantoolSetup {
         defaultMapper = tarantoolClient.getConfig().getMessagePackMapper();
         resultMapper = tarantoolTupleResultMapperFactory
             .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata);
+        resultMapperSupplier = () -> resultMapper;
 
         log.info("Successfully connected to Tarantool, version = {}", tarantoolClient.getVersion());
     }

--- a/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/TarantoolSetup.java
@@ -8,6 +8,7 @@ import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import org.openjdk.jmh.annotations.Level;
@@ -37,6 +38,7 @@ public class TarantoolSetup {
     TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> tarantoolClient;
     TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> retryingTarantoolClient;
     MessagePackMapper defaultMapper;
+    Supplier<MessagePackObjectMapper> defaultMapperSupplier = () -> defaultMapper;
     CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
         resultMapper;
     Supplier<CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>>

--- a/src/test/java/io/tarantool/driver/core/CustomConnection.java
+++ b/src/test/java/io/tarantool/driver/core/CustomConnection.java
@@ -6,13 +6,14 @@ import io.tarantool.driver.api.connection.TarantoolConnection;
 import io.tarantool.driver.api.connection.TarantoolConnectionCloseListener;
 import io.tarantool.driver.api.connection.TarantoolConnectionFailureListener;
 import io.tarantool.driver.exceptions.TarantoolClientException;
-import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.msgpack.value.Value;
 
 /**
  * @author Alexey Kuzin
@@ -65,7 +66,7 @@ final class CustomConnection implements TarantoolConnection {
     }
 
     @Override
-    public <T> CompletableFuture<T> sendRequest(TarantoolRequest request, MessagePackValueMapper resultMapper) {
+    public CompletableFuture<Value> sendRequest(TarantoolRequest request) {
         return null;
     }
 

--- a/src/test/java/io/tarantool/driver/core/CustomConnection.java
+++ b/src/test/java/io/tarantool/driver/core/CustomConnection.java
@@ -9,11 +9,8 @@ import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.msgpack.value.Value;
 
 /**
  * @author Alexey Kuzin
@@ -66,7 +63,7 @@ final class CustomConnection implements TarantoolConnection {
     }
 
     @Override
-    public CompletableFuture<Value> sendRequest(TarantoolRequest request) {
+    public TarantoolRequestMetadata sendRequest(TarantoolRequest request) {
         return null;
     }
 

--- a/src/test/java/io/tarantool/driver/core/proxy/ProxyOperationBuildersTest.java
+++ b/src/test/java/io/tarantool/driver/core/proxy/ProxyOperationBuildersTest.java
@@ -25,6 +25,7 @@ import io.tarantool.driver.core.metadata.TarantoolMetadata;
 import io.tarantool.driver.core.metadata.TestMetadataProvider;
 import io.tarantool.driver.mappers.CallResultMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
@@ -49,6 +50,7 @@ public class ProxyOperationBuildersTest {
     private final MessagePackMapper defaultMapper =
         DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
     private final TarantoolTupleFactory factory = new DefaultTarantoolTupleFactory(defaultMapper);
+    private final Supplier<MessagePackObjectMapper> defaultMapperSupplier = () -> defaultMapper;
     TarantoolTupleResultMapperFactory tarantoolTupleResultMapperFactory =
         TarantoolTupleResultMapperFactoryImpl.getInstance();
     private final
@@ -71,7 +73,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withIndexQuery(indexQuery)
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxyDeleteOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                 )
@@ -98,7 +100,7 @@ public class ProxyOperationBuildersTest {
                 .withSpaceName("space1")
                 .withFunctionName("function1")
                 .withTuple(tarantoolTuple)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withOptions(ProxyInsertOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -128,7 +130,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withTuples(tarantoolTuples)
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxyInsertManyOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                     .withRollbackOnError(RollbackOnError.TRUE)
@@ -143,6 +145,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, operation.getClient());
         assertEquals("function1", operation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuples, options), operation.getArguments());
+        assertEquals(defaultMapperSupplier, operation.getArgumentsMapperSupplier());
         assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
@@ -158,7 +161,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withTuple(tarantoolTuple)
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxyReplaceOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                 )
@@ -170,6 +173,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, operation.getClient());
         assertEquals("function1", operation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuple, options), operation.getArguments());
+        assertEquals(defaultMapperSupplier, operation.getArgumentsMapperSupplier());
         assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
@@ -187,7 +191,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withTuples(tarantoolTuples)
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxyReplaceManyOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                     .withRollbackOnError(RollbackOnError.TRUE)
@@ -203,6 +207,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, operation.getClient());
         assertEquals("function1", operation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuples, options), operation.getArguments());
+        assertEquals(defaultMapperSupplier, operation.getArgumentsMapperSupplier());
         assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
@@ -225,7 +230,7 @@ public class ProxyOperationBuildersTest {
                 .withConditions(conditions)
                 .withFunctionName("function1")
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxySelectOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                     .withBatchSize(123456)
@@ -263,7 +268,7 @@ public class ProxyOperationBuildersTest {
                 .withIndexQuery(indexQuery)
                 .withTupleOperation(TupleOperations.add(3, 90).andAdd(4, 5))
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxyUpdateOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                 )
@@ -280,6 +285,7 @@ public class ProxyOperationBuildersTest {
                 TupleOperations.add(3, 90).andAdd(4, 5).asProxyOperationList(), options),
             operation.getArguments());
 
+        assertEquals(defaultMapperSupplier, operation.getArgumentsMapperSupplier());
         assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
@@ -299,7 +305,7 @@ public class ProxyOperationBuildersTest {
                 .withTuple(tarantoolTuple)
                 .withTupleOperation(TupleOperations.add(3, 90).andAdd(4, 5))
                 .withResultMapperSupplier(defaultResultMapperSupplier)
-                .withArgumentsMapper(defaultMapper)
+                .withArgumentsMapperSupplier(defaultMapperSupplier)
                 .withOptions(ProxyUpsertOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                 )
@@ -313,6 +319,7 @@ public class ProxyOperationBuildersTest {
         assertIterableEquals(Arrays.asList("space1", tarantoolTuple,
                 TupleOperations.add(3, 90).andAdd(4, 5).asProxyOperationList(), options),
             operation.getArguments());
+        assertEquals(defaultMapperSupplier, operation.getArgumentsMapperSupplier());
         assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 

--- a/src/test/java/io/tarantool/driver/core/proxy/ProxyOperationBuildersTest.java
+++ b/src/test/java/io/tarantool/driver/core/proxy/ProxyOperationBuildersTest.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -54,6 +55,9 @@ public class ProxyOperationBuildersTest {
     CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>
         defaultResultMapper = tarantoolTupleResultMapperFactory
         .withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null);
+    private final
+    Supplier<CallResultMapper<TarantoolResult<TarantoolTuple>, SingleValueCallResult<TarantoolResult<TarantoolTuple>>>>
+        defaultResultMapperSupplier = () -> defaultResultMapper;
 
     @Test
     public void deleteOperationBuilderTest() {
@@ -66,7 +70,7 @@ public class ProxyOperationBuildersTest {
                 .withSpaceName("space1")
                 .withFunctionName("function1")
                 .withIndexQuery(indexQuery)
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxyDeleteOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -80,7 +84,7 @@ public class ProxyOperationBuildersTest {
         assertEquals("function1", deleteProxyOperation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", Collections.singletonList(42L), options),
             deleteProxyOperation.getArguments());
-        assertEquals(defaultResultMapper, deleteProxyOperation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, deleteProxyOperation.getResultMapperSupplier());
     }
 
     @Test
@@ -95,7 +99,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withTuple(tarantoolTuple)
                 .withArgumentsMapper(defaultMapper)
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withOptions(ProxyInsertOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
                 )
@@ -107,7 +111,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, insertOperation.getClient());
         assertEquals("function1", insertOperation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuple, options), insertOperation.getArguments());
-        assertEquals(defaultResultMapper, insertOperation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, insertOperation.getResultMapperSupplier());
     }
 
     @Test
@@ -123,7 +127,7 @@ public class ProxyOperationBuildersTest {
                 .withSpaceName("space1")
                 .withFunctionName("function1")
                 .withTuples(tarantoolTuples)
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxyInsertManyOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -139,7 +143,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, operation.getClient());
         assertEquals("function1", operation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuples, options), operation.getArguments());
-        assertEquals(defaultResultMapper, operation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
     @Test
@@ -153,7 +157,7 @@ public class ProxyOperationBuildersTest {
                 .withSpaceName("space1")
                 .withFunctionName("function1")
                 .withTuple(tarantoolTuple)
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxyReplaceOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -166,7 +170,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, operation.getClient());
         assertEquals("function1", operation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuple, options), operation.getArguments());
-        assertEquals(defaultResultMapper, operation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
     @Test
@@ -182,7 +186,7 @@ public class ProxyOperationBuildersTest {
                 .withSpaceName("space1")
                 .withFunctionName("function1")
                 .withTuples(tarantoolTuples)
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxyReplaceManyOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -199,7 +203,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(client, operation.getClient());
         assertEquals("function1", operation.getFunctionName());
         assertIterableEquals(Arrays.asList("space1", tarantoolTuples, options), operation.getArguments());
-        assertEquals(defaultResultMapper, operation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
     @Test
@@ -220,7 +224,7 @@ public class ProxyOperationBuildersTest {
                 .withSpaceName("space1")
                 .withConditions(conditions)
                 .withFunctionName("function1")
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxySelectOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -243,7 +247,7 @@ public class ProxyOperationBuildersTest {
         assertEquals(selectArguments, argumentValues.get(1));
         Map<String, Object> actualOptions = (Map<String, Object>) argumentValues.get(2);
         assertEquals(options.toString(), actualOptions.toString());
-        assertEquals(defaultResultMapper, op.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, op.getResultMapperSupplier());
     }
 
     @Test
@@ -258,7 +262,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withIndexQuery(indexQuery)
                 .withTupleOperation(TupleOperations.add(3, 90).andAdd(4, 5))
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxyUpdateOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -276,7 +280,7 @@ public class ProxyOperationBuildersTest {
                 TupleOperations.add(3, 90).andAdd(4, 5).asProxyOperationList(), options),
             operation.getArguments());
 
-        assertEquals(defaultResultMapper, operation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
     @Test
@@ -294,7 +298,7 @@ public class ProxyOperationBuildersTest {
                 .withFunctionName("function1")
                 .withTuple(tarantoolTuple)
                 .withTupleOperation(TupleOperations.add(3, 90).andAdd(4, 5))
-                .withResultMapper(defaultResultMapper)
+                .withResultMapperSupplier(defaultResultMapperSupplier)
                 .withArgumentsMapper(defaultMapper)
                 .withOptions(ProxyUpsertOptions.create()
                     .withTimeout(client.getConfig().getRequestTimeout())
@@ -309,7 +313,7 @@ public class ProxyOperationBuildersTest {
         assertIterableEquals(Arrays.asList("space1", tarantoolTuple,
                 TupleOperations.add(3, 90).andAdd(4, 5).asProxyOperationList(), options),
             operation.getArguments());
-        assertEquals(defaultResultMapper, operation.getResultMapper());
+        assertEquals(defaultResultMapperSupplier, operation.getResultMapperSupplier());
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -366,7 +366,7 @@ public class ClusterTarantoolTupleClientIT extends SharedTarantoolContainer {
             "user_function_complex_query",
             Collections.singletonList(1000),
             defaultMapper,
-            factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata)
+            () -> factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata)
         ).get();
 
         assertTrue(result.size() >= 3);
@@ -378,7 +378,7 @@ public class ClusterTarantoolTupleClientIT extends SharedTarantoolContainer {
             "user_function_complex_query",
             Collections.singletonList(1000),
             defaultMapper,
-            factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null)
+            () -> factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null)
         ).get();
         assertTrue(result.size() >= 3);
         tuple = result.get(0);

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -13,6 +13,7 @@ import io.tarantool.driver.exceptions.TarantoolSpaceFieldNotFoundException;
 import io.tarantool.driver.exceptions.TarantoolSpaceOperationException;
 import io.tarantool.driver.mappers.DefaultMessagePackMapper;
 import io.tarantool.driver.mappers.MessagePackMapper;
+import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactory;
 import io.tarantool.driver.mappers.TarantoolTupleResultMapperFactoryImpl;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
@@ -31,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -359,13 +361,14 @@ public class ClusterTarantoolTupleClientIT extends SharedTarantoolContainer {
     @Test
     public void callForTarantoolResultTest() throws Exception {
         MessagePackMapper defaultMapper = client.getConfig().getMessagePackMapper();
+        Supplier<MessagePackObjectMapper> defaultMapperSupplier = () -> defaultMapper;
         TarantoolTupleResultMapperFactory factory =
             TarantoolTupleResultMapperFactoryImpl.getInstance();
         TarantoolSpaceMetadata spaceMetadata = client.metadata().getSpaceByName("test_space").get();
         TarantoolResult<TarantoolTuple> result = client.call(
             "user_function_complex_query",
             Collections.singletonList(1000),
-            defaultMapper,
+            defaultMapperSupplier,
             () -> factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, spaceMetadata)
         ).get();
 
@@ -377,7 +380,7 @@ public class ClusterTarantoolTupleClientIT extends SharedTarantoolContainer {
         result = client.call(
             "user_function_complex_query",
             Collections.singletonList(1000),
-            defaultMapper,
+            defaultMapperSupplier,
             () -> factory.withSingleValueArrayToTarantoolTupleResultMapper(defaultMapper, null)
         ).get();
         assertTrue(result.size() >= 3);

--- a/src/test/java/io/tarantool/driver/integration/CustomConnection.java
+++ b/src/test/java/io/tarantool/driver/integration/CustomConnection.java
@@ -6,11 +6,12 @@ import io.tarantool.driver.api.connection.TarantoolConnection;
 import io.tarantool.driver.api.connection.TarantoolConnectionCloseListener;
 import io.tarantool.driver.api.connection.TarantoolConnectionFailureListener;
 import io.tarantool.driver.exceptions.TarantoolClientException;
-import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
+
+import org.msgpack.value.Value;
 
 /**
  * @author Alexey Kuzin
@@ -44,8 +45,8 @@ public class CustomConnection implements TarantoolConnection {
     }
 
     @Override
-    public <T> CompletableFuture<T> sendRequest(TarantoolRequest request, MessagePackValueMapper resultMapper) {
-        return connection.sendRequest(request, resultMapper);
+    public CompletableFuture<Value> sendRequest(TarantoolRequest request) {
+        return connection.sendRequest(request);
     }
 
     @Override

--- a/src/test/java/io/tarantool/driver/integration/CustomConnection.java
+++ b/src/test/java/io/tarantool/driver/integration/CustomConnection.java
@@ -5,13 +5,11 @@ import io.tarantool.driver.TarantoolVersion;
 import io.tarantool.driver.api.connection.TarantoolConnection;
 import io.tarantool.driver.api.connection.TarantoolConnectionCloseListener;
 import io.tarantool.driver.api.connection.TarantoolConnectionFailureListener;
+import io.tarantool.driver.core.TarantoolRequestMetadata;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.TarantoolRequest;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletableFuture;
-
-import org.msgpack.value.Value;
 
 /**
  * @author Alexey Kuzin
@@ -45,7 +43,7 @@ public class CustomConnection implements TarantoolConnection {
     }
 
     @Override
-    public CompletableFuture<Value> sendRequest(TarantoolRequest request) {
+    public TarantoolRequestMetadata sendRequest(TarantoolRequest request) {
         return connection.sendRequest(request);
     }
 

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -376,8 +377,9 @@ public class ProxyTarantoolClientMixedInstancesIT extends CartridgeMixedInstance
                     composite.field4 = (Double) valueMap.get("field4");
                     return composite;
                 }, TestCompositeCallResult.class);
+        Supplier<CallResultMapper<TestComposite, SingleValueCallResult<TestComposite>>> mapperSupplier = () -> mapper;
         TestComposite actual =
-            client.callForSingleResult("get_composite_data", Collections.singletonList(123000), mapper).get();
+            client.callForSingleResult("get_composite_data", Collections.singletonList(123000), mapperSupplier).get();
 
         assertEquals("Jane Doe", actual.field1);
         assertEquals(999, actual.field2);

--- a/src/test/java/io/tarantool/driver/integration/TarantoolRequestSignaturesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/TarantoolRequestSignaturesIT.java
@@ -1,0 +1,136 @@
+package io.tarantool.driver.integration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolClientFactory;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.TarantoolServerAddress;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
+import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
+import io.tarantool.driver.mappers.MessagePackMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Alexey Kuzin
+ */
+public class TarantoolRequestSignaturesIT extends SharedCartridgeContainer {
+    private static final String TEST_SPACE = "test_space";
+    private static final String TEST_PROFILE = "test__profile";
+
+    private static final MessagePackMapper defaultMapper =
+        DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
+    private static final TarantoolTupleFactory tupleFactory = new DefaultTarantoolTupleFactory(defaultMapper);
+    private static TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> client;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        startCluster();
+        initClient();
+        truncateSpace(TEST_SPACE);
+        truncateSpace(TEST_PROFILE);
+    }
+
+    public static void initClient() {
+        client = TarantoolClientFactory.createClient()
+            .withAddresses(
+                new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3301)),
+                new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3302)),
+                new TarantoolServerAddress(container.getRouterHost(), container.getMappedPort(3303))
+            )
+            .withCredentials(container.getUsername(), container.getPassword())
+            .withConnections(10)
+            .withEventLoopThreadsNumber(10)
+            .withRequestTimeout(10000)
+            .withProxyMethodMapping()
+            .build();
+    }
+
+    private static void truncateSpace(String spaceName) {
+        client.space(spaceName).truncate().join();
+    }
+
+    @Test
+    public void test_cachingWithRequestSignatures_shouldNotProvideCollisions() throws InterruptedException {
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace =
+            client.space(TEST_SPACE);
+        TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> profileSpace =
+            client.space(TEST_PROFILE);
+
+        // Fill 10000 rows into both spaces
+        TarantoolTuple tarantoolTuple;
+        String uuid;
+        List<CompletableFuture<?>> allFutures = new ArrayList<>(20_000);
+        for (int i = 0; i < 10_000; i++) {
+            uuid = UUID.randomUUID().toString();
+            tarantoolTuple = tupleFactory.create(1_000_000 + i, null, uuid, 200_000 + i);
+            allFutures.add(testSpace.insert(tarantoolTuple));
+            tarantoolTuple = tupleFactory.create(1_000_000 + i, null, uuid, 50_000 + i, 100_000 + i);
+            allFutures.add(profileSpace.insert(tarantoolTuple));
+            if (i % 2000 == 0) {
+                allFutures.forEach(CompletableFuture::join); // to not catch storage timeouts
+                allFutures.clear();
+            }
+        }
+        allFutures.forEach(CompletableFuture::join);
+
+        // Make requests concurrently
+        allFutures.clear();
+        int nextTestSpaceId = 10_000;
+        AtomicLong testSpaceSum = new AtomicLong(0);
+        AtomicInteger testCounter = new AtomicInteger(0);
+        int nextProfileSpaceId = 10_000;
+        AtomicLong profileSpaceSum = new AtomicLong(0);
+        AtomicInteger profileCounter = new AtomicInteger(0);
+        boolean coin;
+        int nextId;
+        while (nextTestSpaceId > 0 || nextProfileSpaceId > 0) {
+            coin = Math.random() - 0.5 > 0;
+            if (coin && nextTestSpaceId > 0 || nextProfileSpaceId <= 0) {
+                nextId = 1_000_000 + --nextTestSpaceId;
+                allFutures.add(
+                    client.callForSingleResult(
+                        "custom_crud_get_one_record", Arrays.asList(TEST_SPACE, nextId), List.class)
+                        .thenAccept(t -> {
+                            testSpaceSum.getAndAdd((Integer) t.get(3));
+                            testCounter.getAndIncrement();
+                        })
+                );
+            } else {
+                nextId = 1_000_000 + --nextProfileSpaceId;
+                allFutures.add(
+                    // this method actually calls callForSingleResult inside too but with different mapper stack
+                    profileSpace.select(Conditions.indexEquals("profile_id", Collections.singletonList(nextId)))
+                        .thenAccept(t -> {
+                            profileSpaceSum.getAndAdd(t.get(0).getInteger("balance"));
+                            profileCounter.getAndIncrement();
+                        })
+                );
+            }
+        }
+        allFutures.forEach(CompletableFuture::join);
+
+        assertEquals(10_000, testCounter.get());
+        assertEquals(10_000, profileCounter.get());
+
+        // Check that all requests returned correct values
+        int baseSum = 9999 * 10000 / 2;
+        assertEquals(2_000_000_000L + baseSum, testSpaceSum.get());
+        assertEquals(1_000_000_000L + baseSum, profileSpaceSum.get());
+    }
+}

--- a/src/test/java/io/tarantool/driver/protocol/TarantoolRequestSignatureTest.java
+++ b/src/test/java/io/tarantool/driver/protocol/TarantoolRequestSignatureTest.java
@@ -1,0 +1,102 @@
+package io.tarantool.driver.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * @author Alexey Kuzin
+ */
+public class TarantoolRequestSignatureTest {
+
+    @Test
+    public void testEquals() {
+        Map<String, TarantoolRequestSignatureTestCase> testCases = new HashMap<>();
+        testCases.put(
+            "two empty signatures should be equal",
+            new TarantoolRequestSignatureTestCase(
+                new TarantoolRequestSignature(),
+                new TarantoolRequestSignature(),
+                true
+            ));
+        testCases.put(
+            "empty and non-empty signatures should be not equal",
+            new TarantoolRequestSignatureTestCase(
+                new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature(),
+                false
+            ));
+        testCases.put(
+            "two signatures can be equal with different component contents",
+            new TarantoolRequestSignatureTestCase(
+                new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param three", 4})),
+                true
+            ));
+        testCases.put(
+            "two signatures with different String components should not be equal",
+            new TarantoolRequestSignatureTestCase(
+                new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature(
+                    "other_function", Arrays.asList(new Object[]{"param three", 4})),
+                false
+            ));
+        testCases.put(
+            "two signatures should not be equal with different component order",
+            new TarantoolRequestSignatureTestCase(
+                new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature(
+                    Arrays.asList(new Object[]{"param three", 4}), "function"),
+                false
+            ));
+
+        for (String testName: testCases.keySet()) {
+            TarantoolRequestSignatureTestCase testCase = testCases.get(testName);
+            if (testCase.equals) {
+                assertEquals(testCase.first.hashCode(), testCase.second.hashCode(), testName);
+                assertEquals(testCase.first, testCase.second, testName);
+            } else {
+                assertNotEquals(testCase.first.hashCode(), testCase.second.hashCode(), testName);
+                assertNotEquals(testCase.first, testCase.second, testName);
+            }
+        }
+    }
+
+    @Test
+    public void testSignatureAddComponent() {
+        TarantoolRequestSignature signature = new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param one", "param two"}));
+        TarantoolRequestSignature updatedSignature = new TarantoolRequestSignature(
+                    "function", Arrays.asList(new Object[]{"param one", "param two"}));
+        updatedSignature.addComponent("one more parameter");
+        assertNotEquals(signature.hashCode(), updatedSignature.hashCode());
+        assertNotEquals(signature, updatedSignature, "updated signature should not be equal to the source");
+        int oldHashCode = updatedSignature.hashCode();
+        updatedSignature.addComponent("last parameter");
+        assertNotEquals(updatedSignature.hashCode(), oldHashCode);
+    }
+
+    static class TarantoolRequestSignatureTestCase {
+        TarantoolRequestSignature first;
+        TarantoolRequestSignature second;
+        boolean equals;
+
+        TarantoolRequestSignatureTestCase(
+            TarantoolRequestSignature first, TarantoolRequestSignature second, boolean equals) {
+            this.first = first;
+            this.second = second;
+            this.equals = equals;
+        }
+    }
+}

--- a/src/test/java/io/tarantool/driver/protocol/requests/TarantoolAuthRequestTest.java
+++ b/src/test/java/io/tarantool/driver/protocol/requests/TarantoolAuthRequestTest.java
@@ -1,8 +1,10 @@
-package io.tarantool.driver.protocol;
+package io.tarantool.driver.protocol.requests;
 
 import io.tarantool.driver.auth.TarantoolAuthMechanism;
 import io.tarantool.driver.mappers.factories.DefaultMessagePackMapperFactory;
-import io.tarantool.driver.protocol.requests.TarantoolAuthRequest;
+import io.tarantool.driver.protocol.TarantoolHeader;
+import io.tarantool.driver.protocol.TarantoolProtocolException;
+import io.tarantool.driver.protocol.TarantoolRequestType;
 import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -96,6 +96,10 @@ local function custom_crud_select(space_name)
     return crud.select(space_name)
 end
 
+local function custom_crud_get_one_record(space_name, tuple_id)
+    return crud.get(space_name, {tuple_id}).rows[1]
+end
+
 local function raising_error()
     error("Test error: raising_error() called")
 end
@@ -246,6 +250,7 @@ local function init(opts)
     rawset(_G, 'box_error_non_network_error', box_error_non_network_error)
     rawset(_G, 'crud_error_timeout', crud_error_timeout)
     rawset(_G, 'custom_crud_select', custom_crud_select)
+    rawset(_G, 'custom_crud_get_one_record', custom_crud_get_one_record)
     rawset(_G, 'get_routers_status', get_routers_status)
     rawset(_G, 'init_router_status', init_router_status)
     rawset(_G, 'test_no_such_procedure', test_no_such_procedure)

--- a/src/test/resources/cartridge/init.lua
+++ b/src/test/resources/cartridge/init.lua
@@ -17,6 +17,9 @@ local ok, err = cartridge.cfg({
         'app.roles.custom',
     },
     cluster_cookie = 'testapp-cluster-cookie',
+}, {
+    readahead = 10 * 1024 * 1024, -- 10 MB
+    net_msg_max = 11140,
 })
 
 assert(ok, tostring(err))


### PR DESCRIPTION
This work is a part of the global task of decoupling the MessagePack object mapping from the core driver code in the scope of discoverable mapper bindings, caching, and support for different Tarantool cluster and API library implementations.

The goal of this patch is to reduce the number of Java reflection calls by introducing the concept of "request signatures" and replacing real-time converter lookup with memoization and table lookup.

New cluster-oriented benchmark scripts are also added. The comparison and memory consumption improvements based on the benchmark measurements will follow in the next PRs.

See the commit messages for more detailed information about the changes.

TODO:
- [x] Decouple mapping from the core driver workflow and move it up to the client implementation level
- [x] Implement request signatures
- [x] Change mapper references to suppliers in API
- [x] Implement mapper binding to request signatures
- [ ] Perform benchmark results comparison

Depends on https://github.com/tarantool/cartridge-java/pull/410
