### PR TITLE
Add connection close

### DIFF
--- a/src/main/java/io/tarantool/driver/cluster/BinaryDiscoveryClusterAddressProvider.java
+++ b/src/main/java/io/tarantool/driver/cluster/BinaryDiscoveryClusterAddressProvider.java
@@ -113,4 +113,14 @@ public class BinaryDiscoveryClusterAddressProvider extends AbstractDiscoveryClus
             throw new TarantoolClientException("Cluster discovery task error", e);
         }
     }
+
+    @Override
+    public void close() {
+        super.close();
+        try {
+            client.close();
+        } catch (Exception e) {
+            throw new TarantoolClientException(e);
+        }
+    }
 }


### PR DESCRIPTION
Fix connection to multiple instances doesn't shut down EventLoopGroup by finishing the work

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [x] Tests
- [ ] Changelog
- [ ] Documentation
- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [ ] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
Closes #435
