### PR TITLE
Replace streams with loops in DefaultMessagePackMapper

### DIFF
--- a/src/main/java/io/tarantool/driver/api/MessagePackMapperBuilder.java
+++ b/src/main/java/io/tarantool/driver/api/MessagePackMapperBuilder.java
@@ -7,6 +7,7 @@ import io.tarantool.driver.mappers.converters.ValueConverter;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueType;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
+++ b/src/main/java/io/tarantool/driver/core/AbstractTarantoolClient.java
@@ -285,11 +285,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<T> tupleClass)
         throws TarantoolClientException {
-        Supplier<CallResultMapper<TarantoolResult<T>, SingleValueCallResult<TarantoolResult<T>>>>
-            resultMapperSupplier = () ->
-            mapperFactoryFactory.getTarantoolResultMapper(config.getMessagePackMapper(), tupleClass);
         TarantoolRequestSignature signature = TarantoolRequestSignature.create(
-            functionName, arguments, tupleClass, argumentsMapperSupplier, resultMapperSupplier);
+            functionName, arguments, argumentsMapperSupplier, tupleClass);
+        Supplier<CallResultMapper<TarantoolResult<T>, SingleValueCallResult<TarantoolResult<T>>>> resultMapperSupplier =
+            () -> mapperFactoryFactory.getTarantoolResultMapper(config.getMessagePackMapper(), tupleClass);
         return callForSingleResult(functionName, arguments, signature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
@@ -355,10 +354,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         Class<S> resultClass)
         throws TarantoolClientException {
-        Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier = () ->
-            mapperFactoryFactory.getDefaultSingleValueMapper(config.getMessagePackMapper(), resultClass);
         TarantoolRequestSignature signature = TarantoolRequestSignature.create(
-            functionName, arguments, resultClass, argumentsMapperSupplier, resultMapperSupplier);
+            functionName, arguments, argumentsMapperSupplier, resultClass);
+        Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier =
+            () -> mapperFactoryFactory.getDefaultSingleValueMapper(config.getMessagePackMapper(), resultClass);
         return callForSingleResult(functionName, arguments, signature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
@@ -369,10 +368,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Supplier<? extends MessagePackObjectMapper> argumentsMapperSupplier,
         ValueConverter<Value, S> valueConverter)
         throws TarantoolClientException {
-        Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier = () ->
-            mapperFactoryFactory.getSingleValueResultMapper(valueConverter);
         TarantoolRequestSignature signature = TarantoolRequestSignature.create(
-            functionName, arguments, valueConverter.getClass(), argumentsMapperSupplier, resultMapperSupplier);
+            functionName, arguments, argumentsMapperSupplier, valueConverter);
+        Supplier<CallResultMapper<S, SingleValueCallResult<S>>> resultMapperSupplier =
+            () -> mapperFactoryFactory.getSingleValueResultMapper(valueConverter);
         return callForSingleResult(functionName, arguments, signature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
@@ -464,10 +463,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Supplier<R> resultContainerSupplier,
         Class<T> resultClass)
         throws TarantoolClientException {
-        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier = () ->
-            mapperFactoryFactory.getDefaultMultiValueMapper(config.getMessagePackMapper(), resultClass);
         TarantoolRequestSignature signature = TarantoolRequestSignature.create(
-            functionName, arguments, resultClass, argumentsMapperSupplier, resultMapperSupplier);
+            functionName, arguments, argumentsMapperSupplier, resultContainerSupplier, resultClass);
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier =
+            () -> mapperFactoryFactory.getDefaultMultiValueMapper(config.getMessagePackMapper(), resultClass);
         return callForMultiResult(functionName, arguments, signature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
@@ -479,10 +478,10 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Supplier<R> resultContainerSupplier,
         ValueConverter<Value, T> valueConverter)
         throws TarantoolClientException {
-        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier = () ->
-            mapperFactoryFactory.getMultiValueResultMapper(resultContainerSupplier, valueConverter);
         TarantoolRequestSignature signature = TarantoolRequestSignature.create(
-            functionName, arguments, valueConverter.getClass(), argumentsMapperSupplier, resultMapperSupplier);
+            functionName, arguments, argumentsMapperSupplier, resultContainerSupplier, valueConverter);
+        Supplier<CallResultMapper<R, MultiValueCallResult<T, R>>> resultMapperSupplier =
+            () -> mapperFactoryFactory.getMultiValueResultMapper(resultContainerSupplier, valueConverter);
         return callForMultiResult(functionName, arguments, signature, argumentsMapperSupplier, resultMapperSupplier);
     }
 
