### PR TITLE
Fix incorrect package change for TarantoolSpaceOperations

### DIFF
--- a/src/main/java/io/tarantool/driver/api/TarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolClient.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.TarantoolVersion;
 import io.tarantool.driver.api.connection.TarantoolConnectionListeners;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolMetadataProvider;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.Packable;
 

--- a/src/main/java/io/tarantool/driver/api/cursor/OffsetCursor.java
+++ b/src/main/java/io/tarantool/driver/api/cursor/OffsetCursor.java
@@ -1,7 +1,7 @@
 package io.tarantool.driver.api.cursor;
 
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.Packable;
 

--- a/src/main/java/io/tarantool/driver/api/cursor/StartAfterCursor.java
+++ b/src/main/java/io/tarantool/driver/api/cursor/StartAfterCursor.java
@@ -1,7 +1,7 @@
 package io.tarantool.driver.api.cursor;
 
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.mappers.MessagePackMapper;
 import io.tarantool.driver.protocol.Packable;

--- a/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
+++ b/src/main/java/io/tarantool/driver/api/space/TarantoolSpaceOperations.java
@@ -1,4 +1,4 @@
-package io.tarantool.driver.api.space.options;
+package io.tarantool.driver.api.space;
 
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.cursor.TarantoolCursor;
@@ -6,6 +6,14 @@ import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.Packable;
+import io.tarantool.driver.api.space.options.DeleteOptions;
+import io.tarantool.driver.api.space.options.InsertOptions;
+import io.tarantool.driver.api.space.options.InsertManyOptions;
+import io.tarantool.driver.api.space.options.ReplaceOptions;
+import io.tarantool.driver.api.space.options.ReplaceManyOptions;
+import io.tarantool.driver.api.space.options.SelectOptions;
+import io.tarantool.driver.api.space.options.UpdateOptions;
+import io.tarantool.driver.api.space.options.UpsertOptions;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/io/tarantool/driver/api/space/package-info.java
+++ b/src/main/java/io/tarantool/driver/api/space/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Contains interfaces for Tarantool space operations
+ *
+ * @author Alexey Kuzin
+ */
+package io.tarantool.driver.api.space;

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -31,7 +31,7 @@ import io.tarantool.driver.api.connection.TarantoolConnectionListeners;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolMetadataProvider;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.core.connection.TarantoolConnectionFactory;
 import io.tarantool.driver.core.connection.TarantoolConnectionManager;
 import io.tarantool.driver.core.metadata.SpacesMetadataProvider;

--- a/src/main/java/io/tarantool/driver/core/ClusterTarantoolTupleClient.java
+++ b/src/main/java/io/tarantool/driver/core/ClusterTarantoolTupleClient.java
@@ -7,7 +7,7 @@ import io.tarantool.driver.api.TarantoolServerAddress;
 import io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategies.ParallelRoundRobinStrategyFactory;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.auth.TarantoolCredentials;

--- a/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/ProxyTarantoolClient.java
@@ -13,7 +13,7 @@ import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolMetadataProvider;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.proxy.ProxyOperationsMappingConfig;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.core.metadata.DDLTarantoolSpaceMetadataConverter;
 import io.tarantool.driver.core.metadata.ProxyMetadataProvider;
 import io.tarantool.driver.core.metadata.TarantoolMetadata;

--- a/src/main/java/io/tarantool/driver/core/ProxyTarantoolTupleClient.java
+++ b/src/main/java/io/tarantool/driver/core/ProxyTarantoolTupleClient.java
@@ -7,7 +7,7 @@ import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.proxy.ProxyOperationsMappingConfig;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.space.ProxyTarantoolTupleSpace;
 

--- a/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/RetryingTarantoolClient.java
@@ -11,7 +11,7 @@ import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolMetadataProvider;
 import io.tarantool.driver.api.retry.RequestRetryPolicy;
 import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.core.space.RetryingTarantoolSpace;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.mappers.CallResultMapper;

--- a/src/main/java/io/tarantool/driver/core/RetryingTarantoolTupleClient.java
+++ b/src/main/java/io/tarantool/driver/core/RetryingTarantoolTupleClient.java
@@ -3,7 +3,7 @@ package io.tarantool.driver.core;
 import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.space.RetryingTarantoolSpace;
 

--- a/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/ProxyTarantoolSpace.java
@@ -7,7 +7,7 @@ import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.proxy.ProxyOperationsMappingConfig;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.DeleteOptions;
 import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.InsertOptions;

--- a/src/main/java/io/tarantool/driver/core/space/RetryingTarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/RetryingTarantoolSpace.java
@@ -5,7 +5,7 @@ import io.tarantool.driver.api.cursor.TarantoolCursor;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.retry.RequestRetryPolicy;
 import io.tarantool.driver.api.retry.RequestRetryPolicyFactory;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.DeleteOptions;
 import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.InsertOptions;

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
@@ -6,7 +6,7 @@ import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.metadata.TarantoolIndexMetadata;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.operations.TupleOperation;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.core.connection.TarantoolConnectionManager;

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -4,7 +4,7 @@ package io.tarantool.driver.integration;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.operations.TupleOperations;
 import io.tarantool.driver.core.tuple.TarantoolTupleImpl;

