### PR TITLE
Optimize usage of the Netty's and MsgPack's buffers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <dependency>
             <groupId>org.msgpack</groupId>
             <artifactId>msgpack-core</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/io/tarantool/driver/api/TarantoolClientConfig.java
+++ b/src/main/java/io/tarantool/driver/api/TarantoolClientConfig.java
@@ -27,6 +27,7 @@ public class TarantoolClientConfig {
     private static final int DEFAULT_CONNECTIONS = 1;
     private static final int DEFAULT_CURSOR_BATCH_SIZE = 100;
     private static final int DEFAULT_EVENT_LOOP_THREADS_NUMBER = 0;
+    private static final int DEFAULT_WRITE_BATCH_SIZE = 128;
 
     private TarantoolCredentials credentials;
     private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
@@ -34,6 +35,7 @@ public class TarantoolClientConfig {
     private int requestTimeout = DEFAULT_REQUEST_TIMEOUT;
     private int connections = DEFAULT_CONNECTIONS;
     private int eventLoopThreadsNumber = DEFAULT_EVENT_LOOP_THREADS_NUMBER;
+    private int writeBatchSize = DEFAULT_WRITE_BATCH_SIZE;
     private MessagePackMapper messagePackMapper =
         DefaultMessagePackMapperFactory.getInstance().defaultComplexTypesMapper();
     private ConnectionSelectionStrategyFactory connectionSelectionStrategyFactory =
@@ -63,6 +65,7 @@ public class TarantoolClientConfig {
         this.isSecure.set(config.isSecure.get());
         this.sslContext = config.getSslContext();
         this.eventLoopThreadsNumber = config.getEventLoopThreadsNumber();
+        this.writeBatchSize = config.getWriteBatchSize();
     }
 
     /**
@@ -269,6 +272,24 @@ public class TarantoolClientConfig {
     }
 
     /**
+     * Get maximum number of requests to be sent in one batch to the server.
+     *
+     * @return a positive integer value
+     */
+    public int getWriteBatchSize() {
+        return writeBatchSize;
+    }
+
+    /**
+     * Set maximum number of requests to be sent in one batch to the server.
+     *
+     * @param writeBatchSize maximum number of requests in batch
+     */
+    public void setWriteBatchSize(int writeBatchSize) {
+        this.writeBatchSize = writeBatchSize;
+    }
+
+    /**
      * A builder for {@link TarantoolClientConfig}
      */
     public static final class Builder {
@@ -416,6 +437,20 @@ public class TarantoolClientConfig {
         public Builder withEventLoopThreadsNumber(int eventLoopThreadsNumber) {
             Assert.state(eventLoopThreadsNumber > 0, "EventLoopThreadsNumber should be equals or greater than 0");
             config.setEventLoopThreadsNumber(eventLoopThreadsNumber);
+            return this;
+        }
+
+        /**
+         * Specify request batch size. Increase this number if this client instance does much
+         * more writes than reads, but the bigger is this number, the more memory will be used by the
+         * client and the bigger will be the amount of outbound bytes sent at once. Default is 128
+         *
+         * @param writeBatchSize maximum number of requests in batch
+         * @return builder
+         */
+        public Builder withWriteBatchSize(int writeBatchSize) {
+            Assert.state(writeBatchSize > 0, "WriteBatchSize should be equal or greater than 0");
+            config.setWriteBatchSize(writeBatchSize);
             return this;
         }
 

--- a/src/main/java/io/tarantool/driver/codecs/MessagePackFrameEncoder.java
+++ b/src/main/java/io/tarantool/driver/codecs/MessagePackFrameEncoder.java
@@ -5,8 +5,11 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.tarantool.driver.mappers.MessagePackObjectMapper;
 import io.tarantool.driver.protocol.TarantoolRequest;
-import org.msgpack.core.MessageBufferPacker;
+
 import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.buffer.ArrayBufferOutput;
+import org.msgpack.core.buffer.MessageBuffer;
 
 /**
  * Converts Tarantool requests from Java objects to MessagePack frames
@@ -15,8 +18,13 @@ import org.msgpack.core.MessagePack;
  */
 public class MessagePackFrameEncoder extends MessageToByteEncoder<TarantoolRequest> {
 
-    private static final int MINIMAL_HEADER_SIZE = 5; // MP_UINT32
+    private static final int MINIMAL_HEADER_SIZE = 8; // MP_UINT32
+    private static final int MINIMAL_BODY_SIZE = 1 * 1024 * 1024; // 1 MB
     private final MessagePackObjectMapper mapper;
+    private final ArrayBufferOutput lenBufferOutput = new ArrayBufferOutput(MINIMAL_HEADER_SIZE);
+    private final MessagePacker lenPacker = new MessagePack.PackerConfig().newPacker(lenBufferOutput);
+    private final ArrayBufferOutput bodyBufferOutput = new ArrayBufferOutput(MINIMAL_BODY_SIZE);
+    private final MessagePacker bodyPacker = new MessagePack.PackerConfig().newPacker(bodyBufferOutput);
 
     public MessagePackFrameEncoder(MessagePackObjectMapper mapper) {
         super();
@@ -24,18 +32,22 @@ public class MessagePackFrameEncoder extends MessageToByteEncoder<TarantoolReque
     }
 
     @Override
-    protected void encode(
-        ChannelHandlerContext ctx, TarantoolRequest tarantoolRequest,
-        ByteBuf byteBuf) throws Exception {
-        MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();
-        tarantoolRequest.toMessagePack(packer, mapper);
-        long outputSize = packer.getTotalWrittenBytes();
-        byteBuf.capacity((int) (outputSize + MINIMAL_HEADER_SIZE));
-        byte[] output = packer.toByteArray();
-        packer.clear();
-        packer.packLong(outputSize);
-        byteBuf.writeBytes(packer.toByteArray());
-        packer.close();
-        byteBuf.writeBytes(output);
+    protected void encode(ChannelHandlerContext ctx, TarantoolRequest tarantoolRequest, ByteBuf byteBuf)
+        throws Exception {
+        bodyBufferOutput.clear();
+        bodyPacker.clear();
+        tarantoolRequest.toMessagePack(bodyPacker, mapper);
+        bodyPacker.flush();
+        MessageBuffer bodyBuffer = bodyBufferOutput.toMessageBuffer();
+        lenBufferOutput.clear();
+        lenPacker.clear();
+        lenPacker.packLong(bodyBuffer.size());
+        lenPacker.flush();
+        MessageBuffer lenBuffer = lenBufferOutput.toMessageBuffer();
+        byteBuf.capacity(bodyBuffer.size() + lenBuffer.size());
+        byteBuf.writeBytes(
+            lenBufferOutput.toMessageBuffer().sliceAsByteBuffer(0, lenBuffer.size()));
+        byteBuf.writeBytes(
+            bodyBufferOutput.toMessageBuffer().sliceAsByteBuffer(0, bodyBuffer.size()));
     }
 }

--- a/src/main/java/io/tarantool/driver/core/TarantoolChannelInitializer.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolChannelInitializer.java
@@ -4,6 +4,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslContext;
 import io.tarantool.driver.TarantoolVersionHolder;
 import io.tarantool.driver.api.TarantoolClientConfig;
@@ -56,7 +57,9 @@ public class TarantoolChannelInitializer extends ChannelInitializer<SocketChanne
         }
 
         // greeting and authentication (will be removed after successful authentication)
-        pipeline.addLast("TarantoolAuthenticationHandler",
+        pipeline
+            .addLast("FlushConsolidationHandler", new FlushConsolidationHandler(config.getWriteBatchSize(), true))
+            .addLast("TarantoolAuthenticationHandler",
                 new TarantoolAuthenticationHandler<>(
                     connectionFuture,
                     versionHolder,

--- a/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionFactory.java
+++ b/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionFactory.java
@@ -97,7 +97,7 @@ public class TarantoolConnectionFactory {
 
         return result.handle((connection, ex) -> {
             if (ex != null) {
-                logger.warn("Connection failed: {}", ex.getMessage());
+                logger.error(String.format("Failed to connect to the Tarantool server at %s", serverAddress), ex);
                 future.channel().close();
             }
             return connection;

--- a/src/main/java/io/tarantool/driver/handlers/TarantoolRequestHandler.java
+++ b/src/main/java/io/tarantool/driver/handlers/TarantoolRequestHandler.java
@@ -28,7 +28,7 @@ public class TarantoolRequestHandler extends ChannelOutboundHandlerAdapter {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         TarantoolRequest request = (TarantoolRequest) msg;
-        ctx.write(request).addListener((ChannelFutureListener) channelFuture -> {
+        ctx.writeAndFlush(request, promise).addListener((ChannelFutureListener) channelFuture -> {
             if (!channelFuture.isSuccess()) {
                 TarantoolRequestMetadata requestMeta = futureManager.getRequest(request.getHeader().getSync());
                 // The request metadata may has been deleted already after timeout


### PR DESCRIPTION
Previously we were creating a new buffer and MsgPack packer on each request. This resulted in dramatic overload of GC with short-lived byte arrays. The new approach tries to maximize reusing of these byte arrays.