@@ -591,7 +590,7 @@ public abstract class AbstractTarantoolClient<T extends Packable, R extends Coll
         Supplier<? extends MessagePackValueMapper> resultMapperSupplier) throws TarantoolClientException {
         try {
             TarantoolRequestSignature signature = TarantoolRequestSignature.create(
-                expression, arguments, List.class, argumentsMapperSupplier, resultMapperSupplier);
+                expression, arguments, argumentsMapperSupplier, resultMapperSupplier);
             MessagePackObjectMapper argumentsMapper = argumentsMapperCache.computeIfAbsent(
                 signature, s -> argumentsMapperSupplier.get());
             MessagePackValueMapper resultMapper = resultMapperCache.computeIfAbsent(

--- a/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
+++ b/src/main/java/io/tarantool/driver/core/TarantoolRequestMetadata.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CompletableFuture;
 import org.msgpack.value.Value;
 
 import io.tarantool.driver.protocol.TarantoolRequest;
-import io.tarantool.driver.protocol.TarantoolRequestSignature;
 
 /**
  * Intermediate request metadata holder

--- a/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionImpl.java
+++ b/src/main/java/io/tarantool/driver/core/connection/TarantoolConnectionImpl.java
@@ -79,7 +79,7 @@ public class TarantoolConnectionImpl implements TarantoolConnection {
                 requestFuture.completeExceptionally(
                     new RuntimeException("Failed to send the request to Tarantool server", f.cause()));
             } else {
-                logger.debug("Request {} sent, status Success", request.getHeader().getSync());
+                logger.trace("Request {} sent, status Success", request);
             }
         });
 

--- a/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
+++ b/src/main/java/io/tarantool/driver/core/space/TarantoolSpace.java
@@ -66,24 +66,32 @@ public abstract class TarantoolSpace<T extends Packable, R extends Collection<T>
         String spaceIdStr = String.valueOf(this.spaceId);
         methodSignatures.put(
             TarantoolDeleteRequest.class.getName(),
-            new TarantoolRequestSignature(spaceIdStr, TarantoolDeleteRequest.class.getName()));
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent(TarantoolDeleteRequest.class.getName()));
         methodSignatures.put(
             TarantoolInsertRequest.class.getName(),
-            new TarantoolRequestSignature(spaceIdStr, TarantoolInsertRequest.class.getName()));
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent(TarantoolInsertRequest.class.getName()));
         methodSignatures.put(
             TarantoolReplaceRequest.class.getName(),
-            new TarantoolRequestSignature(spaceIdStr, TarantoolReplaceRequest.class.getName()));
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent(TarantoolReplaceRequest.class.getName()));
         methodSignatures.put(
             TarantoolSelectRequest.class.getName(),
-            new TarantoolRequestSignature(spaceIdStr, TarantoolSelectRequest.class.getName()));
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent(TarantoolSelectRequest.class.getName()));
         methodSignatures.put(
             TarantoolUpdateRequest.class.getName(),
-            new TarantoolRequestSignature(spaceIdStr, TarantoolUpdateRequest.class.getName()));
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent(TarantoolUpdateRequest.class.getName()));
         methodSignatures.put(
             TarantoolUpsertRequest.class.getName(),
-            new TarantoolRequestSignature(spaceIdStr, TarantoolUpsertRequest.class.getName()));
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent(TarantoolUpsertRequest.class.getName()));
         methodSignatures.put(
-            "truncate", new TarantoolRequestSignature(spaceIdStr, "truncate", TarantoolCallRequest.class.getName()));
+            "truncate",
+            new TarantoolRequestSignature()
+                .addComponent(spaceIdStr).addComponent("truncate").addComponent(TarantoolCallRequest.class.getName()));
     }
 
     @Override

--- a/src/main/java/io/tarantool/driver/mappers/AbstractResultMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/AbstractResultMapper.java
@@ -111,7 +111,7 @@ public abstract class AbstractResultMapper<T> implements MessagePackValueMapper 
     @Override
     public <V extends Value, O> Optional<ValueConverter<V, O>> getValueConverter(
         ValueType valueType,
-        Class<O> objectClass) {
+        Class<? extends O> objectClass) {
         return valueMapper.getValueConverter(valueType, objectClass);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/DefaultMessagePackMapper.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,8 +77,8 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         ValueConverter<V, O> converter;
         List<ConverterWrapper<ValueConverter<? extends Value, ?>>> wrappers =
             valueConverters.getOrDefault(valueType, Collections.emptyList());
-        for (ConverterWrapper<ValueConverter<? extends Value, ?>> wrapper : wrappers) {
-            converter = (ValueConverter<V, O>) wrapper.getConverter();
+        for (int i = 0; i < wrappers.size(); i++) {
+            converter = (ValueConverter<V, O>) wrappers.get(i).getConverter();
             if (converter.canConvertValue(v)) {
                 return Optional.of(converter);
             }
@@ -103,7 +102,9 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         ValueConverter<V, O> converter;
         List<ConverterWrapper<ValueConverter<? extends Value, ?>>> wrappers =
             valueConverters.getOrDefault(valueType, Collections.emptyList());
-        for (ConverterWrapper<ValueConverter<? extends Value, ?>> wrapper : wrappers) {
+        ConverterWrapper<ValueConverter<? extends Value, ?>> wrapper;
+        for (int i = 0; i < wrappers.size(); i++) {
+            wrapper = wrappers.get(i);
             if (checkConverterByTargetType(wrapper.getTargetClass(), targetClass)) {
                 converter = (ValueConverter<V, O>) wrapper.getConverter();
                 if (converter.canConvertValue(v)) {
@@ -126,7 +127,9 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         ValueType valueType, Class<? extends O> targetClass) {
         List<ConverterWrapper<ValueConverter<? extends Value, ?>>> wrappers =
             valueConverters.getOrDefault(valueType, Collections.emptyList());
-        for (ConverterWrapper<ValueConverter<? extends Value, ?>> wrapper : wrappers) {
+        ConverterWrapper<ValueConverter<? extends Value, ?>> wrapper;
+        for (int i = 0; i < wrappers.size(); i++) {
+            wrapper = wrappers.get(i);
             if (checkConverterByTargetType(wrapper.getTargetClass(), targetClass)) {
                 return Optional.of((ValueConverter<V, O>) wrapper.getConverter());
             }
@@ -169,7 +172,7 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         Class<? extends O> objectClass,
         ValueConverter<V, ? extends O> converter) {
         List<ConverterWrapper<ValueConverter<? extends Value, ?>>> converters =
-            valueConverters.computeIfAbsent(valueType, k -> new LinkedList<>());
+            valueConverters.computeIfAbsent(valueType, k -> new ArrayList<>());
         converters.add(0, new ConverterWrapper<>(converter, objectClass));
     }
 
@@ -177,7 +180,7 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         ValueType valueType,
         ValueConverter<V, ? extends O> converter) {
         List<ConverterWrapper<ValueConverter<? extends Value, ?>>> converters =
-            valueConverters.computeIfAbsent(valueType, k -> new LinkedList<>());
+            valueConverters.computeIfAbsent(valueType, k -> new ArrayList<>());
         converters.add(0, new ConverterWrapper<>(converter, Object.class));
     }
 
@@ -204,8 +207,8 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         ObjectConverter<O, V> converter;
         List<ConverterWrapper<ObjectConverter<?, ? extends Value>>> wrappers =
             objectConverters.getOrDefault(typeName, Collections.emptyList());
-        for (ConverterWrapper<ObjectConverter<?, ? extends Value>> wrapper : wrappers) {
-            converter = (ObjectConverter<O, V>) wrapper.getConverter();
+        for (int i = 0; i < wrappers.size(); i++) {
+            converter = (ObjectConverter<O, V>) wrappers.get(i).getConverter();
             if (converter.canConvertObject(o)) {
                 return Optional.of(converter);
             }
@@ -234,7 +237,9 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         String typeName, Class<? extends V> valueClass) {
         List<ConverterWrapper<ObjectConverter<?, ? extends Value>>> wrappers =
             objectConverters.getOrDefault(typeName, Collections.emptyList());
-        for (ConverterWrapper<ObjectConverter<?, ? extends Value>> wrapper : wrappers) {
+        ConverterWrapper<ObjectConverter<?, ? extends Value>> wrapper;
+        for (int i = 0; i < wrappers.size(); i++) {
+            wrapper = wrappers.get(i);
             if (checkConverterByTargetType(wrapper.getTargetClass(), valueClass)) {
                 return Optional.of((ObjectConverter<O, V>) wrapper.getConverter());
             }
@@ -314,7 +319,7 @@ public class DefaultMessagePackMapper implements MessagePackMapper {
         Class<V> valueClass,
         ObjectConverter<O, V> converter) {
         List<ConverterWrapper<ObjectConverter<?, ? extends Value>>> converters =
-            objectConverters.computeIfAbsent(objectClass.getTypeName(), k -> new LinkedList<>());
+            objectConverters.computeIfAbsent(objectClass.getTypeName(), k -> new ArrayList<>());
         converters.add(0, new ConverterWrapper<>(converter, valueClass));
     }
 

--- a/src/main/java/io/tarantool/driver/mappers/MessagePackObjectMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/MessagePackObjectMapper.java
@@ -37,5 +37,6 @@ public interface MessagePackObjectMapper {
         Class<? extends O> objectClass, Class<V> valueClass,
         ObjectConverter<O, V> converter);
 
-    <V extends Value, O> Optional<ObjectConverter<O, V>> getObjectConverter(Class<O> objectClass, Class<V> valueClass);
+    <V extends Value, O> Optional<ObjectConverter<O, V>> getObjectConverter(
+        Class<? extends O> objectClass, Class<? extends V> valueClass);
 }

--- a/src/main/java/io/tarantool/driver/mappers/MessagePackValueMapper.java
+++ b/src/main/java/io/tarantool/driver/mappers/MessagePackValueMapper.java
@@ -64,5 +64,6 @@ public interface MessagePackValueMapper {
      * @param <O>         java object's type that the converter accepts and/or returns
      * @return a nullable converter instance wrapped in {@code Optional}
      */
-    <V extends Value, O> Optional<ValueConverter<V, O>> getValueConverter(ValueType valueType, Class<O> objectClass);
+    <V extends Value, O> Optional<ValueConverter<V, O>> getValueConverter(
+        ValueType valueType, Class<? extends O> objectClass);
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultMapToMapValueConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/object/DefaultMapToMapValueConverter.java
@@ -26,8 +26,12 @@ public class DefaultMapToMapValueConverter implements ObjectConverter<Map<?, ?>,
 
     @Override
     public MapValue toValue(Map<?, ?> object) {
-        Map<Value, Value> values = object.entrySet().stream()
-            .collect(Collectors.toMap(e -> mapper.toValue(e.getKey()), e -> mapper.toValue(e.getValue())));
-        return ValueFactory.newMap(values);
+        Value[] values = new Value[object.size() * 2];
+        int i = 0;
+        for (Object key : object.keySet()) {
+            values[i++] = mapper.toValue(key);
+            values[i++] = mapper.toValue(object.get(key));
+        }
+        return ValueFactory.newMap(values, true);
     }
 }

--- a/src/main/java/io/tarantool/driver/mappers/converters/value/defaults/DefaultMapValueToMapConverter.java
+++ b/src/main/java/io/tarantool/driver/mappers/converters/value/defaults/DefaultMapValueToMapConverter.java
@@ -3,7 +3,9 @@ package io.tarantool.driver.mappers.converters.value.defaults;
 import io.tarantool.driver.mappers.MessagePackValueMapper;
 import io.tarantool.driver.mappers.converters.ValueConverter;
 import org.msgpack.value.MapValue;
+import org.msgpack.value.Value;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -24,8 +26,14 @@ public class DefaultMapValueToMapConverter implements ValueConverter<MapValue, M
 
     @Override
     public Map<?, ?> fromValue(MapValue value) {
-        return value.map().entrySet().stream()
-            .filter(e -> !e.getValue().isNilValue())
-            .collect(Collectors.toMap(e -> mapper.fromValue(e.getKey()), e -> mapper.fromValue(e.getValue())));
+        Map<?, ?> result = new HashMap<Object, Object>(value.size(), 1);
+        Map<Value, Value> valueMap = value.map();
+        for (Value key : valueMap.keySet()) {
+            Value val = valueMap.get(key);
+            if (!val.isNilValue()) {
+                result.put(mapper.fromValue(key), mapper.fromValue(val));
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/io/tarantool/driver/protocol/TarantoolHeader.java
+++ b/src/main/java/io/tarantool/driver/protocol/TarantoolHeader.java
@@ -100,7 +100,7 @@ public final class TarantoolHeader implements Packable {
      * @return MessagePack representation of the header
      */
     public Value toMessagePackValue(MessagePackObjectMapper mapper) {
-        Map<IntegerValue, IntegerValue> values = new HashMap<>();
+        Map<IntegerValue, IntegerValue> values = new HashMap<>(3, 1);
         values.put(ValueFactory.newInteger(IPROTO_REQUEST_TYPE), ValueFactory.newInteger(code));
         values.put(ValueFactory.newInteger(IPROTO_SYNC), ValueFactory.newInteger(sync));
         if (schemaVersion != null) {

--- a/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
+++ b/src/test/java/io/tarantool/driver/integration/ClusterTarantoolTupleClientIT.java
@@ -416,8 +416,10 @@ public class ClusterTarantoolTupleClientIT extends SharedTarantoolContainer {
     @Test
     public void testCallReturnLongValue() throws Exception {
         client.getVersion();
-        List<?> result = client.call("user_function_return_long_value").get();
+        List<Integer> result = client.callForSingleResult(
+            "user_function_return_long_value", List.class).get();
 
-        assertEquals(1, result.size());
+        assertEquals(2800 * 3, result.size());
+        assertFalse(result.stream().anyMatch(v -> v != 1));
     }
 }

--- a/src/test/java/io/tarantool/driver/protocol/TarantoolRequestSignatureTest.java
+++ b/src/test/java/io/tarantool/driver/protocol/TarantoolRequestSignatureTest.java
@@ -28,36 +28,36 @@ public class TarantoolRequestSignatureTest {
         testCases.put(
             "empty and non-empty signatures should be not equal",
             new TarantoolRequestSignatureTestCase(
-                new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param one", "param two"})),
                 new TarantoolRequestSignature(),
                 false
             ));
         testCases.put(
             "two signatures can be equal with different component contents",
             new TarantoolRequestSignatureTestCase(
-                new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
-                new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param three", 4})),
+                new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param three", 4})),
                 true
             ));
         testCases.put(
             "two signatures with different String components should not be equal",
             new TarantoolRequestSignatureTestCase(
-                new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
-                new TarantoolRequestSignature(
-                    "other_function", Arrays.asList(new Object[]{"param three", 4})),
+                new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature()
+                    .addComponent("other_function").addComponent(Arrays.asList(new Object[]{"param three", 4})),
                 false
             ));
         testCases.put(
             "two signatures should not be equal with different component order",
             new TarantoolRequestSignatureTestCase(
-                new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param one", "param two"})),
-                new TarantoolRequestSignature(
-                    Arrays.asList(new Object[]{"param three", 4}), "function"),
+                new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param one", "param two"})),
+                new TarantoolRequestSignature()
+                    .addComponent(Arrays.asList(new Object[]{"param three", 4})).addComponent("function"),
                 false
             ));
 
@@ -75,10 +75,10 @@ public class TarantoolRequestSignatureTest {
 
     @Test
     public void testSignatureAddComponent() {
-        TarantoolRequestSignature signature = new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param one", "param two"}));
-        TarantoolRequestSignature updatedSignature = new TarantoolRequestSignature(
-                    "function", Arrays.asList(new Object[]{"param one", "param two"}));
+        TarantoolRequestSignature signature = new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param one", "param two"}));
+        TarantoolRequestSignature updatedSignature = new TarantoolRequestSignature()
+                    .addComponent("function").addComponent(Arrays.asList(new Object[]{"param one", "param two"}));
         updatedSignature.addComponent("one more parameter");
         assertNotEquals(signature.hashCode(), updatedSignature.hashCode());
         assertNotEquals(signature, updatedSignature, "updated signature should not be equal to the source");


### PR DESCRIPTION
`toValue` and `fromValue` methods in DefaultMessagePackMapper are hot spots as they are called on each request. This code was first written using Java streams, but while it allowed to make the code more readable, the streams are not very well-suitable for this task. The Java streams work better when we can execute the chained lambda functions in parallel on an executor, but are worse when replacing the normal `for` loops - they add significant overhead because of a lot of created auxiliary classes and objects in runtime.

Now as the DefaultMessagePackMapper code is stable we can replace the stream-based code with more optimized loop-based code.