--- a/src/test/java/io/tarantool/driver/integration/ClusterTruncateIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTruncateIT.java
@@ -3,7 +3,7 @@ package io.tarantool.driver.integration;
 
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.tuple.TarantoolTupleImpl;
 import io.tarantool.driver.exceptions.TarantoolClientException;

--- a/src/test/java/io/tarantool/driver/integration/OffsetCursorIT.java
+++ b/src/test/java/io/tarantool/driver/integration/OffsetCursorIT.java
@@ -3,7 +3,7 @@ package io.tarantool.driver.integration;
 
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.cursor.TarantoolCursor;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.core.tuple.TarantoolTupleImpl;
 import io.tarantool.driver.exceptions.TarantoolClientException;

--- a/src/test/java/io/tarantool/driver/integration/ProxyCursorIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyCursorIT.java
@@ -9,7 +9,7 @@ import io.tarantool.driver.api.TarantoolServerAddress;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.cursor.TarantoolCursor;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.auth.SimpleTarantoolCredentials;
 import io.tarantool.driver.auth.TarantoolCredentials;

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientExampleIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientExampleIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientFactory;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientIT.java
@@ -34,7 +34,7 @@ import io.tarantool.driver.api.metadata.TarantoolIndexType;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientMixedInstancesIT.java
@@ -13,7 +13,7 @@ import io.tarantool.driver.api.metadata.TarantoolIndexType;
 import io.tarantool.driver.api.metadata.TarantoolMetadataOperations;
 import io.tarantool.driver.api.metadata.TarantoolSpaceMetadata;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientWithAddressProviderExampleIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTarantoolClientWithAddressProviderExampleIT.java
@@ -6,7 +6,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolClusterAddressProvider;
 import io.tarantool.driver.api.TarantoolResult;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ProxyTruncateIT.java
@@ -8,7 +8,7 @@ import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.TarantoolServerAddress;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/ReconnectIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ReconnectIT.java
@@ -7,7 +7,7 @@ import io.tarantool.driver.api.TarantoolClusterAddressProvider;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.TarantoolServerAddress;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleIT.java
+++ b/src/test/java/io/tarantool/driver/integration/SingleInstanceExampleIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientFactory;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.api.tuple.TarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/Utils.java
+++ b/src/test/java/io/tarantool/driver/integration/Utils.java
@@ -3,7 +3,7 @@ package io.tarantool.driver.integration;
 import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.tuple.TarantoolTuple;
 import io.tarantool.driver.exceptions.TarantoolClientException;
 import io.tarantool.driver.protocol.Packable;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceDeleteOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceDeleteOptionsIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.InsertOptions;
 import io.tarantool.driver.api.space.options.ProxyDeleteOptions;
 import io.tarantool.driver.api.space.options.ProxyInsertOptions;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertManyOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertManyOptionsIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.InsertManyOptions;
 import io.tarantool.driver.api.space.options.crud.enums.RollbackOnError;
 import io.tarantool.driver.api.space.options.crud.enums.StopOnError;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceInsertOptionsIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.InsertOptions;
 import io.tarantool.driver.api.space.options.SelectOptions;
 import io.tarantool.driver.api.space.options.ProxyInsertOptions;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceManyOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceManyOptionsIT.java
@@ -3,7 +3,7 @@ package io.tarantool.driver.integration.proxy.options;
 import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.ReplaceManyOptions;
 import io.tarantool.driver.api.space.options.crud.enums.RollbackOnError;
 import io.tarantool.driver.api.space.options.crud.enums.StopOnError;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceReplaceOptionsIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.ReplaceOptions;
 import io.tarantool.driver.api.space.options.ProxyDeleteOptions;
 import io.tarantool.driver.api.space.options.ProxyReplaceOptions;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceSelectOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceSelectOptionsIT.java
@@ -6,7 +6,7 @@ import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
 import io.tarantool.driver.api.space.options.crud.enums.Mode;
 import io.tarantool.driver.api.space.options.SelectOptions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.ProxySelectOptions;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpdateOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpdateOptionsIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.UpdateOptions;
 import io.tarantool.driver.api.space.options.ProxyUpdateOptions;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;

--- a/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpsertOptionsIT.java
+++ b/src/test/java/io/tarantool/driver/integration/proxy/options/ProxySpaceUpsertOptionsIT.java
@@ -4,7 +4,7 @@ import io.tarantool.driver.api.TarantoolClient;
 import io.tarantool.driver.api.TarantoolClientConfig;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.conditions.Conditions;
-import io.tarantool.driver.api.space.options.TarantoolSpaceOperations;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
 import io.tarantool.driver.api.space.options.ProxyUpsertOptions;
 import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
 import io.tarantool.driver.api.tuple.TarantoolTuple;


### PR DESCRIPTION
TarantoolSpaceOperations interface does not belong to the "options" package, and its implementations too.
This change was made by mistake in https://github.com/tarantool/cartridge-java/pull/418