### PR TITLE
Add benchmark for cluster API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
 ## [Unreleased]
+
+### Bugfixes
+
+- Significantly reduce memory allocation overhead and excessive GC pressure ([#401](https://github.com/tarantool/cartridge-java/issues/401))
+
 ### Internal and API changes
 
 - Bump org.testcontainers:junit-jupiter version to 1.19.3 ([#442](https://github.com/tarantool/cartridge-java/issues/442))
 - Bump testcontainers-java-tarantool version to 1.2.0 ([#442](https://github.com/tarantool/cartridge-java/issues/442))
 - Bump netty version to 4.1.104.Final ([#446](https://github.com/tarantool/cartridge-java/issues/446))
+- Bump msgpack-java version to 0.9.6
 
 ### Features
 

--- a/profile.jfc
+++ b/profile.jfc
@@ -1,0 +1,809 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="Profiling" description="Low overhead configuration for profiling, typically around 2 % overhead." provider="Oracle">
+
+  <event name="jdk.ThreadAllocationStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ClassLoadingStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ClassLoaderStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.JavaThreadStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadStart">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ThreadEnd">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ThreadSleep">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="synchronization-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadPark">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="synchronization-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorEnter">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="synchronization-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorWait">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="synchronization-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorInflate">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="synchronization-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.BiasedLockRevocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.BiasedLockSelfRevocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.BiasedLockClassRevocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ReservedStackActivation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ClassLoad">
+    <setting name="enabled" control="class-loading-enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ClassDefine">
+    <setting name="enabled" control="class-loading-enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ClassUnload">
+    <setting name="enabled" control="class-loading-enabled">false</setting>
+  </event>
+
+  <event name="jdk.JVMInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.InitialSystemProperty">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ExecutionSample">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+    <setting name="period" control="method-sampling-java-interval">10 ms</setting>
+  </event>
+
+  <event name="jdk.NativeMethodSample">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+    <setting name="period" control="method-sampling-native-interval">20 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointBegin">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointStateSynchronization">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointWaitBlocked">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointCleanup">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointCleanupTask">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointEnd">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ExecuteVMOperation">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.Shutdown">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ThreadDump">
+    <setting name="enabled" control="thread-dump-enabled">true</setting>
+    <setting name="period" control="thread-dump-interval">60 s</setting>
+  </event>
+
+  <event name="jdk.IntFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.UnsignedIntFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.LongFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.UnsignedLongFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.DoubleFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.BooleanFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.StringFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.IntFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.UnsignedIntFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.LongFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.UnsignedLongFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DoubleFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.BooleanFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.StringFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ObjectCount">
+    <setting name="enabled" control="memory-profiling-enabled-all">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCHeapConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.YoungGenerationConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.GCTLABConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.GCSurvivorConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ObjectCountAfterGC">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.GCHeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PSHeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1HeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceGCThreshold">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceAllocationFailure">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceOOM">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceChunkFreeListSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.GarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ParallelOldGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.YoungGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.OldGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.G1GarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePause">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel1">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel2">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel3">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel4">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhaseConcurrent">
+    <setting name="enabled" control="gc-enabled-all">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCReferenceStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PromotionFailed">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.EvacuationFailed">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.EvacuationInformation">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1MMU">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1EvacuationYoungStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1EvacuationOldStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1BasicIHOP">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1AdaptiveIHOP">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PromoteObjectInNewPLAB">
+    <setting name="enabled" control="memory-profiling-enabled-medium">true</setting>
+  </event>
+
+  <event name="jdk.PromoteObjectOutsidePLAB">
+    <setting name="enabled" control="memory-profiling-enabled-medium">true</setting>
+  </event>
+
+  <event name="jdk.ConcurrentModeFailure">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.AllocationRequiringGC">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.TenuringDistribution">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1HeapRegionInformation">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.G1HeapRegionTypeChange">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+  </event>
+
+  <event name="jdk.OldObjectSample">
+    <setting name="enabled" control="memory-leak-detection-enabled">true</setting>
+    <setting name="stackTrace" control="memory-leak-detection-stack-trace">true</setting>
+    <setting name="cutoff" control="memory-leak-detection-cutoff">0 ns</setting>
+  </event>
+
+  <event name="jdk.CompilerConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CompilerStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.Compilation">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-compilation-threshold">100 ms</setting>
+  </event>
+
+  <event name="jdk.CompilerPhase">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-phase-threshold">10 s</setting>
+  </event>
+
+  <event name="jdk.CompilationFailure">
+    <setting name="enabled" control="compiler-enabled-failure">true</setting>
+  </event>
+
+  <event name="jdk.CompilerInlining">
+    <setting name="enabled" control="compiler-enabled-failure">false</setting>
+  </event>
+
+  <event name="jdk.CodeSweeperConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CodeSweeperStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.SweepCodeCache">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-sweeper-threshold">100 ms</setting>
+  </event>
+
+  <event name="jdk.CodeCacheConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CodeCacheStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.CodeCacheFull">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+  </event>
+
+  <event name="jdk.OSInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CPUInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ThreadContextSwitchRate">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.CPULoad">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadCPULoad">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.CPUTimeStampCounter">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.SystemProcess">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.NetworkUtilization">
+    <setting name="enabled">true</setting>
+    <setting name="period">5 s</setting>
+  </event>
+
+  <event name="jdk.InitialEnvironmentVariable">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.PhysicalMemory">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationInNewTLAB">
+    <setting name="enabled" control="memory-profiling-enabled-medium">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationOutsideTLAB">
+    <setting name="enabled" control="memory-profiling-enabled-medium">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.NativeLibrary">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.FileForce">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="file-io-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.FileRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="file-io-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.FileWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="file-io-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SocketRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="socket-io-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SocketWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="socket-io-threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.JavaExceptionThrow">
+    <setting name="enabled" control="enable-exceptions">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.JavaErrorThrow">
+    <setting name="enabled" control="enable-errors">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ExceptionStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ActiveRecording">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ActiveSetting">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DataLoss">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DumpReason">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ZPageAllocation">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.ZThreadPhase">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZStatisticsCounter">
+    <setting name="threshold">10 ms</setting>
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ZStatisticsSampler">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <control>
+
+    <selection name="gc-level" default="detailed" label="Garbage Collector">
+      <option label="Off" name="off">off</option>
+      <option label="Normal" name="detailed">normal</option>
+      <option label="All" name="all">all</option>
+    </selection>
+
+    <condition name="gc-enabled-normal" true="true" false="false">
+      <or>
+        <test name="gc-level" operator="equal" value="normal"/>
+        <test name="gc-level" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-all" true="true" false="false">
+      <test name="gc-level" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="memory-profiling" default="medium" label="Memory Profiling">
+      <option label="Off" name="off">off</option>
+      <option label="Object Allocation and Promotion" name="medium">medium</option>
+      <option label="All, including Heap Statistics (May cause long full GCs)" name="all">all</option>
+    </selection>
+
+    <condition name="memory-profiling-enabled-medium" true="true" false="false">
+      <or>
+        <test name="memory-profiling" operator="equal" value="medium"/>
+        <test name="memory-profiling" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="memory-profiling-enabled-all" true="true" false="false">
+      <test name="memory-profiling" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="compiler-level" default="detailed" label="Compiler">
+      <option label="Off" name="off">off</option>
+      <option label="Normal" name="normal">normal</option>
+      <option label="Detailed" name="detailed">detailed</option>
+      <option label="All" name="all">all</option>
+    </selection>
+
+    <condition name="compiler-enabled" true="false" false="true">
+      <test name="compiler-level" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="compiler-enabled-failure" true="true" false="false">
+      <or>
+        <test name="compiler-level" operator="equal" value="detailed"/>
+        <test name="compiler-level" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="compiler-sweeper-threshold" true="0 ms" false="100 ms">
+      <test name="compiler-level" operator="equal" value="all"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="1000 ms">
+      <test name="compiler-level" operator="equal" value="normal"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="100 ms">
+      <test name="compiler-level" operator="equal" value="detailed"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="0 ms">
+      <test name="compiler-level" operator="equal" value="all"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="60 s">
+      <test name="compiler-level" operator="equal" value="normal"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="10 s">
+      <test name="compiler-level" operator="equal" value="detailed"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="0 s">
+      <test name="compiler-level" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="method-sampling-interval" default="normal" label="Method Sampling">
+      <option label="Off" name="off">off</option>
+      <option label="Normal" name="normal">normal</option>
+      <option label="High" name="high">high</option>
+      <option label="Ludicrous (High Overhead)" name="ludicrous">ludicrous</option>
+    </selection>
+
+    <condition name="method-sampling-java-interval" true="999 d">
+      <test name="method-sampling-interval" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="20 ms">
+      <test name="method-sampling-interval" operator="equal" value="normal"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="10 ms">
+      <test name="method-sampling-interval" operator="equal" value="high"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="1 ms">
+      <test name="method-sampling-interval" operator="equal" value="ludicrous"/>
+    </condition>
+
+    <condition name="method-sampling-native-interval" true="999 d">
+      <test name="method-sampling-interval" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="method-sampling-native-interval" true="20 ms">
+      <or>
+        <test name="method-sampling-interval" operator="equal" value="normal"/>
+        <test name="method-sampling-interval" operator="equal" value="high"/>
+        <test name="method-sampling-interval" operator="equal" value="ludicrous"/>
+      </or>
+    </condition>
+
+    <condition name="method-sampling-enabled" true="false" false="true">
+      <test name="method-sampling-interval" operator="equal" value="off"/>
+    </condition>
+
+    <selection name="thread-dump-interval" default="everyMinute" label="Thread Dump">
+      <option label="Off" name="off">999 d</option>
+      <option label="At least Once" name="normal">everyChunk</option>
+      <option label="Every 60 s" name="everyMinute">60 s</option>
+      <option label="Every 10 s" name="everyTenSecond">10 s</option>
+      <option label="Every 1 s" name="everySecond">1 s</option>
+    </selection>
+
+    <condition name="thread-dump-enabled" true="false" false="true">
+      <test name="thread-dump-interval" operator="equal" value="999 d"/>
+    </condition>
+
+    <selection name="exception-level" default="errors" label="Exceptions">
+      <option label="Off" name="off">off</option>
+      <option label="Errors Only" name="errors">errors</option>
+      <option label="All Exceptions, including Errors" name="all">all</option>
+    </selection>
+
+    <condition name="enable-errors" true="true" false="false">
+      <or>
+        <test name="exception-level" operator="equal" value="errors"/>
+        <test name="exception-level" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="enable-exceptions" true="true" false="false">
+      <test name="exception-level" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="memory-leak-detection" default="medium" label="Memory Leak Detection">
+      <option label="Off" name="off">off</option>
+      <option label="Object Types" name="minimal">minimal</option>
+      <option label="Object Types + Allocation Stack Traces" name="medium">medium</option>
+      <option label="Object Types + Allocation Stack Traces + Path to GC Root" name="full">full</option>
+    </selection>
+
+    <condition name="memory-leak-detection-enabled" true="false" false="true">
+      <test name="memory-leak-detection" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="memory-leak-detection-stack-trace" true="true" false="false">
+      <or>
+        <test name="memory-leak-detection" operator="equal" value="medium"/>
+        <test name="memory-leak-detection" operator="equal" value="full"/>
+      </or>
+    </condition>
+
+    <condition name="memory-leak-detection-cutoff" true="1 h" false="0 ns">
+      <test name="memory-leak-detection" operator="equal" value="full"/>
+    </condition>
+
+    <text name="synchronization-threshold" label="Synchronization Threshold" contentType="timespan" minimum="0 s">10 ms</text>
+
+    <text name="file-io-threshold" label="File I/O Threshold" contentType="timespan" minimum="0 s">10 ms</text>
+
+    <text name="socket-io-threshold" label="Socket I/O Threshold" contentType="timespan" minimum="0 s">10 ms</text>
+
+    <flag name="class-loading-enabled" label="Class Loading">false</flag>
+
+  </control>
+
+</configuration>

--- a/src/test/java/io/tarantool/driver/benchmark/ClusterTarantoolSetup.java
+++ b/src/test/java/io/tarantool/driver/benchmark/ClusterTarantoolSetup.java
@@ -37,7 +37,6 @@ public class ClusterTarantoolSetup {
             "cartridge-java-test",
             "cartridge/instances.yml",
             "cartridge/topology.lua")
-            .withDirectoryBinding("cartridge")
             .withLogConsumer(new Slf4jLogConsumer(logger))
             .waitingFor(Wait.forLogMessage(".*Listening HTTP on.*", 5))
             .withStartupTimeout(Duration.ofMinutes(2));
@@ -55,8 +54,8 @@ public class ClusterTarantoolSetup {
                 new TarantoolServerAddress(tarantoolContainer.getRouterHost(), tarantoolContainer.getMappedPort(3303))
             )
             .withCredentials(tarantoolContainer.getUsername(), tarantoolContainer.getPassword())
-            .withConnections(10)
-            .withEventLoopThreadsNumber(10)
+            .withConnections(2)
+            .withEventLoopThreadsNumber(2)
             .withRequestTimeout(10000)
             .withProxyMethodMapping()
             .build();

--- a/src/test/resources/cartridge/app/roles/api_router.lua
+++ b/src/test/resources/cartridge/app/roles/api_router.lua
@@ -100,6 +100,10 @@ local function custom_crud_get_one_record(space_name, tuple_id)
     return crud.get(space_name, {tuple_id}).rows[1]
 end
 
+local function custom_crud_insert_one_record(space_name, tuple)
+    return crud.insert(space_name, tuple)
+end
+
 local function raising_error()
     error("Test error: raising_error() called")
 end
@@ -251,6 +255,7 @@ local function init(opts)
     rawset(_G, 'crud_error_timeout', crud_error_timeout)
     rawset(_G, 'custom_crud_select', custom_crud_select)
     rawset(_G, 'custom_crud_get_one_record', custom_crud_get_one_record)
+    rawset(_G, 'custom_crud_insert_one_record', custom_crud_insert_one_record)
     rawset(_G, 'get_routers_status', get_routers_status)
     rawset(_G, 'init_router_status', init_router_status)
     rawset(_G, 'test_no_such_procedure', test_no_such_procedure)

--- a/src/test/resources/org/testcontainers/containers/cluster_benchmark.lua
+++ b/src/test/resources/org/testcontainers/containers/cluster_benchmark.lua
@@ -1,0 +1,10 @@
+local crud = require('crud')
+local uuid = require('uuid')
+
+crud.truncate('test_space')
+crud.truncate('test__profile')
+
+for i = 1, 10000 do
+    crud.insert('test_space', {1000000 + i, nil, uuid.new(), 200000 + i})
+    crud.insert('test__profile', {1000000 + i, nil, uuid.new(), 50000 + i, 100000 + i})
+end


### PR DESCRIPTION
## Before memory optimizations

Benchmark results on commit https://github.com/tarantool/cartridge-java/commit/a6199e8268577517167492191b0c5989fbcf99e8 (before optimizations):
```
Total time: 00:33:33

Benchmark                                            Mode  Cnt      Score      Error  Units
ClusterBenchmarkRunner.readDataUsingCallAPI         thrpt   10  13761.025 ± 2657.463  ops/s
ClusterBenchmarkRunner.readDataUsingCallAPI:·jfr    thrpt             NaN               ---
ClusterBenchmarkRunner.readDataUsingSpaceAPI        thrpt   10  12033.690 ± 2032.909  ops/s
ClusterBenchmarkRunner.readDataUsingSpaceAPI:·jfr   thrpt             NaN               ---
ClusterBenchmarkRunner.writeDataUsingCallAPI        thrpt   10   6175.897 ±  630.966  ops/s
ClusterBenchmarkRunner.writeDataUsingCallAPI:·jfr   thrpt             NaN               ---
ClusterBenchmarkRunner.writeDataUsingSpaceAPI       thrpt   10   7123.615 ±  894.854  ops/s
ClusterBenchmarkRunner.writeDataUsingSpaceAPI:·jfr  thrpt             NaN               ---
```

Allocations for `ClusterBenchmarkRunner.writeDataUsingCallAPI` (before optimizations):

<img width="940" alt="Allocation_before" src="https://github.com/tarantool/cartridge-java/assets/2381032/08260641-7a10-4bd4-ac98-56d05a8c9965">

TLAB allocations for `ClusterBenchmarkRunner.writeDataUsingCallAPI` (before optimizations):

<img width="935" alt="TLAB_allocation_before" src="https://github.com/tarantool/cartridge-java/assets/2381032/50583313-3414-4e9f-a9ee-84bb6ab3cc50">


## After memory optimizations

Benchmark results on commit https://github.com/tarantool/cartridge-java/pull/439/commits/5f9e69c8d9d0e907e356bb5954c547364fa5207d (after optimizations):
```
Total time: 00:24:56

Benchmark                                            Mode  Cnt      Score      Error  Units
ClusterBenchmarkRunner.readDataUsingCallAPI         thrpt   10  19674.739 ± 2977.708  ops/s
ClusterBenchmarkRunner.readDataUsingCallAPI:·jfr    thrpt             NaN               ---
ClusterBenchmarkRunner.readDataUsingSpaceAPI        thrpt   10  17092.066 ± 5721.286  ops/s
ClusterBenchmarkRunner.readDataUsingSpaceAPI:·jfr   thrpt             NaN               ---
ClusterBenchmarkRunner.writeDataUsingCallAPI        thrpt   10   8012.627 ± 1120.023  ops/s
ClusterBenchmarkRunner.writeDataUsingCallAPI:·jfr   thrpt             NaN               ---
ClusterBenchmarkRunner.writeDataUsingSpaceAPI       thrpt   10   9157.278 ± 3705.178  ops/s
ClusterBenchmarkRunner.writeDataUsingSpaceAPI:·jfr  thrpt             NaN               ---
```

Allocations for `ClusterBenchmarkRunner.writeDataUsingCallAPI` (after optimizations):

<img width="941" alt="Allocation_after" src="https://github.com/tarantool/cartridge-java/assets/2381032/a959aa14-bc95-467e-8c6d-206b7069080d">

TLAB allocations for `ClusterBenchmarkRunner.writeDataUsingCallAPI` (after optimizations):

<img width="938" alt="TLAB_allocation_after" src="https://github.com/tarantool/cartridge-java/assets/2381032/ef410520-9dd8-4026-8d3d-74ee15558e3a">


## Summary

The average throughput gain is about 40% on read operations and 30% on write operations. The benchmark run completes approx. 30% faster with optimizations. The main reason for improvements can be a >50% reduction in allocations.

Benchmark runs were performed with JDK 17, G1 GC (default settings), using the following command:
```
mvn exec:exec -Pbenchmark -Dbenchmark="ClusterBenchmarkRunner" -DbenchmarkArgs="-prof=jfr"
```