### PR TITLE
Fix Instant converter to parse 8 bytes datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bugfixes
+- Fix Instant converter to parse 8 bytes datetime ([#408](https://github.com/tarantool/cartridge-java/issues/408))
+
 ## [0.12.1] - 2023-08-04
 
 ### Bugfixes

--- a/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultInstantToExtensionValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultInstantToExtensionValueConverter.java
@@ -24,10 +24,21 @@ public class DefaultInstantToExtensionValueConverter implements ObjectConverter<
     private static final byte DATETIME_TYPE = 0x04;
 
     private byte[] toBytes(Instant value) {
-        ByteBuffer buffer = ByteBuffer.wrap(new byte[16]);
+        long seconds = value.getEpochSecond();
+        Integer nano = value.getNano();
+
+        int size = 8;
+        boolean withOptionalFields = !nano.equals(0);
+        if (withOptionalFields) {
+            size = 16;
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[size]);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
-        buffer.putLong(value.getEpochSecond());
-        buffer.putInt(value.getNano());
+        buffer.putLong(seconds);
+        if (withOptionalFields) {
+            buffer.putInt(nano);
+        }
         return buffer.array();
     }
 

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/defaults/DefaultExtensionValueToInstantConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/defaults/DefaultExtensionValueToInstantConverter.java
@@ -19,9 +19,16 @@ public class DefaultExtensionValueToInstantConverter implements ValueConverter<E
     private static final byte DATETIME_TYPE = 0x04;
 
     private Instant fromBytes(byte[] bytes) {
+        int size = bytes.length;
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
-        return Instant.ofEpochSecond(buffer.getLong()).plusNanos(buffer.getInt());
+        long seconds = buffer.getLong();
+        int nsec = 0;
+        if (size == 16) {
+            nsec = buffer.getInt();
+        }
+
+        return Instant.ofEpochSecond(seconds, nsec);
     }
 
     @Override

--- a/src/test/java/io/tarantool/driver/integration/ConvertersWithClusterClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ConvertersWithClusterClientIT.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 import java.nio.charset.StandardCharsets;
@@ -78,6 +80,15 @@ public class ConvertersWithClusterClientIT extends SharedTarantoolContainer {
 
         //then
         Assertions.assertEquals(instant, fields.getInstant("instant_field"));
+    }
+
+    @Test
+    @EnabledIf("io.tarantool.driver.TarantoolUtils#versionWithInstant")
+    public void test_eval_shouldReturnDatetimeWithoutNsec() throws Exception {
+        Instant expected = LocalDateTime.of(1, 1, 1, 0, 0).toInstant(ZoneOffset.UTC);
+        List<?> result = client.eval("return require('datetime').new({year = 1})").get();
+
+        Assertions.assertEquals(expected, result.get(0));
     }
 
     @Test

--- a/src/test/java/io/tarantool/driver/mappers/DefaultInstantConverterTest.java
+++ b/src/test/java/io/tarantool/driver/mappers/DefaultInstantConverterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
 import org.msgpack.value.ExtensionValue;
 import org.msgpack.value.ImmutableExtensionValue;
 import org.msgpack.value.ValueFactory;
@@ -30,7 +31,8 @@ class DefaultInstantConverterTest {
         Base64.Encoder encoder = Base64.getEncoder();
         Instant instant = LocalDateTime.parse("2022-10-25T12:03:58").toInstant(ZoneOffset.UTC);
         byte[] result = ((MessageBufferPacker) packer.packValue(converter.toValue(instant))).toByteArray();
-        assertEquals("2ASu0FdjAAAAAAAAAAAAAAAA", encoder.encodeToString(result));
+        assertEquals("1wSu0FdjAAAAAA==", encoder.encodeToString(result));
+        packer.close();
     }
 
     @Test
@@ -39,8 +41,10 @@ class DefaultInstantConverterTest {
         Base64.Decoder base64decoder = Base64.getDecoder();
         Instant instant = LocalDateTime.parse("2022-10-25T12:03:58").toInstant(ZoneOffset.UTC);
         byte[] packed = base64decoder.decode("2ASu0FdjAAAAAAAAAAAAAAAA");
-        ExtensionValue value = MessagePack.newDefaultUnpacker(packed).unpackValue().asExtensionValue();
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(packed);
+        ExtensionValue value = unpacker.unpackValue().asExtensionValue();
         assertEquals(instant, converter.fromValue(value));
+        unpacker.close();
     }
 
     @Test


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->

ref: https://www.tarantool.io/en/doc/latest/dev_guide/internals/msgpack_extensions/#the-datetime-type

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #408
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
