### PR TITLE
Fix checking the current Tarantool version for minimum requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
           <version>1.35</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/test/java/io/tarantool/driver/TarantoolUtils.java
+++ b/src/test/java/io/tarantool/driver/TarantoolUtils.java
@@ -14,16 +14,20 @@ public final class TarantoolUtils {
     private TarantoolUtils() {
     }
 
-    public static boolean versionGreaterOrEqualThen(String tarantoolVersion) {
-        Assert.notNull(tarantoolVersion, "tarantoolVersion must not be null");
+    public static boolean versionGreaterOrEqualThen(String minimum) {
+        Assert.notNull(minimum, "minimum must not be null");
         String tarantoolCiVersion = java.lang.System.getenv(TARANTOOL_VERSION);
-        if (tarantoolCiVersion == null || tarantoolCiVersion.isEmpty()) {
-            return true;
-        }
-        TarantoolVersion ciVersion = new TarantoolVersion(tarantoolCiVersion);
-        TarantoolVersion version = new TarantoolVersion(tarantoolVersion);
-        return ciVersion.getMajor() >= version.getMajor() &&
-            ciVersion.getMinor() >= version.getMinor();
+        return versionGreaterOrEqualThen(tarantoolCiVersion, minimum);
+    }
+
+    public static boolean versionGreaterOrEqualThen(String current, String minimum) {
+        return current == null || current.isEmpty() ||
+               versionGreaterOrEqualThen(new TarantoolVersion(current), new TarantoolVersion(minimum));
+    }
+
+    public static boolean versionGreaterOrEqualThen(TarantoolVersion current, TarantoolVersion minimum) {
+        return current.getMajor() > minimum.getMajor() ||
+               current.getMajor().equals(minimum.getMajor()) && current.getMinor() >= minimum.getMinor();
     }
 
     public static boolean versionWithUUID() {

--- a/src/test/java/io/tarantool/driver/TarantoolUtilsTest.java
+++ b/src/test/java/io/tarantool/driver/TarantoolUtilsTest.java
@@ -1,0 +1,29 @@
+package io.tarantool.driver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static io.tarantool.driver.TarantoolUtils.versionGreaterOrEqualThen;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TarantoolUtilsTest {
+
+    @ParameterizedTest(name = "[{index}] {0} >= {1} == {2}")
+    @CsvSource(nullValues = "null", value = {
+        "null , 2.1 , true",
+        "'' , 2.1 , true",
+        "2.2 , 2.1 , true",
+        "2.2 , 2.2 , true",
+        "2.2.1 , 2.2 , true",
+        "2.2 , 2.2.1 , true",
+        "2.2.1 , 2.2.2 , true",
+        "2.x , 2.2 , true",
+        "2.x , 2.x , true",
+        "2.2 , 2.3 , false",
+        "3.2 , 2.3 , true",
+    })
+    void test_minimumVersionCheck(String current, String minimum, boolean expected) {
+        assertEquals(expected, versionGreaterOrEqualThen(current, minimum));
+    }
+
+}


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->
The actual version will assume that version "3.2" is less than version "2.3" because `3 >= 2 && 2 >= 3` will computed as false.

I haven't forgotten about:
- [x] Tests
- [x] Changelog
    (seems that internal changes do not need to be reflected in Changelog)
- [x] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues: none
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->
